### PR TITLE
fix: update tree view styles and accept sx

### DIFF
--- a/src/v1/components/data-display/TreeView/TreeView.tsx
+++ b/src/v1/components/data-display/TreeView/TreeView.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useTheme } from "@mui/material";
+import { SxProps, useTheme } from "@mui/material";
 import { RichTreeView, TreeViewBaseItem } from "@mui/x-tree-view";
 
 type TreeViewProps<Item extends object = TreeViewBaseItem> = { items: Item[] } & Partial<{
@@ -95,9 +95,10 @@ type TreeViewProps<Item extends object = TreeViewBaseItem> = { items: Item[] } &
    * array of strings; when false (default) a string.
    */
   selectedItems: string | string[];
+  sx: SxProps;
 }>;
 
-const TreeView: React.FC<TreeViewProps> = ({ alwaysExpandedIds = [], ...treeViewProps }) => {
+const TreeView: React.FC<TreeViewProps> = ({ alwaysExpandedIds = [], sx, ...treeViewProps }) => {
   const theme = useTheme();
   const [expandedItems, setExpandedItems] = useState(alwaysExpandedIds);
 
@@ -115,6 +116,7 @@ const TreeView: React.FC<TreeViewProps> = ({ alwaysExpandedIds = [], ...treeView
       {...treeViewProps}
       sx={{
         ".MuiTreeItem-content": {
+          marginY: "2px",
           ":hover": {
             ...highlightingStyle,
           },
@@ -131,6 +133,11 @@ const TreeView: React.FC<TreeViewProps> = ({ alwaysExpandedIds = [], ...treeView
             },
           },
         },
+
+        "& .MuiRichTreeView-itemContent": {
+          marginY: "40px",
+        },
+        ...sx,
       }}
     />
   );


### PR DESCRIPTION
Ticket: https://telicent.atlassian.net/browse/TELFE-1304

### Work Completed

Updated TreeView component to adding some padding and to accept sx as props. 

---

<details>
  <summary><strong>🕵️ Review Guidance</strong></summary>

---

General guidance

- Generally, approve a PR if it makes the system better, even if it's not perfect. — [Google: The Standard of Code Review](https://google.github.io/eng-practices/review/reviewer/standard.html)
- The aim of both PR AUTHOR and PR REVIEWER is to get the code merged
- Aim for consensus, defined as _everyone can live with the outcome_
- PR with changes requires 2 approvals
- PR with no changes requires 1 approvals

For PR REVIEWER:

1. Read the ticket & description
2. [Review the code](https://google.github.io/eng-practices/review/reviewer/looking-for.html)
3. Request any changes that are essential.
4. For non-essential comments:
   - Use prefixes, e.g. "**nit:** change to Pascal case"
     - **nit:** small, non-essential change
     - **obs:** just an observation, doesn't affect the PR
     - **idea:** a suggestion to think about
     - **q:** questions
   - Use modifiers, e.g. "**obs**`[pr-owner-resolve]`: Jim is also editing this file"
     - `pr-author-resolve` PR author can resolve after reading
     - `pr-author-delete` (rare) delete after reading to avoid confusion
5. try to add _at least_ a helpful comment per ~500 lines; less if the PR is already busy

For PR AUTHOR:

1. Aim for enough detail in PR description for things to go smoothly
2. After requested changes, [re-request a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews#re-requesting-a-review) (so the PR shows up in [reviews-requested:@me](https://github.com/pulls?q=is%3Apr+is%3Aopen+archived%3Afalse+sort%3Aupdated-desc+review-requested%3A%40me+))

</details>
