### PR TITLE
fix(MiniSearchAutocomplete): add onKeyDown prop

### DIFF
--- a/src/v1/components/inputs/SearchBox/MiniSearchAutocomplete.test.tsx
+++ b/src/v1/components/inputs/SearchBox/MiniSearchAutocomplete.test.tsx
@@ -143,4 +143,15 @@ describe("MiniSearchAutocomplete", () => {
     expect(onSearch).toHaveBeenCalledTimes(2);
   });
 
+  test("calls onKeyDown when key is pressed", async () => {
+    const onKeyDown = jest.fn();
+    const { user } = renderComponent({ onKeyDown });
+
+    const input = screen.getByRole("combobox");
+
+    // Step 1: Type a search query
+    await user.type(input, "A");
+
+    expect(onKeyDown).toHaveBeenCalled()
+  })
 });

--- a/src/v1/components/inputs/SearchBox/MiniSearchAutocomplete.tsx
+++ b/src/v1/components/inputs/SearchBox/MiniSearchAutocomplete.tsx
@@ -81,6 +81,12 @@ export interface MiniSearchAutocompleteProps<
    * `(event: React.MouseEvent<HTMLButtonElement>) => void;`
    */
   onSearch?: React.MouseEventHandler<HTMLButtonElement>;
+  /**
+   * Callback fired when the a key is pressed
+   *
+   * `(event: React.KeyboardEvent<HTMLButtonElement>) => void;`
+   */
+  onKeyDown?: React.KeyboardEventHandler<HTMLInputElement>;
 }
 
 const MiniSearchAutocomplete = forwardRef(function Autocomplete<
@@ -107,6 +113,7 @@ const MiniSearchAutocomplete = forwardRef(function Autocomplete<
     progressProps,
     renderOption,
     onSearch,
+    onKeyDown,
     freeSolo = true as FreeSolo,
     ...autocompleteProps
   } = props;
@@ -136,6 +143,7 @@ const MiniSearchAutocomplete = forwardRef(function Autocomplete<
         type="search"
         sx={{ width: 360 }}
         id={id}
+        onKeyDown={onKeyDown}
         name={name}
         error={error}
         endAdornment={


### PR DESCRIPTION
## Ticket
https://telicent.atlassian.net/browse/TELFE-848

## Work done
Added onKeyDown Prop so that Graph can implement a listener for when the user presses 'Enter'

## Tests
Add a test to ensure that the callback gets triggered on keypress