### PR TITLE
Setup build cron job - Publish workflow fix

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -1,6 +1,13 @@
 name: Build package
 
-on: workflow_call
+on:
+  workflow_call:
+    inputs:
+      dry-run:
+        description: "Dry run mode"
+        required: false
+        default: "false"
+        type: boolean
 
 jobs:
   get_version:
@@ -56,3 +63,10 @@ jobs:
 
       - name: Build package
         run: yarn build
+
+      - name: Upload build artifacts
+        if: inputs.dry-run == 'false'
+        uses: actions/upload-artifact@v3
+        with:
+          name: design-system-build-artifacts
+          path: ${{ github.workspace }}/dist/**

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -1,11 +1,6 @@
 name: Build package
 
-on:
-  workflow_call:
-    inputs:
-      node-auth-token:
-        required: true
-        type: string
+on: workflow_call
 
 jobs:
   get_version:
@@ -39,7 +34,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           scope: "telicent-oss"
         env:
-          NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
 
       - name: Get node version
         id: node

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -1,10 +1,11 @@
 name: Build package
 
-on: workflow_call
-  inputs:
-    node-auth-token:
-      required: true
-      type: string
+on:
+  workflow_call:
+    inputs:
+      node-auth-token:
+        required: true
+        type: string
 
 jobs:
   get_version:

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -1,6 +1,10 @@
 name: Build package
 
 on: workflow_call
+  inputs:
+    node-auth-token:
+      required: true
+      type: string
 
 jobs:
   get_version:
@@ -34,7 +38,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           scope: "telicent-oss"
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
 
       - name: Get node version
         id: node

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -1,9 +1,6 @@
 name: Build package
 
-on:
-  schedule:
-    - cron: 0 9 * * 1
-  workflow_dispatch:
+on: workflow_call
 
 jobs:
   get_version:
@@ -17,7 +14,7 @@ jobs:
     outputs:
       version: ${{ steps.semver.outputs.current-version }}
 
-  build_and_publish:
+  build:
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/check-build-cron.yml
+++ b/.github/workflows/check-build-cron.yml
@@ -9,4 +9,7 @@ on:
 jobs:
   build_and_publish:
     runs-on: ubuntu-latest
-    uses: telicent-oss/telicent-ds/.github/workflows/build-package.yml@main
+    steps:
+      - uses: telicent-oss/telicent-ds/.github/workflows/build-package.yml@main
+        with:
+          node-auth-token: ${{ secrets.NPM_REGISTRY_TOKEN }}

--- a/.github/workflows/check-build-cron.yml
+++ b/.github/workflows/check-build-cron.yml
@@ -1,0 +1,14 @@
+name: Check build (CRON)
+
+on:
+  schedule:
+    - cron: 0 9 * * 1
+  workflow_dispatch:
+
+jobs:
+  build_and_publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Build package
+        uses: telicent-oss/telicent-ds/.github/workflows/build-package.yml@main

--- a/.github/workflows/check-build-cron.yml
+++ b/.github/workflows/check-build-cron.yml
@@ -11,5 +11,4 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Build package
-        uses: telicent-oss/telicent-ds/.github/workflows/build-package.yml@main
+      uses: telicent-oss/telicent-ds/.github/workflows/build-package.yml@main

--- a/.github/workflows/check-build-cron.yml
+++ b/.github/workflows/check-build-cron.yml
@@ -10,3 +10,5 @@ jobs:
   check_build:
     uses: telicent-oss/telicent-ds/.github/workflows/build-package.yml@main
     secrets: inherit
+    with:
+      dry-run: true

--- a/.github/workflows/check-build-cron.yml
+++ b/.github/workflows/check-build-cron.yml
@@ -11,4 +11,4 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: telicent-oss/telicent-ds/.github/workflows/build-package.yml@main
+      - uses: telicent-oss/telicent-ds/.github/workflows/build-package.yml@main

--- a/.github/workflows/check-build-cron.yml
+++ b/.github/workflows/check-build-cron.yml
@@ -7,9 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build_and_publish:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: telicent-oss/telicent-ds/.github/workflows/build-package.yml@main
-        with:
-          node-auth-token: ${{ secrets.NPM_REGISTRY_TOKEN }}
+  check_build:
+    uses: telicent-oss/telicent-ds/.github/workflows/build-package.yml@main
+    with:
+      node-auth-token: ${{ secrets.NPM_REGISTRY_TOKEN }}

--- a/.github/workflows/check-build-cron.yml
+++ b/.github/workflows/check-build-cron.yml
@@ -9,5 +9,4 @@ on:
 jobs:
   check_build:
     uses: telicent-oss/telicent-ds/.github/workflows/build-package.yml@main
-    with:
-      node-auth-token: ${{ secrets.NPM_REGISTRY_TOKEN }}
+    secrets: inherit

--- a/.github/workflows/check-build-cron.yml
+++ b/.github/workflows/check-build-cron.yml
@@ -2,6 +2,7 @@ name: Check build (CRON)
 
 on:
   schedule:
+    # 9am every monday
     - cron: 0 9 * * 1
   workflow_dispatch:
 

--- a/.github/workflows/check-build-cron.yml
+++ b/.github/workflows/check-build-cron.yml
@@ -9,6 +9,4 @@ on:
 jobs:
   build_and_publish:
     runs-on: ubuntu-latest
-
-    steps:
-      - uses: telicent-oss/telicent-ds/.github/workflows/build-package.yml@main
+    uses: telicent-oss/telicent-ds/.github/workflows/build-package.yml@main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,4 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build_package
     steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: design-system-build-artifacts
+          path: ${{ github.workspace }}/dist/**
       - run: npm publish --access public --provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,10 +12,11 @@ on:
 jobs:
   build_and_publish:
     runs-on: ubuntu-latest
-    uses: telicent-oss/telicent-ds/.github/workflows/build-package.yml@main
 
     steps:
+      - uses: telicent-oss/telicent-ds/.github/workflows/build-package.yml@main
+        with:
+          node-auth-token: ${{ secrets.NPM_REGISTRY_TOKEN }}
+
       - name: Publish package
         run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,9 +10,14 @@ on:
   workflow_dispatch:
 
 jobs:
-  publish_package:
-    uses: telicent-oss/telicent-ds/.github/workflows/build-package.yml@main
+  build_and_publish:
+    runs-on: ubuntu-latest
+
     steps:
-      - run: npm publish --access public --provenance
+      - name: Build package
+        uses: telicent-oss/telicent-ds/.github/workflows/build-package.yml@main
+
+      - name: Publish package
+        run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,13 +10,13 @@ on:
   workflow_dispatch:
 
 jobs:
-  build_and_publish:
+  build_package:
+    uses: telicent-oss/telicent-ds/.github/workflows/build-package.yml@main
+    with:
+      node-auth-token: ${{ secrets.NPM_REGISTRY_TOKEN }}
+
+  publish_package:
     runs-on: ubuntu-latest
-
+    needs: build_package
     steps:
-      - uses: telicent-oss/telicent-ds/.github/workflows/build-package.yml@main
-        with:
-          node-auth-token: ${{ secrets.NPM_REGISTRY_TOKEN }}
-
-      - name: Publish package
-        run: npm publish --access public --provenance
+      - run: npm publish --access public --provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,7 @@ on:
 jobs:
   build_package:
     uses: telicent-oss/telicent-ds/.github/workflows/build-package.yml@main
-    with:
-      node-auth-token: ${{ secrets.NPM_REGISTRY_TOKEN }}
+    secrets: inherit
 
   publish_package:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: telicent-oss/telicent-ds/.github/workflows/build-package.yml@main
+      - uses: telicent-oss/telicent-ds/.github/workflows/build-package.yml@main
 
       - name: Publish package
         run: npm publish --access public --provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Build package
-        uses: telicent-oss/telicent-ds/.github/workflows/build-package.yml@main
+      uses: telicent-oss/telicent-ds/.github/workflows/build-package.yml@main
 
       - name: Publish package
         run: npm publish --access public --provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,10 +12,9 @@ on:
 jobs:
   build_and_publish:
     runs-on: ubuntu-latest
+    uses: telicent-oss/telicent-ds/.github/workflows/build-package.yml@main
 
     steps:
-      - uses: telicent-oss/telicent-ds/.github/workflows/build-package.yml@main
-
       - name: Publish package
         run: npm publish --access public --provenance
         env:


### PR DESCRIPTION
The publish workflow is current failing because the publish step cannot find the build folder. This is because the build and publish steps are being executed in separate contexts.

To ensure the artefacts are available before the publish step, the build artefacts are stored after the build step if dry-run is set to false (it's set to false by default) and are retrieved before the publish step executed

[TELFE-73](https://telicent.atlassian.net/browse/TELFE-73)

[TELFE-73]: https://telicent.atlassian.net/browse/TELFE-73?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ