### PR TITLE
fix(package.json): update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,8 @@
   "exports": {
     ".": {
       "import": "./dist/ds.js",
-      "require": "./dist/ds.umd.cjs"
+      "require": "./dist/ds.umd.cjs",
+      "types": "./dist/export.d.ts"
     },
     "./dist/style.css": {
       "import": "./dist/style.css",


### PR DESCRIPTION
When importing the ds in to another app it was throwing an error, 'Could not find a declaration file'.

Although the type location was explicitly stated in the package.json file. The only way to get the error to disappear was to add the types path to the exports