### PR TITLE
Setup build cron job - Fix publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,5 +22,5 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: design-system-build-artifacts
-          path: ${{ github.workspace }}/dist/**
+          path: ${{ github.workspace }}
       - run: npm publish --access public --provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,5 +22,4 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: design-system-build-artifacts
-          path: ${{ github.workspace }}
       - run: npm publish --access public --provenance


### PR DESCRIPTION
Removed path from publish.yml to resolve error which was occuring when attempting to publish package. The error was occurring because the artefacts were being in the wrong directory. Now using the default workspace as the download directory