### PR TITLE
feat: add checkbox component

### DIFF
--- a/src/v1/components/inputs/Checkbox/Checkbox.stories.tsx
+++ b/src/v1/components/inputs/Checkbox/Checkbox.stories.tsx
@@ -88,6 +88,15 @@ export const WithRequired: Story = {
   },
 };
 
+export const WithNoLabel: Story = {
+  args: {
+    checked: true,
+    id: "checkbox-custom-label",
+    required: true,
+    onChange: () => {},
+  },
+};
+
 export const ExampleWithOnChange: Story = {
   render: (args) => <RenderCheckbox {...args} />,
   args: {

--- a/src/v1/components/inputs/Checkbox/Checkbox.tsx
+++ b/src/v1/components/inputs/Checkbox/Checkbox.tsx
@@ -21,11 +21,11 @@ const Checkbox: React.FC<CustomCheckboxProps> = ({
   return label ? (
     <FormControlLabel
       required={required}
-      control={<MuiCheckbox checked={checked} id={id} name={name} {...rest} />}
+      control={<MuiCheckbox checked={checked} id={id} name={name} {...rest} color="primary" />}
       label={label}
     />
   ) : (
-    <MuiCheckbox checked={checked} id={id} name={name} {...rest} />
+    <MuiCheckbox checked={checked} id={id} name={name} {...rest} color="primary" />
   );
 };
 

--- a/src/v1/theme/createTheme.test.ts
+++ b/src/v1/theme/createTheme.test.ts
@@ -44,7 +44,7 @@ test("tmp theme diffs via unified patches", () => {
     ===================================================================
     --- 0	DataNavy (light)
     +++ 0	DataNavy (dark)
-    @@ -81,36 +81,20 @@
+    @@ -78,36 +78,20 @@
            "styleOverrides": "\\n    @font-face {\\n      font-family: 'Space Grotesk';\\n      font-style: normal;\\n      font-variant: normal;\\n      font-weight: 400;\\n      src: local('Space Grotesk'), url() format('woff2');\\n    }\\n\\n    @font-face {\\n      font-family: 'Space Grotesk';\\n      font-style: normal;\\n      font-variant: normal;\\n      font-weight: 500;\\n      src: local('Space Grotesk'), url() format('woff2');\\n    }\\n\\n    @font-face {\\n      font-family: 'Figtree';\\n      font-style: normal;\\n      font-variant: normal;\\n      font-weight: 400;\\n      src: local('Figtree'), url() format('woff2');\\n    }\\n\\n    @font-face {\\n      font-family: 'Figtree';\\n      font-style: normal;\\n      font-variant: normal;\\n      font-weight: 500;\\n      src: local('Figtree'), url() format('woff2');\\n    }\\n\\n    @font-face {\\n      font-family: 'Figtree';\\n      font-style: normal;\\n      font-variant: normal;\\n      font-weight: 700;\\n      src: local('Figtree'), url() format('woff2');\\n    }\\n    "
          }
        },
@@ -101,7 +101,7 @@ test("tmp theme diffs via unified patches", () => {
              }
            ],
            "styleOverrides": {}
-    @@ -83,12 +83,12 @@
+    @@ -80,12 +80,12 @@
        },
        "palette": {
          "mode": "dark",
@@ -135,7 +135,7 @@ test("tmp theme diffs via unified patches", () => {
              }
            ],
            "styleOverrides": {}
-    @@ -81,36 +81,20 @@
+    @@ -78,36 +78,20 @@
            "styleOverrides": "\\n    @font-face {\\n      font-family: 'Space Grotesk';\\n      font-style: normal;\\n      font-variant: normal;\\n      font-weight: 400;\\n      src: local('Space Grotesk'), url() format('woff2');\\n    }\\n\\n    @font-face {\\n      font-family: 'Space Grotesk';\\n      font-style: normal;\\n      font-variant: normal;\\n      font-weight: 500;\\n      src: local('Space Grotesk'), url() format('woff2');\\n    }\\n\\n    @font-face {\\n      font-family: 'Figtree';\\n      font-style: normal;\\n      font-variant: normal;\\n      font-weight: 400;\\n      src: local('Figtree'), url() format('woff2');\\n    }\\n\\n    @font-face {\\n      font-family: 'Figtree';\\n      font-style: normal;\\n      font-variant: normal;\\n      font-weight: 500;\\n      src: local('Figtree'), url() format('woff2');\\n    }\\n\\n    @font-face {\\n      font-family: 'Figtree';\\n      font-style: normal;\\n      font-variant: normal;\\n      font-weight: 700;\\n      src: local('Figtree'), url() format('woff2');\\n    }\\n    "
          }
        },
@@ -196,7 +196,7 @@ test("tmp theme diffs via unified patches", () => {
              }
            ],
            "styleOverrides": {}
-    @@ -83,12 +83,12 @@
+    @@ -80,12 +80,12 @@
        },
        "palette": {
          "mode": "dark",
@@ -230,7 +230,7 @@ test("tmp theme diffs via unified patches", () => {
              }
            ],
            "styleOverrides": {}
-    @@ -81,36 +81,20 @@
+    @@ -78,36 +78,20 @@
            "styleOverrides": "\\n    @font-face {\\n      font-family: 'Space Grotesk';\\n      font-style: normal;\\n      font-variant: normal;\\n      font-weight: 400;\\n      src: local('Space Grotesk'), url() format('woff2');\\n    }\\n\\n    @font-face {\\n      font-family: 'Space Grotesk';\\n      font-style: normal;\\n      font-variant: normal;\\n      font-weight: 500;\\n      src: local('Space Grotesk'), url() format('woff2');\\n    }\\n\\n    @font-face {\\n      font-family: 'Figtree';\\n      font-style: normal;\\n      font-variant: normal;\\n      font-weight: 400;\\n      src: local('Figtree'), url() format('woff2');\\n    }\\n\\n    @font-face {\\n      font-family: 'Figtree';\\n      font-style: normal;\\n      font-variant: normal;\\n      font-weight: 500;\\n      src: local('Figtree'), url() format('woff2');\\n    }\\n\\n    @font-face {\\n      font-family: 'Figtree';\\n      font-style: normal;\\n      font-variant: normal;\\n      font-weight: 700;\\n      src: local('Figtree'), url() format('woff2');\\n    }\\n    "
          }
        },
@@ -291,7 +291,7 @@ test("tmp theme diffs via unified patches", () => {
              }
            ],
            "styleOverrides": {}
-    @@ -83,12 +83,12 @@
+    @@ -80,12 +80,12 @@
        },
        "palette": {
          "mode": "dark",
@@ -325,7 +325,7 @@ test("tmp theme diffs via unified patches", () => {
              }
            ],
            "styleOverrides": {}
-    @@ -81,36 +81,20 @@
+    @@ -78,36 +78,20 @@
            "styleOverrides": "\\n    @font-face {\\n      font-family: 'Space Grotesk';\\n      font-style: normal;\\n      font-variant: normal;\\n      font-weight: 400;\\n      src: local('Space Grotesk'), url() format('woff2');\\n    }\\n\\n    @font-face {\\n      font-family: 'Space Grotesk';\\n      font-style: normal;\\n      font-variant: normal;\\n      font-weight: 500;\\n      src: local('Space Grotesk'), url() format('woff2');\\n    }\\n\\n    @font-face {\\n      font-family: 'Figtree';\\n      font-style: normal;\\n      font-variant: normal;\\n      font-weight: 400;\\n      src: local('Figtree'), url() format('woff2');\\n    }\\n\\n    @font-face {\\n      font-family: 'Figtree';\\n      font-style: normal;\\n      font-variant: normal;\\n      font-weight: 500;\\n      src: local('Figtree'), url() format('woff2');\\n    }\\n\\n    @font-face {\\n      font-family: 'Figtree';\\n      font-style: normal;\\n      font-variant: normal;\\n      font-weight: 700;\\n      src: local('Figtree'), url() format('woff2');\\n    }\\n    "
          }
        },
@@ -386,7 +386,7 @@ test("tmp theme diffs via unified patches", () => {
              }
            ],
            "styleOverrides": {}
-    @@ -83,11 +83,11 @@
+    @@ -80,11 +80,11 @@
        },
        "palette": {
          "mode": "dark",
@@ -418,7 +418,7 @@ test("tmp theme diffs via unified patches", () => {
              }
            ],
            "styleOverrides": {}
-    @@ -81,36 +81,20 @@
+    @@ -78,36 +78,20 @@
            "styleOverrides": "\\n    @font-face {\\n      font-family: 'Space Grotesk';\\n      font-style: normal;\\n      font-variant: normal;\\n      font-weight: 400;\\n      src: local('Space Grotesk'), url() format('woff2');\\n    }\\n\\n    @font-face {\\n      font-family: 'Space Grotesk';\\n      font-style: normal;\\n      font-variant: normal;\\n      font-weight: 500;\\n      src: local('Space Grotesk'), url() format('woff2');\\n    }\\n\\n    @font-face {\\n      font-family: 'Figtree';\\n      font-style: normal;\\n      font-variant: normal;\\n      font-weight: 400;\\n      src: local('Figtree'), url() format('woff2');\\n    }\\n\\n    @font-face {\\n      font-family: 'Figtree';\\n      font-style: normal;\\n      font-variant: normal;\\n      font-weight: 500;\\n      src: local('Figtree'), url() format('woff2');\\n    }\\n\\n    @font-face {\\n      font-family: 'Figtree';\\n      font-style: normal;\\n      font-variant: normal;\\n      font-weight: 700;\\n      src: local('Figtree'), url() format('woff2');\\n    }\\n    "
          }
        },

--- a/src/v1/theme/style-overrides/components.ts
+++ b/src/v1/theme/style-overrides/components.ts
@@ -49,17 +49,6 @@ const generateComponentOverrides = (uiTheme: UITheme) =>
       },
     },
 
-    MuiCheckbox: {
-      styleOverrides: {
-        root: ({ theme }) => ({
-          color: theme.palette.mode === "dark" ? "#D9D9D9" : "#1b1b1b", //This will make light blank theme work for the moment until we decide of a final palette.
-          "&.Mui-checked": {
-            color: theme.palette.primary.main,
-          },
-        }),
-      },
-    },
-
     MuiAppBar: {
       styleOverrides: {
         root: {


### PR DESCRIPTION
Ticket: https://telicent.atlassian.net/browse/TELFE-1227

### Goal

Add custom Checkbox component with DS theming and support for required

### Work Completed ✅

- Created a new Checkbox component wrapping MUI’s Checkbox
- Applied design system theming via global overrides (MuiCheckbox)
- Supports optional label and required props
Works in both controlled and uncontrolled modes

Styling moved to ComponentOverrides for consistency

Storybook stories for:
Default checkbox
Disabled state
With custom label
Required checkbox
Interactive example using useState

### Screenshot of the story 📸 

![Screenshot 2025-07-04 at 09 52 02](https://github.com/user-attachments/assets/88ad95d4-3907-428c-92d4-60da60d2745b)

https://www.figma.com/design/DTHPiGn1VDLvUpiuxSqC0h/MUI-for-Figma-Material-UI-v5.16.0?node-id=11012-143645&t=IEL3otEtqZSUCJIE-0

---

<details>
  <summary><strong>🕵️ Review Guidance</strong></summary>

---

General guidance

- Generally, approve a PR if it makes the system better, even if it's not perfect. — [Google: The Standard of Code Review](https://google.github.io/eng-practices/review/reviewer/standard.html)
- The aim of both PR AUTHOR and PR REVIEWER is to get the code merged
- Aim for consensus, defined as _everyone can live with the outcome_

For PR REVIEWER:

1. Read the ticket & description
2. [Review the code](https://google.github.io/eng-practices/review/reviewer/looking-for.html)
3. Request any changes that are essential.
4. For non-essential comments:
   - Use prefixes, e.g. "**nit:** change to Pascal case"
     - **nit:** small, non-essential change
     - **obs:** just an observation, doesn't affect the PR
     - **idea:** a suggestion to think about
     - **q:** questions
   - Use modifiers, e.g. "**obs**`[pr-owner-resolve]`: Jim is also editing this file"
     - `pr-author-resolve` PR author can resolve after reading
     - `pr-author-delete` (rare) delete after reading to avoid confusion
5. try to add _at least_ a helpful comment per ~500 lines; less if the PR is already busy

For PR AUTHOR:

1. Aim for enough detail in PR description for things to go smoothly
2. After requested changes, [re-request a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews#re-requesting-a-review) (so the PR shows up in [reviews-requested:@me](https://github.com/pulls?q=is%3Apr+is%3Aopen+archived%3Afalse+sort%3Aupdated-desc+review-requested%3A%40me+))

</details>
