### PR TITLE
feat(Logger): [TELFE-1184] added

### DIFF
--- a/src/candidate-packages/utils-lib/src/Logger/Logger.test.ts
+++ b/src/candidate-packages/utils-lib/src/Logger/Logger.test.ts
@@ -1,0 +1,42 @@
+import { Logger } from "./Logger";
+
+describe("Logger", () => {
+  let spyDebug: ReturnType<typeof jest.spyOn>;
+  let spyInfo: ReturnType<typeof jest.spyOn>;
+  let spyWarn: ReturnType<typeof jest.spyOn>;
+  let spyError: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    spyDebug = jest.spyOn(console, "debug").mockImplementation(() => {});
+    spyInfo = jest.spyOn(console, "info").mockImplementation(() => {});
+    spyWarn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    spyError = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("buffers calls before init and flushes on init with string level", () => {
+    const logger = new Logger();
+    logger.debug("a");
+    logger.info("b");
+    logger.init("debug");
+    expect(spyDebug).toHaveBeenCalledWith("a");
+    expect(spyInfo).toHaveBeenCalledWith("b");
+  });
+
+  it("works with numeric level initialization", () => {
+    const logger = new Logger(2);
+    logger.info("skip");
+    logger.warn("ok");
+    expect(spyInfo).not.toHaveBeenCalled();
+    expect(spyWarn).toHaveBeenCalledWith("ok");
+  });
+
+  it("logs immediately after init", () => {
+    const logger = new Logger("warn");
+    logger.error("now");
+    expect(spyError).toHaveBeenCalledWith("now");
+  });
+});

--- a/src/candidate-packages/utils-lib/src/Logger/Logger.ts
+++ b/src/candidate-packages/utils-lib/src/Logger/Logger.ts
@@ -2,7 +2,7 @@ export type LevelString = "debug" | "info" | "warn" | "error";
 
 export type Level = LevelString | number;
 
-const levelOrder: Record<LevelString, number> = {
+export const levelOrder: Record<LevelString, number> = {
   debug: 0,
   info: 1,
   warn: 2,

--- a/src/candidate-packages/utils-lib/src/Logger/Logger.ts
+++ b/src/candidate-packages/utils-lib/src/Logger/Logger.ts
@@ -1,8 +1,8 @@
-export type LevelString = "debug" | "info" | "warn" | "error";
+export type LoggerLevelString = "debug" | "info" | "warn" | "error";
 
-export type Level = LevelString | number;
+export type LoggerLevel = LoggerLevelString | number;
 
-export const levelOrder: Record<LevelString, number> = {
+export const loggerLevelOrder: Record<LoggerLevelString, number> = {
   debug: 0,
   info: 1,
   warn: 2,
@@ -52,25 +52,25 @@ export const levelOrder: Record<LevelString, number> = {
  */
 
 export class Logger {
-  private buffer: Array<{ level: LevelString; args: unknown[] }> = [];
-  private currentLevelNum = levelOrder.info;
+  private buffer: Array<{ level: LoggerLevelString; args: unknown[] }> = [];
+  private currentLevelNum = loggerLevelOrder.info;
   private ready = false;
 
-  constructor(level?: Level) {
+  constructor(level?: LoggerLevel) {
     if (level !== undefined) this.init(level);
   }
 
-  init(level: Level): void {
+  init(level: LoggerLevel): void {
     this.currentLevelNum =
       typeof level === "number"
         ? level
-        : levelOrder[level] ?? this.currentLevelNum;
+        : loggerLevelOrder[level] ?? this.currentLevelNum;
     this.ready = true;
     this.flush();
   }
 
-  private shouldLog(lvl: LevelString): boolean {
-    return levelOrder[lvl] >= this.currentLevelNum;
+  private shouldLog(lvl: LoggerLevelString): boolean {
+    return loggerLevelOrder[lvl] >= this.currentLevelNum;
   }
 
   private flush(): void {
@@ -80,7 +80,7 @@ export class Logger {
     this.buffer = [];
   }
 
-  private record(lvl: LevelString, ...args: unknown[]): void {
+  private record(lvl: LoggerLevelString, ...args: unknown[]): void {
     if (!this.ready) {
       this.buffer.push({ level: lvl, args });
     } else if (this.shouldLog(lvl)) {

--- a/src/candidate-packages/utils-lib/src/Logger/Logger.ts
+++ b/src/candidate-packages/utils-lib/src/Logger/Logger.ts
@@ -1,0 +1,95 @@
+export type LevelString = "debug" | "info" | "warn" | "error";
+
+export type Level = LevelString | number;
+
+const levelOrder: Record<LevelString, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+/**
+ * BufferedLogger
+ *
+ * Buffers log calls until a level is set, then flushes buffered messages
+ * at or above that level and logs subsequent calls immediately.
+ *
+ * @example
+ * ```ts
+ * import { BufferedLogger } from './buffered-logger';
+ *
+ * const logger = new BufferedLogger();
+ *
+ * // These calls are buffered
+ * logger.debug('debug before init');
+ * logger.info('info before init');
+ *
+ * // Initialize log level and flush buffer
+ * logger.setLevel('info');
+ *
+ * // Only "info" and above were flushed; debug was dropped
+ *
+ * // Subsequent calls log immediately
+ * logger.debug('this won’t show');
+ * logger.warn('this will show as warning');
+ * ```
+ *
+ * @method setLevel
+ * @param {'debug'|'info'|'warn'|'error'} level — minimum level to log
+ *
+ * @method debug
+ * @param {...any} args — arguments forwarded to console.debug
+ *
+ * @method info
+ * @param {...any} args — arguments forwarded to console.info
+ *
+ * @method warn
+ * @param {...any} args — arguments forwarded to console.warn
+ *
+ * @method error
+ * @param {...any} args — arguments forwarded to console.error
+ */
+
+export class Logger {
+  private buffer: Array<{ level: LevelString; args: unknown[] }> = [];
+  private currentLevelNum = levelOrder.info;
+  private ready = false;
+
+  constructor(level?: Level) {
+    if (level !== undefined) this.init(level);
+  }
+
+  init(level: Level): void {
+    this.currentLevelNum =
+      typeof level === "number"
+        ? level
+        : levelOrder[level] ?? this.currentLevelNum;
+    this.ready = true;
+    this.flush();
+  }
+
+  private shouldLog(lvl: LevelString): boolean {
+    return levelOrder[lvl] >= this.currentLevelNum;
+  }
+
+  private flush(): void {
+    for (const { level, args } of this.buffer) {
+      if (this.shouldLog(level)) console[level](...args);
+    }
+    this.buffer = [];
+  }
+
+  private record(lvl: LevelString, ...args: unknown[]): void {
+    if (!this.ready) {
+      this.buffer.push({ level: lvl, args });
+    } else if (this.shouldLog(lvl)) {
+      console[lvl](...args);
+    }
+  }
+
+  debug = (...args: unknown[]) => this.record("debug", ...args);
+  info = (...args: unknown[]) => this.record("info", ...args);
+  warn = (...args: unknown[]) => this.record("warn", ...args);
+  error = (...args: unknown[]) => this.record("error", ...args);
+}

--- a/src/candidate-packages/utils-lib/src/index.ts
+++ b/src/candidate-packages/utils-lib/src/index.ts
@@ -13,5 +13,12 @@ export {
   toStringEncoded,
   type URLSearchParamsInit,
 } from "./getCodec/toStringEncoded";
+export {
+  type LevelString,
+  type Level,
+  levelOrder,
+  Logger
+} from "./Logger/Logger";
+
 
 export { GRAPH_APP } from "./GraphApp/constants";

--- a/src/candidate-packages/utils-lib/src/index.ts
+++ b/src/candidate-packages/utils-lib/src/index.ts
@@ -14,9 +14,9 @@ export {
   type URLSearchParamsInit,
 } from "./getCodec/toStringEncoded";
 export {
-  type LevelString,
-  type Level,
-  levelOrder,
+  type LoggerLevelString,
+  type LoggerLevel,
+  loggerLevelOrder,
   Logger
 } from "./Logger/Logger";
 

--- a/src/export.ts
+++ b/src/export.ts
@@ -33,6 +33,11 @@ export {
   toStringEncoded,
   type URLSearchParamsInit,
   GRAPH_APP,
+  // Logger
+  type LoggerLevelString,
+  type LoggerLevel,
+  loggerLevelOrder,
+  Logger
 } from "./candidate-packages/utils-lib/src/index";
 
 // PROPOSED @telicent-oss/logout-syncer


### PR DESCRIPTION
Ticket: in service of TELFE-1184

### Goal

Our method for debug output is unclear - causing a few instances of missing output. 

Want:
```ts
// usage
const logger = new Logger();
logger.debug('pre-init debug');  // buffered
logger.info('pre-init info');    // buffered
// later...
logger.setLevel('debug');        // flushes only debug+ levels
logger.info('post-init');        // logs immediately
```


### Work Completed

Simple solution

### Testing Method

Log levels:
https://github.com/user-attachments/assets/1a7ab4ce-0bae-4ed2-b8b9-cd769a5eecf1

Queue if not inited, and Flush after init
https://github.com/user-attachments/assets/3d46874d-98d1-41fa-a878-647419a18f40



---




<details>
  <summary><strong>🕵️ Review Guidance</strong></summary>

---

General guidance

- Generally, approve a PR if it makes the system better, even if it's not perfect. — [Google: The Standard of Code Review](https://google.github.io/eng-practices/review/reviewer/standard.html)
- The aim of both PR AUTHOR and PR REVIEWER is to get the code merged
- Aim for consensus, defined as _everyone can live with the outcome_

For PR REVIEWER:

1. Read the ticket & description
2. [Review the code](https://google.github.io/eng-practices/review/reviewer/looking-for.html)
3. Request any changes that are essential.
4. For non-essential comments:
   - Use prefixes, e.g. "**nit:** change to Pascal case"
     - **nit:** small, non-essential change
     - **obs:** just an observation, doesn't affect the PR
     - **idea:** a suggestion to think about
     - **q:** questions
   - Use modifiers, e.g. "**obs**`[pr-owner-resolve]`: Jim is also editing this file"
     - `pr-author-resolve` PR author can resolve after reading
     - `pr-author-delete` (rare) delete after reading to avoid confusion
5. try to add _at least_ a helpful comment per ~500 lines; less if the PR is already busy

For PR AUTHOR:

1. Aim for enough detail in PR description for things to go smoothly
2. After requested changes, [re-request a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews#re-requesting-a-review) (so the PR shows up in [reviews-requested:@me](https://github.com/pulls?q=is%3Apr+is%3Aopen+archived%3Afalse+sort%3Aupdated-desc+review-requested%3A%40me+))

</details>
