### PR TITLE
bump(package.json)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/telicent-oss/telicent-ds.git"
   },
   "type": "module",
-  "version": "0.0.2-rc3",
+  "version": "0.0.3",
   "private": false,
   "dependencies": {
     "@emotion/react": "^11.10.6",


### PR DESCRIPTION
Merging in manually with `-rc3` tag caused release-me-please to open release branch with `-rc3`

So for now I'll just manually remove - and for certainty, I did a manual bump.

This _should_ trigger an "xtra bump" to 0.0.4 - but is not ideal but is is harmless. And temporary