### PR TITLE
fix(vuln): [TELFE-336] nth-check

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,12 @@
     "zod": "^3.21.4"
   },
   "resolutions": {
-    "jackspeak": "2.1.1"
+    "jackspeak": "2.1.1",
+    "nth-check": "^2.1.1"
   },
-  "scripts": {
+  "resolutionsReasons": {
+    "nth-check": "vulnerability: Tested `react-scripts start/test/build`"
+  },  "scripts": {
     "lint": "eslint --resolve-plugins-relative-to src",
     "clean": "rimraf dist storybook-static",
     "start": "vite",
@@ -179,6 +182,6 @@
     }
   },
   "engine": {
-    "node": "18"
+    "node": "20.14.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6774,7 +6774,7 @@ bonjour-service@^1.0.11:
     fast-deep-equal "^3.1.3"
     multicast-dns "^7.2.5"
 
-boolbase@^1.0.0, boolbase@~1.0.0:
+boolbase@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
@@ -13311,14 +13311,7 @@ npmlog@^6.0.2:
     gauge "^4.0.3"
     set-blocking "^2.0.0"
 
-nth-check@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
-  integrity sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==
-  dependencies:
-    boolbase "~1.0.0"
-
-nth-check@^2.0.1:
+nth-check@^1.0.2, nth-check@^2.0.1, nth-check@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
   integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==


### PR DESCRIPTION
Before
```
info Has been hoisted to "nth-check"
info Reasons this module exists
   - Hoisted from "css-select#nth-check"
   - Hoisted from "release-please#node-html-parser#css-select#nth-check"
info Disk size without dependencies: "120KB"
info Disk size with unique dependencies: "132KB"
info Disk size with transitive dependencies: "132KB"
info Number of shared dependencies: 1
=> Found "svgo#nth-check@1.0.2"
info Reasons this module exists
   - "react-scripts#@svgr#webpack#@svgr#plugin-svgo#svgo#css-select" depends on it
   - Hoisted from "react-scripts#@svgr#webpack#@svgr#plugin-svgo#svgo#css-select#nth-check"
info Disk size without dependencies: "24KB"
info Disk size with unique dependencies: "36KB"
info Disk size with transitive dependencies: "36KB"
info Number of shared dependencies: 1
✨  Done in 0.36s.
```

After

```
=> Found "nth-check@2.1.1"
info Reasons this module exists
   - "css-select" depends on it
   - Hoisted from "css-select#nth-check"
   - Hoisted from "release-please#node-html-parser#css-select#nth-check"
   - Hoisted from "react-scripts#@svgr#webpack#@svgr#plugin-svgo#svgo#css-select#nth-check"
info Disk size without dependencies: "120KB"
info Disk size with unique dependencies: "132KB"
info Disk size with transitive dependencies: "132KB"
info Number of shared dependencies: 1
✨  Done in 0.66s.
```

# Testing
- the breaking changes in v2.0.0 don't seem problematic for us
https://github.com/fb55/nth-check/releases/tag/v2.0.0

`react-scripts test` ran fine