### PR TITLE
fix: text field and editable text field changes

### DIFF
--- a/src/v1/components/inputs/DatePicker/DatePicker.tsx
+++ b/src/v1/components/inputs/DatePicker/DatePicker.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { DatePickerProps as MuiDatePickerProps, DatePicker as MuiDatePicker } from "@mui/x-date-pickers/DatePicker";
-import { TextField, TextFieldProps } from "@mui/material";
+import { TextFieldProps } from "@mui/material";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import dayjs, { Dayjs } from "dayjs";

--- a/src/v1/components/inputs/EditableTextField/EditableTextField.stories.tsx
+++ b/src/v1/components/inputs/EditableTextField/EditableTextField.stories.tsx
@@ -105,3 +105,22 @@ export const WithErrorText: Story = {
     );
   },
 };
+
+export const NoInitialValue: Story = {
+  render: () => {
+    const [value, setValue] = useState<string>("");
+
+    const handleChange = (newValue: string) => {
+      setValue(newValue);
+    };
+
+    return (
+      <EditableTextField
+        value={value}
+        onSave={handleChange}
+        label="This is an empty field"
+        helperText="This is a helper text, that will show on the input field as long as there are no errorText"
+      />
+    );
+  },
+};

--- a/src/v1/components/inputs/EditableTextField/EditableTextField.tsx
+++ b/src/v1/components/inputs/EditableTextField/EditableTextField.tsx
@@ -53,9 +53,7 @@ const EditableTextField: React.FC<InputText> = ({ value, onSave, error, errorTex
         </FlexBox>
       ) : (
         <FlexBox direction="column">
-          <Text>
-            <b>{label}:</b>
-          </Text>
+          {label && <Text sx={{ fontWeight: "bold" }}>{label}:</Text>}
           <FlexBox direction="row" alignItems="center" gap={1}>
             <Typography>{value}</Typography>
             <IconButton onClick={handleEdit} size="small">

--- a/src/v1/components/inputs/EditableTextField/EditableTextField.tsx
+++ b/src/v1/components/inputs/EditableTextField/EditableTextField.tsx
@@ -6,16 +6,29 @@ import CheckIcon from "@mui/icons-material/Check";
 import ClearIcon from "@mui/icons-material/Clear";
 import { FlexBox } from "../../layout";
 import { Text } from "../../data-display";
+import { useExtendedTheme } from "../../../../export";
 
 export type InputText = TextFieldProps & {
   value: string;
   onSave: (value: string) => void;
   errorText?: string;
+  fullWidth?: boolean;
 };
 
-const EditableTextField: React.FC<InputText> = ({ value, onSave, error, errorText, helperText, label, ...props }) => {
+const EditableTextField: React.FC<InputText> = ({
+  value,
+  onSave,
+  error,
+  errorText,
+  helperText,
+  label,
+  fullWidth,
+  ...props
+}) => {
   const [isEditing, setIsEditing] = useState(false);
   const [tempValue, setTempValue] = useState(value || "");
+
+  const theme = useExtendedTheme();
 
   const handleEdit = () => {
     setIsEditing(true);
@@ -33,8 +46,8 @@ const EditableTextField: React.FC<InputText> = ({ value, onSave, error, errorTex
 
   return (
     <Box display="flex" alignItems="center" gap={1}>
-      {isEditing ? (
-        <FlexBox direction="row" alignItems="center" gap={1}>
+      {isEditing || value === "" ? (
+        <FlexBox direction="row" alignItems="baseline" gap={1}>
           <TextField
             autoFocus
             label={label}
@@ -45,10 +58,10 @@ const EditableTextField: React.FC<InputText> = ({ value, onSave, error, errorTex
             {...props}
           />
           <IconButton onClick={handleSave} size="small">
-            <CheckIcon sx={{ color: "green", lineHeight: "inherit" }} />
+            <CheckIcon sx={{ color: theme.palette.primary.main, lineHeight: "inherit" }} />
           </IconButton>
           <IconButton onClick={handleCancel} size="small">
-            <ClearIcon sx={{ color: "red", lineHeight: "inherit" }} />
+            <ClearIcon sx={{ color: theme.palette.primary.main, lineHeight: "inherit" }} />
           </IconButton>
         </FlexBox>
       ) : (

--- a/src/v1/components/inputs/EditableTextField/EditableTextField.tsx
+++ b/src/v1/components/inputs/EditableTextField/EditableTextField.tsx
@@ -5,6 +5,7 @@ import EditIcon from "@mui/icons-material/Edit";
 import CheckIcon from "@mui/icons-material/Check";
 import ClearIcon from "@mui/icons-material/Clear";
 import { FlexBox } from "../../layout";
+import { Text } from "../../data-display";
 
 export type InputText = TextFieldProps & {
   value: string;
@@ -12,7 +13,7 @@ export type InputText = TextFieldProps & {
   errorText?: string;
 };
 
-const EditableTextField: React.FC<InputText> = ({ value, onSave, error, errorText, helperText, ...props }) => {
+const EditableTextField: React.FC<InputText> = ({ value, onSave, error, errorText, helperText, label, ...props }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [tempValue, setTempValue] = useState(value || "");
 
@@ -36,6 +37,7 @@ const EditableTextField: React.FC<InputText> = ({ value, onSave, error, errorTex
         <FlexBox direction="row" alignItems="center" gap={1}>
           <TextField
             autoFocus
+            label={label}
             value={tempValue ?? ""}
             onChange={(e) => setTempValue(e.target.value)}
             error={error}
@@ -50,11 +52,16 @@ const EditableTextField: React.FC<InputText> = ({ value, onSave, error, errorTex
           </IconButton>
         </FlexBox>
       ) : (
-        <FlexBox direction="row" alignItems="center" gap={1}>
-          <Typography>{value}</Typography>
-          <IconButton onClick={handleEdit} size="small">
-            <EditIcon fontSize="inherit" />
-          </IconButton>
+        <FlexBox direction="column">
+          <Text>
+            <b>{label}:</b>
+          </Text>
+          <FlexBox direction="row" alignItems="center" gap={1}>
+            <Typography>{value}</Typography>
+            <IconButton onClick={handleEdit} size="small">
+              <EditIcon fontSize="inherit" />
+            </IconButton>
+          </FlexBox>
         </FlexBox>
       )}
     </Box>

--- a/src/v1/components/inputs/TextField/TextField.tsx
+++ b/src/v1/components/inputs/TextField/TextField.tsx
@@ -3,8 +3,8 @@ import { TextField as MuiTextField, TextFieldProps as MuiTextFieldProps } from "
 
 type TextFieldProps = MuiTextFieldProps & { errorText?: string };
 
-const TextField: React.FC<TextFieldProps> = ({ errorText, value, label, error, helperText, ...rest }) => {
-  return <MuiTextField value={value} error={error} helperText={error ? errorText : helperText} {...rest} />;
+const TextField: React.FC<TextFieldProps> = ({ errorText, error, helperText, ...rest }) => {
+  return <MuiTextField error={error} helperText={error ? errorText : helperText} {...rest} />;
 };
 
 export default TextField;

--- a/src/v1/components/inputs/TextField/TextField.tsx
+++ b/src/v1/components/inputs/TextField/TextField.tsx
@@ -3,7 +3,7 @@ import { TextField as MuiTextField, TextFieldProps as MuiTextFieldProps } from "
 
 type TextFieldProps = MuiTextFieldProps & { errorText?: string };
 
-const TextField: React.FC<TextFieldProps> = ({ errorText = "", value, label, error, helperText, ...rest }) => {
+const TextField: React.FC<TextFieldProps> = ({ errorText, value, label, error, helperText, ...rest }) => {
   return <MuiTextField value={value} error={error} helperText={error ? errorText : helperText} {...rest} />;
 };
 

--- a/src/v1/components/inputs/TextField/TextField.tsx
+++ b/src/v1/components/inputs/TextField/TextField.tsx
@@ -1,13 +1,10 @@
 import React from "react";
-import { TextField as MuiTextField, TextFieldProps } from "@mui/material";
+import { TextField as MuiTextField, TextFieldProps as MuiTextFieldProps } from "@mui/material";
 
-export type TextField = TextFieldProps & { errorText?: string };
+type TextFieldProps = MuiTextFieldProps & { errorText?: string };
 
-const TextField: React.FC<TextField> = ({ errorText = "", ...props }) => {
-  const { value, label, error, helperText } = props;
-  return (
-    <MuiTextField value={value} label={label} error={error} helperText={error ? errorText : helperText} {...props} />
-  );
+const TextField: React.FC<TextFieldProps> = ({ errorText = "", value, label, error, helperText, ...rest }) => {
+  return <MuiTextField value={value} error={error} helperText={error ? errorText : helperText} {...rest} />;
 };
 
 export default TextField;

--- a/src/v1/components/inputs/index.ts
+++ b/src/v1/components/inputs/index.ts
@@ -1,4 +1,4 @@
-// export { default as TextField } from "./TextField/TextField";
+export { default as TextField } from "./TextField/TextField";
 export { default as TooltipToggleButton } from "./TooltipToggleButton";
 
 export { default as Select } from "./Select/Select";

--- a/src/v1/components/inputs/index.ts
+++ b/src/v1/components/inputs/index.ts
@@ -1,5 +1,7 @@
-export { default as TextField } from "./TextField/TextField";
 export { default as TooltipToggleButton } from "./TooltipToggleButton";
+
+export { default as EditableTextField } from "./EditableTextField/EditableTextField";
+export { default as TextField } from "./TextField/TextField";
 
 export { default as Select } from "./Select/Select";
 export type { SelectProps } from "./Select/Select";

--- a/src/v1/theme/colors/palette/createDarkPalette.ts
+++ b/src/v1/theme/colors/palette/createDarkPalette.ts
@@ -23,9 +23,7 @@ const createDarkPalette = (uiTheme: UITheme): ThemeOptions["palette"] =>
       default: "#1D1D1D",
       paper: "#252525",
     },
-    grey: {
-      ...grey,
-    },
+    grey,
   });
 
 export default createDarkPalette;

--- a/src/v1/theme/colors/palette/createDarkPalette.ts
+++ b/src/v1/theme/colors/palette/createDarkPalette.ts
@@ -1,28 +1,31 @@
 import { ThemeOptions } from "@mui/material";
 import { grey } from "@mui/material/colors";
 import THEME_COLORS, { UITheme } from "../theme-colors";
+import merge from "lodash.merge";
+import createLightPalette from "./createLightPalette";
 
-const createDarkPalette = (uiTheme: UITheme): ThemeOptions["palette"] => ({
-  mode: "dark",
-  primary: THEME_COLORS[uiTheme].primary,
-  secondary: {
-    main: "#8a8a8a",
-    light: "#A1A1A1",
-    dark: "#606060",
-    contrastText: "#FFFFFF",
-  },
-  text: {
-    primary: "#ececec",
-    secondary: "rgba(255, 255, 255, 0.7)",
-    disabled: "#999999",
-  },
-  background: {
-    default: "#1D1D1D",
-    paper: "#252525",
-  },
-  grey: {
-    ...grey,
-  },
-});
+const createDarkPalette = (uiTheme: UITheme): ThemeOptions["palette"] =>
+  merge(createLightPalette(uiTheme), {
+    mode: "dark",
+    primary: THEME_COLORS[uiTheme].primary,
+    secondary: {
+      main: "#8a8a8a",
+      light: "#A1A1A1",
+      dark: "#606060",
+      contrastText: "#FFFFFF",
+    },
+    text: {
+      primary: "#ececec",
+      secondary: "rgba(255, 255, 255, 0.7)",
+      disabled: "#999999",
+    },
+    background: {
+      default: "#1D1D1D",
+      paper: "#252525",
+    },
+    grey: {
+      ...grey,
+    },
+  });
 
 export default createDarkPalette;


### PR DESCRIPTION
Small changes for both components. 

Changing the edit icons to the primary colour. 
Add helper text to editable input field 
Make editable input default to text field if value is an empty string. 
add label back to input text

---

<details>
  <summary><strong>🕵️ Review Guidance</strong></summary>

---

General guidance

- Generally, approve a PR if it makes the system better, even if it's not perfect. — [Google: The Standard of Code Review](https://google.github.io/eng-practices/review/reviewer/standard.html)
- The aim of both PR AUTHOR and PR REVIEWER is to get the code merged
- Aim for consensus, defined as _everyone can live with the outcome_
- PR with changes requires 2 approvals
- PR with no changes requires 1 approvals

For PR REVIEWER:

1. Read the ticket & description
2. [Review the code](https://google.github.io/eng-practices/review/reviewer/looking-for.html)
3. Request any changes that are essential.
4. For non-essential comments:
   - Use prefixes, e.g. "**nit:** change to Pascal case"
     - **nit:** small, non-essential change
     - **obs:** just an observation, doesn't affect the PR
     - **idea:** a suggestion to think about
     - **q:** questions
   - Use modifiers, e.g. "**obs**`[pr-owner-resolve]`: Jim is also editing this file"
     - `pr-author-resolve` PR author can resolve after reading
     - `pr-author-delete` (rare) delete after reading to avoid confusion
5. try to add _at least_ a helpful comment per ~500 lines; less if the PR is already busy

For PR AUTHOR:

1. Aim for enough detail in PR description for things to go smoothly
2. After requested changes, [re-request a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews#re-requesting-a-review) (so the PR shows up in [reviews-requested:@me](https://github.com/pulls?q=is%3Apr+is%3Aopen+archived%3Afalse+sort%3Aupdated-desc+review-requested%3A%40me+))

</details>
