### PR TITLE
fix: publish workflow

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -70,3 +70,6 @@ jobs:
         with:
           name: design-system-build-artifacts
           path: dist/**
+
+      - name: Verify artifacts
+        run: ls -la ${{ github.workspace }}/dist

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -69,4 +69,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: design-system-build-artifacts
-          path: ${{ github.workspace }}/dist/**
+          path: dist/**

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -69,7 +69,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: design-system-build-artifacts
-          path: dist/**
-
-      # - name: Verify artifacts
-      #   run: ls -la ${{ github.workspace }}/dist
+          path: ${{ github.workspace }}/dist/**

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -22,9 +22,6 @@ jobs:
       version: ${{ steps.semver.outputs.current-version }}
 
   build:
-    permissions:
-      id-token: write
-      contents: read
     needs: get_version
     env:
       APP_NAME: ds
@@ -36,12 +33,6 @@ jobs:
 
       - name: configure-node
         uses: actions/setup-node@v4
-        # with:
-        #   node-version: 20
-        #   registry-url: "https://registry.npmjs.org"
-        #   scope: "telicent-oss"
-        # env:
-        #   NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
 
       - name: Get node version
         id: node

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: configure-node
         uses: actions/setup-node@v4
+        with:
+          node-version: 20
 
       - name: Get node version
         id: node

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -71,5 +71,5 @@ jobs:
           name: design-system-build-artifacts
           path: dist/**
 
-      - name: Verify artifacts
-        run: ls -la ${{ github.workspace }}/dist
+      # - name: Verify artifacts
+      #   run: ls -la ${{ github.workspace }}/dist

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -69,4 +69,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: design-system-build-artifacts
-          path: ${{ github.workspace }}/**
+          path: ${{ github.workspace }}/dist/**

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -68,5 +68,5 @@ jobs:
         if: inputs.dry-run == false
         uses: actions/upload-artifact@v3
         with:
-          name: design-system-build-artifacts
-          path: ${{ github.workspace }}/dist/**
+          name: design-system-artifacts
+          path: ${{ github.workspace }}/**

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -68,5 +68,5 @@ jobs:
         if: inputs.dry-run == false
         uses: actions/upload-artifact@v3
         with:
-          name: design-system-artifacts
+          name: design-system-build-artifacts
           path: ${{ github.workspace }}/**

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Get version from package.json
         id: semver
         uses: martinbeentjes/npm-get-version-action@main
@@ -36,12 +36,12 @@ jobs:
 
       - name: configure-node
         uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          registry-url: "https://registry.npmjs.org"
-          scope: "telicent-oss"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
+        # with:
+        #   node-version: 20
+        #   registry-url: "https://registry.npmjs.org"
+        #   scope: "telicent-oss"
+        # env:
+        #   NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
 
       - name: Get node version
         id: node

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: configure-node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: "https://registry.npmjs.org"
+          scope: "telicent-oss"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
+
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: design-system-build-artifacts
+          path: ${{ github.workspace }}/dist
       - name: Verify artifacts
-        run: ls -la ${{ github.workspace }}
+        run: ls -la ${{ github.workspace }} && ls -la ${{ github.workspace }}/dist
       - run: npm publish --access public --provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,5 +23,5 @@ jobs:
         with:
           name: design-system-build-artifacts
       - name: Verify artifacts
-        run: ls -la ${{ github.workspace }}/dist
+        run: ls -la ${{ github.workspace }}
       - run: npm publish --access public --provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,8 @@ jobs:
           node-version: 20
           registry-url: "https://registry.npmjs.org"
           scope: "telicent-oss"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
 
       - name: Download build artifacts
         uses: actions/download-artifact@v3
@@ -39,5 +41,3 @@ jobs:
           path: ${{ github.workspace }}/dist
 
       - run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,6 @@ on:
 jobs:
   build_package:
     uses: telicent-oss/telicent-ds/.github/workflows/build-package.yml@main
-    secrets: inherit
 
   publish_package:
     permissions:
@@ -26,14 +25,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: configure-node
+      - name: Setup Node.js with NPM registry
         uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: "https://registry.npmjs.org"
           scope: "telicent-oss"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
 
       - name: Download build artifacts
         uses: actions/download-artifact@v3
@@ -41,7 +38,6 @@ jobs:
           name: design-system-build-artifacts
           path: ${{ github.workspace }}/dist
 
-      - name: Verify artifacts
-        run: ls -la ${{ github.workspace }} && ls -la ${{ github.workspace }}/dist
-
       - run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,4 +22,6 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: design-system-build-artifacts
+      - name: Verify artifacts
+        run: ls -la ${{ github.workspace }}/dist
       - run: npm publish --access public --provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,6 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: design-system-artifacts
-          # path: ${{ github.workspace }}/dist
       - name: Verify artifacts
         run: ls -la ${{ github.workspace }} && ls -la ${{ github.workspace }}/dist
       - run: npm publish --access public --provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,8 +31,6 @@ jobs:
           node-version: 20
           registry-url: "https://registry.npmjs.org"
           scope: "telicent-oss"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
 
       - name: Download build artifacts
         uses: actions/download-artifact@v3
@@ -41,3 +39,5 @@ jobs:
           path: ${{ github.workspace }}/dist
 
       - run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: design-system-build-artifacts
+          path: ${{ github.workspace }}/dist
 
       - name: Verify artifacts
         run: ls -la ${{ github.workspace }} && ls -la ${{ github.workspace }}/dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
-          name: design-system-artifacts
+          name: design-system-build-artifacts
       - name: Verify artifacts
         run: ls -la ${{ github.workspace }} && ls -la ${{ github.workspace }}/dist
       - run: npm publish --access public --provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,8 +15,13 @@ jobs:
     secrets: inherit
 
   publish_package:
+    permissions:
+      id-token: write
+      contents: read
+
     runs-on: ubuntu-latest
     needs: build_package
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
-          name: design-system-build-artifacts
-          path: ${{ github.workspace }}/dist
+          name: design-system-artifacts
+          # path: ${{ github.workspace }}/dist
       - name: Verify artifacts
         run: ls -la ${{ github.workspace }} && ls -la ${{ github.workspace }}/dist
       - run: npm publish --access public --provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,10 +18,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: build_package
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
           name: design-system-build-artifacts
+
       - name: Verify artifacts
         run: ls -la ${{ github.workspace }} && ls -la ${{ github.workspace }}/dist
+
       - run: npm publish --access public --provenance


### PR DESCRIPTION
Refactored the publish.yml workflow to contain all the required steps to make the workflow work in a similar way to how it was setup originally.

Resolved could not find package.json error from action by adding checkout repository step.
Moved across permission from build.yml to publish.yml as the permission are needed for publishing not building