### PR TITLE
fix: make text black

### DIFF
--- a/src/component-library/Map/map.css
+++ b/src/component-library/Map/map.css
@@ -32,7 +32,7 @@
     @apply text-whiteSmoke;
   }
   .mapboxgl-ctrl-attrib.mapboxgl-compact {
-    @apply m-0.5;
+    @apply m-0.5 text-black-500;
     min-height: 24px;
   }
   


### PR DESCRIPTION
Text inherits from the app, which in some cases means we get white text on a white background