### PR TITLE
Fix: Remove unwanted Paper background in dark mode & update AppBar elevation

### DIFF
--- a/src/v1/components/surfaces/AppBar/AppBar.tsx
+++ b/src/v1/components/surfaces/AppBar/AppBar.tsx
@@ -17,6 +17,7 @@ export type AppBarProps = Partial<{
   position: MUIAppBarProps["position"];
   version?: string;
   onClick?: (event?: Event | React.SyntheticEvent) => void;
+  elevation?: boolean;
 }>;
 
 const AppBar: React.FC<AppBarProps> = ({
@@ -27,6 +28,7 @@ const AppBar: React.FC<AppBarProps> = ({
   endChild,
   version,
   onClick,
+  elevation,
 }) => {
   const theme = useExtendedTheme();
 
@@ -34,12 +36,11 @@ const AppBar: React.FC<AppBarProps> = ({
     <MUIAppBar
       color="inherit"
       position={position}
-      enableColorOnDark
       sx={{
         borderRadius: 0,
         backgroundColor: theme.palette.mode === "dark" ? theme.palette.background.default : "#ffffff",
       }}
-      elevation={0}
+      elevation={elevation ? 4 : 0}
     >
       {startChild && (
         <MUIBox

--- a/src/v1/theme/style-overrides/components.ts
+++ b/src/v1/theme/style-overrides/components.ts
@@ -8,6 +8,13 @@ const generateComponentOverrides = (uiTheme: UITheme) =>
     ...componentOverrides.AVATAR_OVERRIDES,
     ...componentOverrides.generateButtonOverrides(uiTheme),
     ...componentOverrides.generateCardOverrides(uiTheme),
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          backgroundImage: "none",
+        },
+      },
+    },
     MuiAppBar: {
       styleOverrides: {
         root: {


### PR DESCRIPTION
- Override MUI's default behaviour of adding a background image to Paper with elevation in dark mode, as it didn't match the design.

- Updated AppBar to support no elevation, following the design requirement that elevation is only applied when AppNavigation is absent.