### PR TITLE
fix: add refs to all buttons

### DIFF
--- a/src/v1/components/inputs/Button/Button.tsx
+++ b/src/v1/components/inputs/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { forwardRef } from "react";
 import MUIButton, { ButtonProps as MUIButtonProps } from "@mui/material/Button";
 import PrimaryButton from "./PrimaryButton";
 import SecondaryButton from "./SecondaryButton";
@@ -66,25 +66,25 @@ export interface ButtonProps
   variant?: "primary" | "secondary" | "tertiary" | "link" | "text";
 }
 
-const Button: React.FC<ButtonProps> = ({
-  variant = "primary",
-  color = "primary",
-  ...buttonProps
-}) => {
-  if (variant === "primary") return <PrimaryButton {...buttonProps} />;
-  if (variant === "secondary") return <SecondaryButton {...buttonProps} />;
+const Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
+  const { variant = "primary",
+    color = "primary",
+    ...buttonProps
+  } = props
+  if (variant === "primary") return <PrimaryButton {...buttonProps} ref={ref} />;
+  if (variant === "secondary") return <SecondaryButton {...buttonProps} ref={ref} />;
 
   /**
    * Cannot extend variants in theme. Using sx as workaround
    * https://github.com/mui/material-ui/issues/32427
    */
-  if (variant === "link") return <LinkButton {...buttonProps} />;
+  if (variant === "link") return <LinkButton {...buttonProps} ref={ref} />;
 
   return (
-    <MUIButton variant="text" color={color} {...buttonProps}>
+    <MUIButton variant="text" color={color} {...buttonProps} ref={ref}>
       {buttonProps.children}
     </MUIButton>
   );
-};
+});
 
 export default Button;

--- a/src/v1/components/inputs/Button/LinkButton.tsx
+++ b/src/v1/components/inputs/Button/LinkButton.tsx
@@ -1,16 +1,17 @@
-import React from "react";
+import React, { forwardRef } from "react";
 import MUIButton, { ButtonProps as MUIButtonProps } from "@mui/material/Button";
 import MUIBox from "@mui/material/Box";
 import { useTheme } from "@mui/material/styles";
 
 type LinkButtonProps = Omit<MUIButtonProps, "variant" | "color">;
 
-const LinkButton: React.FC<LinkButtonProps> = (buttonProps) => {
+const LinkButton = forwardRef<HTMLButtonElement, LinkButtonProps>((buttonProps, ref) => {
   const theme = useTheme();
 
   return (
     <MUIBox sx={{ width: "fit-content" }}>
       <MUIButton
+        ref={ref}
         variant="text"
         color="primary"
         {...buttonProps}
@@ -43,6 +44,6 @@ const LinkButton: React.FC<LinkButtonProps> = (buttonProps) => {
       />
     </MUIBox>
   );
-};
+});
 
 export default LinkButton;

--- a/src/v1/components/inputs/Button/PrimaryButton.tsx
+++ b/src/v1/components/inputs/Button/PrimaryButton.tsx
@@ -1,12 +1,18 @@
-import React from "react";
+import React, { forwardRef } from "react";
 import { Button, ButtonProps } from "@mui/material";
 
 type PrimaryButtonProps = Omit<ButtonProps, "variant" | "color">;
 
-const PrimaryButton: React.FC<PrimaryButtonProps> = (buttonProps) => (
-  <Button variant="contained" color="primary" {...buttonProps}>
+// const PrimaryButton: React.FC<PrimaryButtonProps> = (buttonProps) => (
+//   <Button variant="contained" color="primary" {...buttonProps}>
+//     {buttonProps.children}
+//   </Button>
+// );
+
+const PrimaryButton = forwardRef<HTMLButtonElement, PrimaryButtonProps>((buttonProps, ref) => (
+  <Button variant="contained" ref={ref} color="primary" {...buttonProps}>
     {buttonProps.children}
   </Button>
-);
+));
 
 export default PrimaryButton;

--- a/src/v1/components/inputs/Button/SecondaryButton.tsx
+++ b/src/v1/components/inputs/Button/SecondaryButton.tsx
@@ -1,21 +1,21 @@
-import React from "react";
+import React, { forwardRef } from "react";
 import MUIButton, { ButtonProps as MUIButtonProps } from "@mui/material/Button";
 
 type SecondaryButtonProps = Omit<MUIButtonProps, "variant" | "color">;
 
-const SecondaryButton: React.FC<SecondaryButtonProps> = (buttonProps) => {
+const SecondaryButton = forwardRef<HTMLButtonElement, SecondaryButtonProps>((buttonProps, ref) => {
   if (buttonProps.disableElevation) {
     return (
-      <MUIButton variant="outlined" color="primary" {...buttonProps}>
+      <MUIButton variant="outlined" color="primary" {...buttonProps} ref={ref}>
         {buttonProps.children}
       </MUIButton>
     );
   }
   return (
-    <MUIButton variant="outlined" color="inherit" {...buttonProps}>
+    <MUIButton variant="outlined" color="inherit" {...buttonProps} ref={ref}>
       {buttonProps.children}
     </MUIButton>
   );
-};
+});
 
 export default SecondaryButton;


### PR DESCRIPTION
Ticket: Done as part of [TELFE-569](https://telicent.atlassian.net/browse/TELFE-569)
### Goal

The buttons in graph all use [MUI Tooltip](https://mui.com/material-ui/react-tooltip/?srsltid=AfmBOor1LmPjMRSnrvlItG2i9vcOEeNAbP3LUhVsyPHu7O_a296RuI70), which weren't working with the buttons provided by the DS. 

The goal is to make the tooltips work with Telicent themed buttons.

### Work Completed

Add refs to all button variants.

![Screenshot 2025-03-31 at 16 30 21](https://github.com/user-attachments/assets/e7443b3e-94ee-45d1-9136-28cc2ed8d499)


### Testing Method

I linked the DS to graph and manually tested.
No additional tests have been added for the tests.

### Code Review Tips <!-- OPTIONAL-->

<!-- Pointers for reviewer  -->

### Engineering Notes <!-- OPTIONAL-->

<!-- Implementation context  -->

### Out-of-scope <!-- OPTIONAL-->

<!-- Boundary setting -->

---

<details>
  <summary><strong>🕵️ Review Guidance</strong></summary>

---

General guidance

- Generally, approve a PR if it makes the system better, even if it's not perfect. — [Google: The Standard of Code Review](https://google.github.io/eng-practices/review/reviewer/standard.html)
- The aim of both PR AUTHOR and PR REVIEWER is to get the code merged
- Aim for consensus, defined as _everyone can live with the outcome_

For PR REVIEWER:

1. Read the ticket & description
2. [Review the code](https://google.github.io/eng-practices/review/reviewer/looking-for.html)
3. Request any changes that are essential.
4. For non-essential comments:
   - Use prefixes, e.g. "**nit:** change to Pascal case"
     - **nit:** small, non-essential change
     - **obs:** just an observation, doesn't affect the PR
     - **idea:** a suggestion to think about
     - **q:** questions
   - Use modifiers, e.g. "**obs**`[pr-owner-resolve]`: Jim is also editing this file"
     - `pr-author-resolve` PR author can resolve after reading
     - `pr-author-delete` (rare) delete after reading to avoid confusion
5. try to add _at least_ a helpful comment per ~500 lines; less if the PR is already busy

For PR AUTHOR:

1. Aim for enough detail in PR description for things to go smoothly
2. After requested changes, [re-request a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews#re-requesting-a-review) (so the PR shows up in [reviews-requested:@me](https://github.com/pulls?q=is%3Apr+is%3Aopen+archived%3Afalse+sort%3Aupdated-desc+review-requested%3A%40me+))

</details>
