### PR TITLE
fix: bump dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@mui/x-tree-view": "7.3.1",
     "@react-spring/web": "9.7.3",
     "@tanstack/react-query": "^5.18.0",
-    "@telicent-oss/ontologyservice": "^0.0.1",
+    "@telicent-oss/ontologyservice": "^0.30.0-dev3",
     "classnames": "^2.3.1",
     "d3": "^7.8.2",
     "lodash": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4664,21 +4664,19 @@
   dependencies:
     "@tanstack/query-core" "5.36.1"
 
-"@telicent-oss/ontologyservice@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@telicent-oss/ontologyservice/-/ontologyservice-0.0.1.tgz#93e918ee8186b37a2cec480435639c5a09c08d87"
-  integrity sha512-/yltsE2p/POt+/OWat0l75J2AfMJ9DieP5ilsD23hAubSQjj5awggWa8hNqe6yoDwvksITSRZAl/Toqu5vjfvw==
+"@telicent-oss/ontologyservice@^0.30.0-dev3":
+  version "0.30.0-dev3"
+  resolved "https://registry.yarnpkg.com/@telicent-oss/ontologyservice/-/ontologyservice-0.30.0-dev3.tgz#8a4a51310e444c04a18554d17f29df163451d3a3"
+  integrity sha512-5bt8T5na0D/rWSFOO1+SWHzGBRYVzS7CbDuGzlukm+l3VgvLBc8lk8JfYHYWLZ7618aJxndCo4y7NpV7inxb/Q==
   dependencies:
-    "@telicent-oss/rdfservice" "*"
-    zod "^3.22.4"
+    "@telicent-oss/rdfservice" "0.30.0-dev3"
 
-"@telicent-oss/rdfservice@*":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@telicent-oss/rdfservice/-/rdfservice-0.0.6.tgz#b6f95d357f51d5da6f5e8c3cc8b52b7ee976fda7"
-  integrity sha512-pcbTj6JGbKmuN4PFYhtq6yGUXTcrqxtM3M7+LWz25Nunkq2uSMeGpi+3f0RYeXIDVl7jYpuOWpzqZ4D4U6u8rg==
+"@telicent-oss/rdfservice@0.30.0-dev3":
+  version "0.30.0-dev3"
+  resolved "https://registry.yarnpkg.com/@telicent-oss/rdfservice/-/rdfservice-0.30.0-dev3.tgz#5b3aca5855f85ada3259d1f8cefa021bff1d2c99"
+  integrity sha512-Mz3v5U5ak2QmNXBofMTPQL+1kmPHZgLnnPV+L0Ynn6KZmJ9slMLcGSi/ojqE+FwnoOELzhPSSchBMS0HW67z+A==
   dependencies:
     global "^4.4.0"
-    pnpm "^8.15.1"
     zod "^3.22.4"
 
 "@testing-library/dom@^8.11.1":
@@ -13843,11 +13841,6 @@ pkg-up@^3.1.0:
   integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
   dependencies:
     find-up "^3.0.0"
-
-pnpm@^8.15.1:
-  version "8.15.8"
-  resolved "https://registry.yarnpkg.com/pnpm/-/pnpm-8.15.8.tgz#e79598268334988b79ec13c8f9f9632a9d625654"
-  integrity sha512-0aAp4aRHrZC8ls1YsPrUhtKZPVMYVjlve6vy2D6xgju4PFo9D8GPZ1stEDIdSesWH+zjb+gTSqWCPs0hX+7Tkg==
 
 polished@^4.2.2:
   version "4.3.1"


### PR DESCRIPTION
ontologyservice used a library that had a vulnerability