### PR TITLE
fix: update react element schema

### DIFF
--- a/src/schema/reactElementsSchema.ts
+++ b/src/schema/reactElementsSchema.ts
@@ -1,8 +1,10 @@
-import { z } from 'zod';
+import { z } from "zod";
 
 // Simulating React.ReactElement validation
 export const reactElementSchema = z.object({
-    type: z.union([z.string(), z.function(), z.symbol()]), // Type can be a string or a function (JSXElementConstructor)
-    props: z.record(z.any()),                 // Props is an object with any keys
-    key: z.union([z.string(), z.number(), z.null()]).optional(), // Key is either string, number, or null
+  type: z.union([z.string(), z.function(), z.symbol(), z.object({}).passthrough()]), // Type can be a string or a function (JSXElementConstructor)
+  props: z.record(z.any()), // Props is an object with any keys
+  key: z.union([z.string(), z.number(), z.null()]).optional(), // Key is either string, number, or null
 });
+
+// z.object({}).passthrough() ← allow component types that are objects (e.g. styled, memo, forwardRef

--- a/src/v1/components/data-display/DropdownButton/DropdownButton.tsx
+++ b/src/v1/components/data-display/DropdownButton/DropdownButton.tsx
@@ -34,53 +34,55 @@ const DropdownButtonMenuItem: React.FC<DropDownButtonMenuItemProps> = ({ onClick
 	const Icon = icon;
 	const theme = useExtendedTheme();
 
-	return <MUIMenuItem
-		onClick={onClick}
-		id={id}
-		selected={selected}
-		sx={{
-			display: "flex",
-			alignItems: "center",
-			marginX: 1,
-			borderRadius: "4px",
-			border: "1px solid rgba(0, 0, 0, 0)",
-			"&.Mui-selected.Mui-selected": {
-				backgroundColor:
-					theme.palette.mode === "dark" ? theme.palette.background.default : "rgba(0, 0, 0, 0.04)",
-			},
-			"&.Mui-selected.Mui-selected:hover": {
-				backgroundColor:
-					theme.palette.mode === "dark" ? theme.palette.background.default : "rgba(0, 0, 0, 0.04)",
-			},
-			"&:hover": {
-				backgroundColor:
-					theme.palette.mode === "dark" ? theme.palette.background.default : "rgba(0, 0, 0, 0.04)",
-				border: `1px solid ${theme.palette.primary.main}`,
-			},
-		}}>
-		{
-			(Icon || faIcon) && <MUIListItemIcon>
-				{Icon && <Icon color={selected ? "primary" : "inherit"} />}
-				{faIcon && <FontAwesomeIcon icon={faIcon} fontSize="medium" color={selected ? theme.palette.primary.main : "white"} />}
-			</MUIListItemIcon>
-		}
-		<MUIListItemText>
-			<MUITypography
-				variant="h1"
-				sx={{
-					marginTop: 0.5,
-					fontFamily: "Figtree",
-					fontSize: 16,
-					fontWeight: 400,
-					color: `${selected ? theme.palette.primary.main : "primary"}`,
-					display: "flex",
-					alignItems: "center",
-				}}
-			>
-				{value}
-			</MUITypography>
-		</MUIListItemText>
-	</MUIMenuItem >
+	return (
+    <MUIMenuItem
+      onClick={() => onClick(value)}
+      id={id}
+      selected={selected}
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        marginX: 1,
+        borderRadius: "4px",
+        border: "1px solid rgba(0, 0, 0, 0)",
+        "&.Mui-selected.Mui-selected": {
+          backgroundColor: theme.palette.mode === "dark" ? theme.palette.background.default : "rgba(0, 0, 0, 0.04)",
+        },
+        "&.Mui-selected.Mui-selected:hover": {
+          backgroundColor: theme.palette.mode === "dark" ? theme.palette.background.default : "rgba(0, 0, 0, 0.04)",
+        },
+        "&:hover": {
+          backgroundColor: theme.palette.mode === "dark" ? theme.palette.background.default : "rgba(0, 0, 0, 0.04)",
+          border: `1px solid ${theme.palette.primary.main}`,
+        },
+      }}
+    >
+      {(Icon || faIcon) && (
+        <MUIListItemIcon>
+          {Icon && <Icon color={selected ? "primary" : "inherit"} />}
+          {faIcon && (
+            <FontAwesomeIcon icon={faIcon} fontSize="medium" color={selected ? theme.palette.primary.main : "white"} />
+          )}
+        </MUIListItemIcon>
+      )}
+      <MUIListItemText>
+        <MUITypography
+          variant="h1"
+          sx={{
+            marginTop: 0.5,
+            fontFamily: "Figtree",
+            fontSize: 16,
+            fontWeight: 400,
+            color: `${selected ? theme.palette.primary.main : "primary"}`,
+            display: "flex",
+            alignItems: "center",
+          }}
+        >
+          {value}
+        </MUITypography>
+      </MUIListItemText>
+    </MUIMenuItem>
+  );
 }
 
 const DropdownButton: React.FC<DropdownButtonProps> = ({ ariaLabel, id, menuItems }) => {

--- a/src/v1/components/inputs/Button/Button.tsx
+++ b/src/v1/components/inputs/Button/Button.tsx
@@ -3,6 +3,7 @@ import MUIButton, { ButtonProps as MUIButtonProps } from "@mui/material/Button";
 import PrimaryButton from "./PrimaryButton";
 import SecondaryButton from "./SecondaryButton";
 import LinkButton from "./LinkButton";
+import { ButtonBase } from "@mui/material";
 
 export interface ButtonProps
   extends Omit<
@@ -63,14 +64,11 @@ export interface ButtonProps
    * The variant to use.
    * @default 'primary'
    */
-  variant?: "primary" | "secondary" | "tertiary" | "link" | "text";
+  variant?: "primary" | "secondary" | "tertiary" | "link" | "text" | "noStyle";
 }
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
-  const { variant = "primary",
-    color = "primary",
-    ...buttonProps
-  } = props
+  const { variant = "primary", color = "primary", ...buttonProps } = props;
   if (variant === "primary") return <PrimaryButton {...buttonProps} ref={ref} />;
   if (variant === "secondary") return <SecondaryButton {...buttonProps} ref={ref} />;
 
@@ -79,6 +77,8 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
    * https://github.com/mui/material-ui/issues/32427
    */
   if (variant === "link") return <LinkButton {...buttonProps} ref={ref} />;
+
+  if (variant === "noStyle") return <ButtonBase {...buttonProps} ref={ref} />;
 
   return (
     <MUIButton variant="text" color={color} {...buttonProps} ref={ref}>

--- a/src/v1/components/layout/FlexBox.tsx
+++ b/src/v1/components/layout/FlexBox.tsx
@@ -1,6 +1,10 @@
-import React from "react";
+import React, { forwardRef } from "react";
 import Stack, { StackProps } from "@mui/material/Stack";
 
-const FlexBox: React.FC<StackProps> = (props) => <Stack {...props}>{props.children}</Stack>;
+const FlexBox = forwardRef<HTMLDivElement, StackProps>((props, ref) => (
+  <Stack ref={ref} {...props}>
+    {props.children}
+  </Stack>
+));
 
 export default FlexBox;


### PR DESCRIPTION
The forward ref that was added to Flexbox component was creating an error, by enabling .passthrough(), the schema no longer removes or errors on unknown keys—so the forwarded ref will just “pass through” untouched.



---

<details>
  <summary><strong>🕵️ Review Guidance</strong></summary>

---

General guidance

- Generally, approve a PR if it makes the system better, even if it's not perfect. — [Google: The Standard of Code Review](https://google.github.io/eng-practices/review/reviewer/standard.html)
- The aim of both PR AUTHOR and PR REVIEWER is to get the code merged
- Aim for consensus, defined as _everyone can live with the outcome_

For PR REVIEWER:

1. Read the ticket & description
2. [Review the code](https://google.github.io/eng-practices/review/reviewer/looking-for.html)
3. Request any changes that are essential.
4. For non-essential comments:
   - Use prefixes, e.g. "**nit:** change to Pascal case"
     - **nit:** small, non-essential change
     - **obs:** just an observation, doesn't affect the PR
     - **idea:** a suggestion to think about
     - **q:** questions
   - Use modifiers, e.g. "**obs**`[pr-owner-resolve]`: Jim is also editing this file"
     - `pr-author-resolve` PR author can resolve after reading
     - `pr-author-delete` (rare) delete after reading to avoid confusion
5. try to add _at least_ a helpful comment per ~500 lines; less if the PR is already busy

For PR AUTHOR:

1. Aim for enough detail in PR description for things to go smoothly
2. After requested changes, [re-request a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews#re-requesting-a-review) (so the PR shows up in [reviews-requested:@me](https://github.com/pulls?q=is%3Apr+is%3Aopen+archived%3Afalse+sort%3Aupdated-desc+review-requested%3A%40me+))

</details>
