### PR TITLE
fix: findIcon can now handle uris which start with 'http://telicent.i…

### DIFF
--- a/src/contexts/OntologyStyles.tsx
+++ b/src/contexts/OntologyStyles.tsx
@@ -1,11 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { createContext, useContext } from "react";
 import OntologyService from "@telicent-oss/ontologyservice";
-import {
-  flattenStyles,
-  getTypeInitials,
-  getURIFragment,
-} from "./context-utils";
+import { flattenStyles, getTypeInitials, getOntologyClass } from "./context-utils";
 
 type OntologyStyle = {
   defaultIcons: {
@@ -55,14 +51,9 @@ type OntologyStylesProviderProps = {
   children: React.ReactNode;
 }>;
 
-const OntologyStylesContext = createContext<OntologyStylesContextProps | null>(
-  null
-);
+const OntologyStylesContext = createContext<OntologyStylesContextProps | null>(null);
 
-const OntologyStylesProvider: React.FC<OntologyStylesProviderProps> = ({
-  service,
-  children,
-}) => {
+const OntologyStylesProvider: React.FC<OntologyStylesProviderProps> = ({ service, children }) => {
   const twentyFourHoursInMs = 1000 * 60 * 60 * 24;
 
   const query = useQuery({
@@ -84,7 +75,7 @@ const OntologyStylesProvider: React.FC<OntologyStylesProviderProps> = ({
 
     if (foundIcon) return foundIcon;
 
-    const alt = getURIFragment(classUri);
+    const alt = getOntologyClass(classUri);
     const iconFallbackText = getTypeInitials(classUri);
 
     return {
@@ -107,9 +98,7 @@ const useOntologyStyles = () => {
   const ontology = useContext(OntologyStylesContext);
 
   if (!ontology) {
-    throw new Error(
-      "useOntologyService has to be used within <OntologyStylesProvider />"
-    );
+    throw new Error("useOntologyService has to be used within <OntologyStylesProvider />");
   }
 
   return ontology;

--- a/src/contexts/context-utils.test.ts
+++ b/src/contexts/context-utils.test.ts
@@ -1,0 +1,8 @@
+import { getOntologyClass } from "./context-utils";
+
+describe("context utils - getOntologyClass()", () => {
+  test("returns DoctorAppointment when uri is 'http://telicent.io/ontology/DoctorAppointment'", () => {
+    const fragment = getOntologyClass("http://telicent.io/ontology/DoctorAppointment");
+    expect(fragment).toBe("DoctorAppointment");
+  });
+});

--- a/src/contexts/context-utils.ts
+++ b/src/contexts/context-utils.ts
@@ -1,14 +1,26 @@
 import { startCase } from "lodash";
 import { IconStyle, StyleResponse } from "./OntologyStyles";
 
-const hasFragment = (uri: string) =>
-  uri && uri.startsWith("http") && uri.includes("#");
+const PREFIX_LOOKUP: Record<string, string> = {
+  "http://telicent.io/ontology/": "telicent:",
+};
 
-export const getURIFragment = (uri: string) => {
+const hasFragment = (uri: string) => uri && uri.startsWith("http") && uri.includes("#");
+
+export const getOntologyClass = (uri: string) => {
   if (hasFragment(uri)) {
     const uriParts = uri.split("#");
     return uriParts.length > 1 ? uriParts[1] : uri;
   }
+
+  const foundNamespace = Object.keys(PREFIX_LOOKUP).find((namespace) => {
+    return uri.startsWith(namespace);
+  });
+
+  if (foundNamespace) {
+    return uri.replace(foundNamespace, "");
+  }
+
   return uri;
 };
 
@@ -19,9 +31,7 @@ const getInitials = (value: string) => {
     if (initials) return initials.join("").slice(0, 3);
   }
 
-  console.warn(
-    `Telicent DS (getInitials): Unable to get initials from "${value}"`
-  );
+  console.warn(`Telicent DS (getInitials): Unable to get initials from "${value}"`);
   return "";
 };
 
@@ -40,7 +50,7 @@ export const flattenStyles = (data: StyleResponse): IconStyle[] => {
     backgroundColor: style.defaultStyles.dark.backgroundColor,
     color: style.defaultStyles.dark.color,
     iconFallbackText: getTypeInitials(classUri),
-    alt: getURIFragment(classUri),
+    alt: getOntologyClass(classUri),
     shape: style.defaultStyles.shape,
     faUnicode: style.defaultIcons.faUnicode,
     faIcon: style.defaultIcons.faIcon,


### PR DESCRIPTION
…o/ontology/'

This is just a temporary solution until a more perminent one is added

[TELFE-50](https://telicent.atlassian.net/browse/TELFE-50)

[TELFE-50]: https://telicent.atlassian.net/browse/TELFE-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ