### PR TITLE
fix(Drawer): [TELFE-647] allow children

### DIFF
--- a/src/component-library/InsetInMap/InsetInMap.tsx
+++ b/src/component-library/InsetInMap/InsetInMap.tsx
@@ -2,6 +2,9 @@ import React from "react";
 import {
   workspace,
 } from "./components/components";
+export {
+  workspace as insetInMap,
+} from "./components/components";
 import { BoxProps } from "@mui/material";
 
 const { Background, Content, ControlArea } = workspace;
@@ -24,8 +27,9 @@ type RootPropsType = Omit<BoxProps, 'children' | 'content'>;
 
 export const InsetInMap: React.FC<RootPropsType & {
   content: React.ReactNode;
+  children?: React.ReactNode;
   controlArea?: Partial<Record<Position, React.ReactNode>>;
-}> = ({ content, controlArea = {}, sx, ...rest }) => {
+}> = ({ content, controlArea = {}, sx, children, ...rest }) => {
   return (
     <Background sx={sx} {...rest}>
       <Content>{content}</Content>
@@ -34,6 +38,7 @@ export const InsetInMap: React.FC<RootPropsType & {
           {node}
         </ControlArea>
       ))}
+      {children}
     </Background>
   );
 };

--- a/src/export.ts
+++ b/src/export.ts
@@ -1,5 +1,5 @@
-import { IconButton, Button  } from "@mui/material";
-export const mui = { IconButton, Button }
+import { IconButton, Button, Box  } from "@mui/material";
+export const mui = { IconButton, Button, Box }
 
 import "./main.css";
 

--- a/src/v1/theme/ColorViewer.stories.tsx
+++ b/src/v1/theme/ColorViewer.stories.tsx
@@ -1,0 +1,60 @@
+// Colors.stories.tsx
+import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
+import { useTheme, Box, Typography } from '@mui/material';
+
+const ColorsDemo = () => {
+  const theme = useTheme();
+  const { palette } = theme;
+  const entries: { name: string; color: string }[] = [];
+
+  Object.entries(palette).forEach(([group, value]) => {
+    if (typeof value === 'string') {
+      entries.push({ name: group, color: value });
+    } else {
+      Object.entries(value).forEach(([variant, variantValue]) => {
+        if (typeof variantValue === 'string') {
+          entries.push({ name: `${group}.${variant}`, color: variantValue });
+        }
+      });
+    }
+  });
+
+  return (
+    <Box display="flex" flexWrap="wrap">
+      {entries.map(({ name, color }) => (
+        <Box
+          key={name}
+          width={120}
+          height={80}
+          m={1}
+          borderRadius={1}
+          overflow="hidden"
+          border={1}
+          borderColor="divider"
+        >
+          <Box bgcolor={color} height="60%" />
+          <Box p={0.5}>
+            <Typography variant="caption" noWrap>
+              {name}
+            </Typography>
+            <Typography variant="caption" noWrap>
+              {color}
+            </Typography>
+          </Box>
+        </Box>
+      ))}
+    </Box>
+  );
+};
+
+type Story = StoryObj<typeof ColorsDemo>;
+
+export default {
+  title: 'Theme/Colors',
+  component: ColorsDemo,
+} as Meta<typeof ColorsDemo>;
+
+export const AllColors: Story = {
+  render: () => <ColorsDemo />,
+};


### PR DESCRIPTION
Ticket: https://telicent.atlassian.net/browse/TELFE-647

### Goal

Allow:
```diff
diff --git a/src/pages/Search.tsx b/src/pages/Search.tsx
index d4bbeff..15d4e04 100644
--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -23,6 +23,7 @@ import {
   ButtonZoomIn,
   ButtonZoomOut,
   useMap,
+  insetInMap,
 } from "@telicent-oss/ds";
 import { TECH_DEBT_ErrorFallbackSX } from "../lib/TECH_DEBT_ErrorFallbackSX";
 import { useAppSettingsContext } from "../contexts/AppSettings";
@@ -95,6 +96,7 @@ const getResultMarkers = (results: Result[]): ResultMarker[] =>
 const Search: React.FC = () => {
   useTrackPageNavigation();
   const { showMap } = useAppSettingsContext();
+  const [showDrawer, setShowDrawer] = useState(true);
 
   const queryParams = useURLQueryParams();
   const { loading, error, data, offset } = useContext(StoreContext);
@@ -156,8 +158,18 @@ const Search: React.FC = () => {
                   </Paper>
                 </Box>
               ),
-              left: (
+            }}
+          >
+            {
+              <insetInMap.ControlArea
+                data-control-area-pointer-events
+                position="left"
+                sx={{
+                  pointerEvents: showDrawer ? undefined : "none",
+                }}
+              >
                 <DrawerWithResults
+                  onVisibilityChange={(open) => setShowDrawer(open)}
                   sx={{
                     ...styles.FULL_HEIGHT_MINUS_HEADER,
                   }}
@@ -167,15 +179,21 @@ const Search: React.FC = () => {
                   drawerWidth={577}
                 >
                   {({ scrollable }) => (
-                    <Box sx={{ p: 2, ...styles.FULL_HEIGHT_MINUS_HEADER }}>
+                    <Box
+                      data-results-wrapper
+                      sx={{
+                        p: 2,
+                        ...styles.FULL_HEIGHT_MINUS_HEADER,
+                      }}
+                    >
                       <AdvancedSearchBarComposite />
                       {renderSearchTemplate(scrollable)}
                     </Box>
                   )}
                 </DrawerWithResults>
-              ),
-            }}
-          />
+              </insetInMap.ControlArea>
+            }
+          </InsetInMap>
         </MapProvider>
       )}
     </Box>
````

### Work Completed

<!-- The Solution.  -->

### Design Testing

- Pre-release version: _e.g. v1.2.3-JIRA-123.0_ <!-- create a prerelease branch, build it, and push it with flux. By also including the version here u allow Dev testers to verify the right version is deployed  -->
- [ ] This PR is setup for easy assessment of "<strong>Design approval areas</strong>")  

<details>
  <summary><strong>Design approval areas</strong></summary>

  <hr />
  
  A _indicative_ list of suggested screenshots or videos.

  Action each: Mark "`[x]`" (click) for _complete_, or "`[-]`" for _not-applicable_.

  - [ ] UI content:
    - [ ] **Ideal** - show UI with "happy content" i.e. what Figma considers typical
    - [ ] **Empty** - show UI with empty (or minimum) content
    - [ ] **Full** - show UI with all (or technically maximum) content
  - [ ] UI States:
    - [ ] **Form validation** - show UI for validation errors, hints and success
    - [ ] **Network states** - show UI for fetch failures and success
    - [ ] **env-config errors** - show release-engineer UI for app config errors
  - [ ] Responsiveness:
    - [ ] **Min width** - show UI with minimum width supported by parent container, or [most common desktop](https://www.google.com/search?q=most+common+desktop+screen+resolution+now) split screen
    - [ ] **Min height** - show UI with minimum height supported by parent container, or [most common desktop](https://www.google.com/search?q=most+common+desktop+screen+resolution+now) half height
  - [ ] Accessibility: new issues introduced this PR (perhaps include report before, and report after)

</details>

### Testing Method

<!-- Describe your testing steps -->

### Code Review Tips <!-- OPTIONAL-->

<!-- Pointers for reviewer  -->

### Engineering Notes <!-- OPTIONAL-->

<!-- Implementation context  -->

### Out-of-scope <!-- OPTIONAL-->

<!-- Boundary setting -->

---

<details>
  <summary><strong>🕵️ Review Guidance</strong></summary>

---

General guidance

- Generally, approve a PR if it makes the system better, even if it's not perfect. — [Google: The Standard of Code Review](https://google.github.io/eng-practices/review/reviewer/standard.html)
- The aim of both PR AUTHOR and PR REVIEWER is to get the code merged
- Aim for consensus, defined as _everyone can live with the outcome_
- PR with changes requires 2 approvals
- PR with no changes requires 1 approvals

For PR REVIEWER:

1. Read the ticket & description
2. [Review the code](https://google.github.io/eng-practices/review/reviewer/looking-for.html)
3. Request any changes that are essential.
4. For non-essential comments:
   - Use prefixes, e.g. "**nit:** change to Pascal case"
     - **nit:** small, non-essential change
     - **obs:** just an observation, doesn't affect the PR
     - **idea:** a suggestion to think about
     - **q:** questions
   - Use modifiers, e.g. "**obs**`[pr-owner-resolve]`: Jim is also editing this file"
     - `pr-author-resolve` PR author can resolve after reading
     - `pr-author-delete` (rare) delete after reading to avoid confusion
5. try to add _at least_ a helpful comment per ~500 lines; less if the PR is already busy

For PR AUTHOR:

1. Aim for enough detail in PR description for things to go smoothly
2. After requested changes, [re-request a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews#re-requesting-a-review) (so the PR shows up in [reviews-requested:@me](https://github.com/pulls?q=is%3Apr+is%3Aopen+archived%3Afalse+sort%3Aupdated-desc+review-requested%3A%40me+))

</details>
