### PR TITLE
fix: version number rendering on top of brand if too long

### DIFF
--- a/src/v1/components/surfaces/AppBar/AppBar.tsx
+++ b/src/v1/components/surfaces/AppBar/AppBar.tsx
@@ -71,12 +71,14 @@ const AppBar: React.FC<AppBarProps> = ({
         {version && (
           <MUIBox
             position="absolute"
-            right={-33}
             bottom={5}
             fontSize={12}
+            left="calc(100% - 12px)"
             paddingInline={0.5}
             sx={{
               color: theme.palette.secondary.contrastText,
+              whiteSpace: "nowrap",
+              marginLeft: "-4px",
             }}
           >
             {version}


### PR DESCRIPTION
fix a small bug where version number would render on top of brand if it was too long. 