### PR TITLE
fix: app switch on app bar

### DIFF
--- a/src/v1/components/surfaces/AppBar/AppBar.stories.tsx
+++ b/src/v1/components/surfaces/AppBar/AppBar.stories.tsx
@@ -67,10 +67,5 @@ export const WithSignOutButton: Story = {
       </Button>
     ),
   },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    await userEvent.click(canvas.getByRole("button", { name: "user-profile" }));
-  },
 };
 

--- a/src/v1/components/surfaces/AppBar/AppBar.stories.tsx
+++ b/src/v1/components/surfaces/AppBar/AppBar.stories.tsx
@@ -10,6 +10,11 @@ const meta: Meta<typeof AppBar> = {
   component: AppBar,
   tags: ["autodocs"],
   parameters: {
+    docs: {
+      description: {
+        component: "The AppBar component provides a top navigation bar that supports branding, actions, and more.",
+      },
+    },
     layout: "fullscreen",
   },
 };
@@ -48,7 +53,7 @@ export const WithUserProfile: Story = {
 
 export const WithVersionNumber: Story = {
   args: {
-    appName: "Search",
+    appName: "Design System",
     version: "1.2.0",
   },
 };

--- a/src/v1/components/surfaces/AppBar/AppBar.test.tsx
+++ b/src/v1/components/surfaces/AppBar/AppBar.test.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { setup } from "../../../../test-utils";
+import AppBar from "./AppBar";
+import { screen, within } from "@testing-library/dom";
+
+describe("AppBar Component", () => {
+
+    test("should render the appName", () => {
+        setup(<AppBar appName="AppBar Test" />);
+  
+      expect(screen.getByText("AppBar Test")).toBeInTheDocument();
+    });
+
+    test("should render the startChild component", () => {
+       setup(
+        <AppBar appName="Design System" startChild={<div id="start-child">Start Child</div>} />
+      );
+  
+  
+      expect(screen.getByTestId("start-child")).toBeInTheDocument();
+      expect(screen.getByText("Start Child")).toBeInTheDocument();
+    });
+
+    test("should render the endChild component", () => {
+       setup(
+        <AppBar appName="Design System" endChild={<div id="end-child">End Child</div>} />
+      );
+  
+
+      expect(screen.getByTestId("end-child")).toBeInTheDocument();
+      expect(screen.getByText("End Child")).toBeInTheDocument();
+    });
+  
+
+    test("should render both startChild and endChild components", () => {
+   setup(
+        <AppBar
+          appName="Design System"
+          startChild={<div id="start-child">Start Child</div>}
+          endChild={<div id="end-child">End Child</div>}
+        />
+      );
+
+      expect(screen.getByTestId("start-child")).toBeInTheDocument();
+      expect(screen.getByText("Start Child")).toBeInTheDocument();
+  
+      expect(screen.getByTestId("end-child")).toBeInTheDocument();
+      expect(screen.getByText("End Child")).toBeInTheDocument();
+    });
+
+    test("shoult render the version number", ()=>{
+       setup(<AppBar version="1.2.3"/>)
+
+       expect(screen.getByText("1.2.3")).toBeInTheDocument();
+    })
+  });

--- a/src/v1/components/surfaces/AppBar/AppBar.tsx
+++ b/src/v1/components/surfaces/AppBar/AppBar.tsx
@@ -12,7 +12,7 @@ import useExtendedTheme from "../../../../hooks/useExtendedTheme";
 export type AppBarProps = Partial<{
   appName: string;
   beta: boolean;
-  apps: AppSwitchLibraryType;
+  startChild: React.ReactNode;
   endChild: React.ReactNode;
   position: MUIAppBarProps["position"];
   version: string;
@@ -22,7 +22,7 @@ const AppBar: React.FC<AppBarProps> = ({
   appName,
   beta = false,
   position = "relative",
-  apps = [],
+  startChild,
   endChild,
   version,
 }) => {
@@ -39,7 +39,7 @@ const AppBar: React.FC<AppBarProps> = ({
       }}
       elevation={0}
     >
-      {apps?.length >= 1 && (
+      {startChild && (
         <MUIBox
           id="app-switch-container"
           sx={{
@@ -49,7 +49,7 @@ const AppBar: React.FC<AppBarProps> = ({
             transform: "translate(0, -50%)",
           }}
         >
-          <AppSwitch apps={apps} />
+          {startChild}
         </MUIBox>
       )}
       <MUIStack


### PR DESCRIPTION
Updated the AppBar component to accept a startChild prop instead of having AppSwitch hardcoded. This change improves flexibility, allowing any component to be passed as the start section of the AppBar while maintaining the existing functionality.