### PR TITLE
fix(authorize-flow): stop replaying auth success events

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/telicent-oss/telicent-ds.git"
   },
   "type": "module",
-  "version": "1.5.14-1",
+  "version": "1.5.14",
   "private": false,
   "dependencies": {
     "@emotion/react": "^11.10.6",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/telicent-oss/telicent-ds.git"
   },
   "type": "module",
-  "version": "1.5.13",
+  "version": "1.5.14-1",
   "private": false,
   "dependencies": {
     "@emotion/react": "^11.10.6",

--- a/src/candidate-packages/authorize-flow/context/AuthProvider.tsx
+++ b/src/candidate-packages/authorize-flow/context/AuthProvider.tsx
@@ -6,6 +6,7 @@ import { registerAuthSync } from "../utils";
 import { QueryClient } from "@tanstack/react-query";
 import { createApi } from "../index";
 import { AuthEvent, broadcastAuthEvent } from "../exports";
+import { useRef } from "react";
 
 interface AuthProviderProps {
   apiUrl: string;
@@ -61,6 +62,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ apiUrl, config, quer
   const [user, setUser] = useState<UserInfo | null>(null);
   const [error, setError] = useState<Error | null>(null);
   const [loading, setLoading] = useState(false);
+  const loginTriggered = useRef(false);
 
   const [client] = useState(() => new AuthServerOAuth2Client(config));
 
@@ -71,7 +73,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ apiUrl, config, quer
     const cleanupCheck = runAsync(async () => {
       if (location.pathname.includes("/callback")) return;
       const authenticated = await client.isAuthenticated();
-      if (!authenticated) {
+      if (!authenticated && !loginTriggered.current) {
+        loginTriggered.current = true;
         // Prevent infinite retry loop
         client.login();
       }

--- a/src/candidate-packages/authorize-flow/pages/Callback.tsx
+++ b/src/candidate-packages/authorize-flow/pages/Callback.tsx
@@ -1,11 +1,15 @@
-import { FC, useEffect } from "react";
+import { FC, useEffect, useRef } from "react";
 import { FlexBox, Text } from "../../../export";
 
 interface CallbackProps {
   clientId: string;
 }
 export const Callback: FC<CallbackProps> = ({ clientId }) => {
+  const fired = useRef(false);
+
   useEffect(() => {
+    if (fired.current) return;
+    fired.current = true;
     setTimeout(() => {
       const event = new CustomEvent("oauth-callback", {
         detail: {

--- a/src/candidate-packages/authorize-flow/services/broadcastChannelService.ts
+++ b/src/candidate-packages/authorize-flow/services/broadcastChannelService.ts
@@ -18,8 +18,12 @@ bc.onmessage = (event: MessageEvent) => {
 export function onAuthEvent(callback: (event: AuthEvent) => void): () => void {
   listeners.add(callback);
 
-  // Immediately fire last known message (StrictMode-safe)
-  if (lastMessage !== null) {
+  // Only replay UNAUTHORIZED on subscription. Replaying AUTH* created the refetch ouroboros:
+  // - AUTH* broadcast sets lastMessage
+  // - New subscriber replays AUTH* immediately
+  // - registerAuthSync (utils) refetchQueries globally
+  // - Next subscriber/broadcast repeats the refetch
+  if (lastMessage === AuthEvent.UNAUTHORIZED) {
     callback(lastMessage);
   }
 

--- a/src/candidate-packages/authorize-flow/utils/index.ts
+++ b/src/candidate-packages/authorize-flow/utils/index.ts
@@ -9,7 +9,7 @@ export const registerAuthSync = (
     switch (event) {
       case AuthEvent.AUTHENTICATED:
       case AuthEvent.REAUTHENTICATED:
-        queryClient.refetchQueries({ stale: true });
+        queryClient.invalidateQueries({ stale: true });
         break;
       case AuthEvent.USER_CHANGED:
         window.location.replace(baseUrl);

--- a/src/v1/components/data-display/Chip/Chip.stories.tsx
+++ b/src/v1/components/data-display/Chip/Chip.stories.tsx
@@ -26,6 +26,9 @@ const meta = {
         },
       },
     },
+    variant: {
+      type: "string"
+    },
     label: {
       description: "The content of the component.",
     },


### PR DESCRIPTION
Ticket: https://telicent.atlassian.net/browse/TELFE-1428

### Goal

1. Reduce chattiness of broadcast
2. Reduce fetching - by changing (immediately) refetches of everything to invalidate cache for scheduled refeches

### Testing Method

I just re-logged in and did some operations
