### PR TITLE
fix(map): [TELFE-1316] dark map attribution style

### DIFF
--- a/src/component-library/Map/primitives/MapCanvas/MapCanvas.tsx
+++ b/src/component-library/Map/primitives/MapCanvas/MapCanvas.tsx
@@ -72,13 +72,20 @@ export const MapCanvas: React.FC<MapCanvasProps> = ({
     <>
       <GlobalStyles
         styles={{
-          "#TelicentMap .maplibregl-ctrl-attrib": {
+        [`#TelicentMap .maplibregl-ctrl-attrib, 
+          #TelicentMap .maplibregl-ctrl-attrib a
+          `]: {
             backgroundColor:
               theme.palette.mode === "dark"
                 ? theme.palette.background.default
                 : theme.palette.background.paper,
             color: theme.palette.text.primary,
           },
+          // Uses a background-image of a black info icon.
+          [`#TelicentMap .maplibregl-ctrl-attrib-button`]:{
+            backgroundColor: 'transparent',
+            ...(theme.palette.mode === "dark" ? {filter: 'invert(100%)'} : {filter: 'invert(10%)'})
+          }
         }}
       />
       <Map


### PR DESCRIPTION
Ticket: https://telicent.atlassian.net/browse/TELFE-1316

### Goal

Fix attribution text style

### Work Completed

#### before
<img width="361" height="126" alt="Screenshot 2025-09-12 at 14 50 53" src="https://github.com/user-attachments/assets/de52f923-087a-422d-8e6e-d98be749158a" />

#### after
<img width="281" height="71" alt="Screenshot 2025-09-12 at 14 32 03" src="https://github.com/user-attachments/assets/e4b21359-d095-430e-bcce-880e33d4a70a" />

### Testing

This version of DS is a bit old, and the themes are a bit broken so I didn't actually test with a light theme. I will re-check when this (and everything upstream) is merged.