### PR TITLE
fix: add color prop to font awesome icons

### DIFF
--- a/src/v1/components/data-display/FontAwesomeIcons/ClockIcon.tsx
+++ b/src/v1/components/data-display/FontAwesomeIcons/ClockIcon.tsx
@@ -1,11 +1,27 @@
 import React from "react";
-import { FontAwesomeIcon, FontAwesomeIconProps } from "@fortawesome/react-fontawesome";
+import {
+  FontAwesomeIcon,
+  FontAwesomeIconProps,
+} from "@fortawesome/react-fontawesome";
 import { faClock } from "@fortawesome/free-regular-svg-icons";
+import { useTheme } from "@mui/material/styles";
 
-type ClockIconProps = Omit<FontAwesomeIconProps, "icon">;
+type ClockIconProps = Omit<FontAwesomeIconProps, "icon"> & {
+  color?: "primary" | "inherit";
+};
 
-const ClockIcon: React.FC<ClockIconProps> = (iconProps) => (
-  <FontAwesomeIcon icon={faClock} {...iconProps} />
-);
+const ClockIcon: React.FC<ClockIconProps> = ({ color, ...iconProps }) => {
+  const theme = useTheme();
+
+  return (
+    <FontAwesomeIcon
+      icon={faClock}
+      css={{
+        color: color === "primary" ? theme.palette.primary.main : "inherit",
+      }}
+      {...iconProps}
+    />
+  );
+};
 
 export default ClockIcon;

--- a/src/v1/components/data-display/FontAwesomeIcons/DownArrowIcon.tsx
+++ b/src/v1/components/data-display/FontAwesomeIcons/DownArrowIcon.tsx
@@ -1,11 +1,27 @@
 import React from "react";
-import { FontAwesomeIcon, FontAwesomeIconProps } from "@fortawesome/react-fontawesome";
+import {
+  FontAwesomeIcon,
+  FontAwesomeIconProps,
+} from "@fortawesome/react-fontawesome";
 import { faAngleDown } from "@fortawesome/free-solid-svg-icons";
+import { useTheme } from "@mui/material/styles";
 
-type DownArrowIconProps = Omit<FontAwesomeIconProps, "icon">;
+type DownArrowIconProps = Omit<FontAwesomeIconProps, "icon"> & {
+  color?: "primary" | "inherit";
+};
 
-const DownArrow: React.FC<DownArrowIconProps> = (iconProps) => (
-  <FontAwesomeIcon icon={faAngleDown} {...iconProps} />
-);
+const DownArrow: React.FC<DownArrowIconProps> = ({ color, ...iconProps }) => {
+  const theme = useTheme();
+
+  return (
+    <FontAwesomeIcon
+      icon={faAngleDown}
+      css={{
+        color: color === "primary" ? theme.palette.primary.main : "inherit",
+      }}
+      {...iconProps}
+    />
+  );
+};
 
 export default DownArrow;

--- a/src/v1/components/data-display/FontAwesomeIcons/DownloadIcon.tsx
+++ b/src/v1/components/data-display/FontAwesomeIcons/DownloadIcon.tsx
@@ -1,11 +1,27 @@
 import React, { FC } from "react";
-import { FontAwesomeIcon, FontAwesomeIconProps } from "@fortawesome/react-fontawesome";
+import {
+  FontAwesomeIcon,
+  FontAwesomeIconProps,
+} from "@fortawesome/react-fontawesome";
 import { faDownload } from "@fortawesome/free-solid-svg-icons";
+import { useTheme } from "@mui/material/styles";
 
-type DownloadIconProps = Omit<FontAwesomeIconProps, "icon">;
+type DownloadIconProps = Omit<FontAwesomeIconProps, "icon"> & {
+  color?: "primary" | "inherit";
+};
 
-const Download: FC<DownloadIconProps> = (iconProps) => (
-  <FontAwesomeIcon icon={faDownload} {...iconProps} />
-);
+const Download: FC<DownloadIconProps> = ({ color, ...iconProps }) => {
+  const theme = useTheme();
+
+  return (
+    <FontAwesomeIcon
+      icon={faDownload}
+      css={{
+        color: color === "primary" ? theme.palette.primary.main : "inherit",
+      }}
+      {...iconProps}
+    />
+  );
+};
 
 export default Download;

--- a/src/v1/components/data-display/FontAwesomeIcons/SearchIcon.tsx
+++ b/src/v1/components/data-display/FontAwesomeIcons/SearchIcon.tsx
@@ -1,11 +1,27 @@
 import React from "react";
-import { FontAwesomeIcon, FontAwesomeIconProps } from "@fortawesome/react-fontawesome";
+import {
+  FontAwesomeIcon,
+  FontAwesomeIconProps,
+} from "@fortawesome/react-fontawesome";
 import { faMagnifyingGlass } from "@fortawesome/free-solid-svg-icons";
+import { useTheme } from "@mui/material/styles";
 
-type SearchIconProps = Omit<FontAwesomeIconProps, "icon">;
+type SearchIconProps = Omit<FontAwesomeIconProps, "icon"> & {
+  color?: "primary" | "inherit";
+};
 
-const SearchIcon: React.FC<SearchIconProps> = (faIconProps) => (
-  <FontAwesomeIcon icon={faMagnifyingGlass} {...faIconProps} />
-);
+const SearchIcon: React.FC<SearchIconProps> = ({ color, ...faIconProps }) => {
+  const theme = useTheme();
+
+  return (
+    <FontAwesomeIcon
+      icon={faMagnifyingGlass}
+      css={{
+        color: color === "primary" ? theme.palette.primary.main : "inherit",
+      }}
+      {...faIconProps}
+    />
+  );
+};
 
 export default SearchIcon;


### PR DESCRIPTION
To get [this ticket ](https://telicent.atlassian.net/browse/TELFE-660) completed, the color prop is required in the font awesome icons to match designs in the ticket.