### PR TITLE
Don't block if tsc --noEmit fails

### DIFF
--- a/.github/workflows/test-feature-branch.yml
+++ b/.github/workflows/test-feature-branch.yml
@@ -9,5 +9,5 @@ on:
 jobs:
   quality:
     name: Run unit tests
-    uses: telicent-oss/shared-workflows/.github/workflows/javascript-test-feature-branch.yml@tsc/skippable
+    uses: telicent-oss/shared-workflows/.github/workflows/javascript-test-feature-branch.yml@main
     secrets: inherit

--- a/.github/workflows/test-feature-branch.yml
+++ b/.github/workflows/test-feature-branch.yml
@@ -9,5 +9,5 @@ on:
 jobs:
   quality:
     name: Run unit tests
-    uses: telicent-oss/shared-workflows/.github/workflows/javascript-test-feature-branch.yml@main
+    uses: telicent-oss/shared-workflows/.github/workflows/javascript-test-feature-branch.yml@tsc/skippable
     secrets: inherit

--- a/package.json
+++ b/package.json
@@ -207,5 +207,10 @@
   },
   "engine": {
     "node": "20.14.0"
+  },
+  "ci": {
+    "shared-workflows/.github/workflows/javascript-test-feature-branch.yml": {
+      "WARNING: TSC CHECK NO ERROR": false
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
   },
   "ci": {
     "shared-workflows/.github/workflows/javascript-test-feature-branch.yml": {
-      "WARNING: TSC CHECK NO ERROR": true
+      "WARNING: TSC CHECK NO ERROR": false
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
   },
   "ci": {
     "shared-workflows/.github/workflows/javascript-test-feature-branch.yml": {
-      "WARNING: TSC CHECK NO ERROR": false
+      "WARNING: TSC CHECK NO ERROR": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -207,5 +207,10 @@
   },
   "engine": {
     "node": "20.14.0"
+  },
+  "ci": {
+    "shared-workflows/.github/workflows/javascript-test-feature-branch.yml": {
+      "WARNING: TSC CHECK NO ERROR": true
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -207,10 +207,5 @@
   },
   "engine": {
     "node": "20.14.0"
-  },
-  "ci": {
-    "shared-workflows/.github/workflows/javascript-test-feature-branch.yml": {
-      "WARNING: TSC CHECK NO ERROR": false
-    }
   }
 }


### PR DESCRIPTION
See workflow: https://github.com/telicent-oss/shared-workflows/pull/100

Runs tsc --noEmit:
* [but doesn't kill job when flag true](https://github.com/telicent-oss/telicent-ds/actions/runs/13590663886/job/37995752502)
* [and kills job with flag false](https://github.com/telicent-oss/telicent-ds/actions/runs/13590701515/job/37995892439)
* [and kills job when flag doesn't exist](https://github.com/telicent-oss/telicent-ds/actions/runs/13590707497/job/37995912688)

Note: subsequent unit tests still fail job

Proof it works with main branch of shared-workflows
https://github.com/telicent-oss/telicent-ds/actions/runs/13590999965/job/37996884891
