### PR TITLE
fix: add onKeyDown prop to mini search autocomplete as a workaround

### DIFF
--- a/src/v1/components/inputs/SearchBox/MiniSearchAutocomplete.tsx
+++ b/src/v1/components/inputs/SearchBox/MiniSearchAutocomplete.tsx
@@ -76,6 +76,14 @@ export interface MiniSearchAutocompleteProps<
     option: Value
   ) => React.ReactNode;
   /**
+   * Use this when the value is being controlled to address the bug below.
+   *
+   * Note: There is a bug with Material UI where if the value is being
+   * controlled and the 'Enter' button is clicked while freeSolo is set to true,
+   * the onChange callback will not be triggered.
+   */
+  onKeyDown?: React.KeyboardEventHandler<HTMLInputElement | HTMLTextAreaElement>;
+  /**
    * Callback fired when the search button is clicked
    *
    * `(event: React.MouseEvent<HTMLButtonElement>) => void;`
@@ -108,6 +116,7 @@ const MiniSearchAutocomplete = forwardRef(function Autocomplete<
     renderOption,
     onSearch,
     freeSolo = true as FreeSolo,
+    onKeyDown,
     ...autocompleteProps
   } = props;
 
@@ -138,6 +147,7 @@ const MiniSearchAutocomplete = forwardRef(function Autocomplete<
         id={id}
         name={name}
         error={error}
+        onKeyDown={onKeyDown}
         endAdornment={
           <>
             <FlexBox direction="row" spacing={0.5}>


### PR DESCRIPTION
Added onKeyDown prop as a work-around for a Material-UI bug. I checked their issues list and bug is not documented so I cannot link it but I have explained it in the code.