### PR TITLE
fix: export appswitchlibrary and appbar types

### DIFF
--- a/src/v1/components/data-display/AppSwitch/AppSwitch.tsx
+++ b/src/v1/components/data-display/AppSwitch/AppSwitch.tsx
@@ -15,9 +15,9 @@ const AppSchema = zod.object({
   icon: zod.string(),
 });
 
-export type AppsType = zod.infer<typeof AppSchema>[];
+export type AppSwitchLibraryType = zod.infer<typeof AppSchema>[];
 
-const AppSwitch: React.FC<{ apps: AppsType }> = ({ apps }) => {
+const AppSwitch: React.FC<{ apps: AppSwitchLibraryType }> = ({ apps }) => {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
 
   const open = Boolean(anchorEl);

--- a/src/v1/components/data-display/AppSwitch/AppSwitch.tsx
+++ b/src/v1/components/data-display/AppSwitch/AppSwitch.tsx
@@ -81,6 +81,7 @@ const AppSwitch: React.FC<{ apps: AppSwitchLibraryType }> = ({ apps }) => {
                   flexDirection: "column",
                   alignItems: "center",
                   rowGap: 4,
+                  width: "100%"
                 }}
               >
                 <img

--- a/src/v1/components/data-display/index.ts
+++ b/src/v1/components/data-display/index.ts
@@ -3,6 +3,8 @@ export * from "./FontAwesomeIcons";
 export * from "./Text/Text";
 export * from "./List/List";
 
+export type { AppSwitchLibraryType } from "./AppSwitch/AppSwitch";
+
 export { default as Chip } from "./Chip/Chip";
 export type { ChipProps } from "./Chip/Chip";
 

--- a/src/v1/components/surfaces/AppBar/AppBar.tsx
+++ b/src/v1/components/surfaces/AppBar/AppBar.tsx
@@ -8,12 +8,14 @@ import zod from "zod";
 
 import TelicentBrand from "./telicent-brand.svg";
 import TelicentMark from "../../data-display/Icons/TelicentMark";
-import AppSwitch, { AppsType } from "../../data-display/AppSwitch/AppSwitch";
+import AppSwitch, {
+  AppSwitchLibraryType,
+} from "../../data-display/AppSwitch/AppSwitch";
 
 export type AppBarProps = Partial<{
   appName: string;
   beta: boolean;
-  apps: AppsType;
+  apps: AppSwitchLibraryType;
   userProfile: React.ReactNode;
   position: MUIAppBarProps["position"];
 }>;

--- a/src/v1/components/surfaces/index.ts
+++ b/src/v1/components/surfaces/index.ts
@@ -1,4 +1,7 @@
 export * from "./Card";
+
 export { default as AppBar } from "./AppBar/AppBar";
+export type { AppBarProps } from "./AppBar/AppBar";
+
 export { default as PopOver } from "./PopOver/Popover";
 export { default as Toolbar } from "./Toolbar/Toolbar";


### PR DESCRIPTION
Exporting types so they can be imported in other applications