### PR TITLE
fix: export fixed panel from surfaces

### DIFF
--- a/src/v1/components/surfaces/index.ts
+++ b/src/v1/components/surfaces/index.ts
@@ -1,5 +1,6 @@
 export * from "./Card";
 export * from "./FloatingPanel";
+export * from "./FixedPanel/FixedPanel";
 
 export { default as AppBar } from "./AppBar/AppBar";
 export type { AppBarProps } from "./AppBar/AppBar";


### PR DESCRIPTION
I didn't realise how all the components were being exported from specific files. Exported FixedPanel from `surfaces/index.ts`