### PR TITLE
fix: preload icons

### DIFF
--- a/src/candidate-packages/utils-lib/src/index.ts
+++ b/src/candidate-packages/utils-lib/src/index.ts
@@ -1,24 +1,23 @@
 // entry file
 export {
-  getCodec,
-  type Codec,
-  base64Codec,
-  uriComponentCodec,
+    getCodec,
+    type Codec,
+    base64Codec,
+    uriComponentCodec,
 } from "./getCodec/getCodec";
 export {
-  ENCODE_SEARCH_PARAMS_MODES_Schema,
-  type ENCODE_SEARCH_PARAMS_MODES_Type,
+    ENCODE_SEARCH_PARAMS_MODES_Schema,
+    type ENCODE_SEARCH_PARAMS_MODES_Type,
 } from "./getCodec/schemaAndTypes";
 export {
-  toStringEncoded,
-  type URLSearchParamsInit,
+    toStringEncoded,
+    type URLSearchParamsInit,
 } from "./getCodec/toStringEncoded";
 export {
-  type LoggerLevelString,
-  type LoggerLevel,
-  loggerLevelOrder,
-  Logger
+    type LoggerLevelString,
+    type LoggerLevel,
+    loggerLevelOrder,
+    Logger,
 } from "./Logger/Logger";
-
 
 export { GRAPH_APP } from "./GraphApp/constants";

--- a/src/component-library/Map/v2/composites/BasicMap/BasicMap.tsx
+++ b/src/component-library/Map/v2/composites/BasicMap/BasicMap.tsx
@@ -1,6 +1,12 @@
-import { MapCanvasV2 } from "../../primitives/MapCanvas/MapCanvas"
+import { MapCanvasV2 } from "../../primitives/MapCanvas/MapCanvas";
 import { LayerSelectorV2 } from "../../primitives/LayerSelector/LayerSelector";
-import React, { useRef, useMemo, useEffect, useState, useImperativeHandle } from "react";
+import React, {
+  useRef,
+  useMemo,
+  useEffect,
+  useState,
+  useImperativeHandle,
+} from "react";
 
 import { Map } from "ol";
 import BaseLayer from "ol/layer/Base";
@@ -10,178 +16,205 @@ import { markerToOLFeature } from "../../utils/markers";
 import { ensureLayers } from "../../utils/ensureLayers";
 import { MARKER_LAYER_ID, POLYGON_LAYER_ID } from "../../utils/layers";
 import { findVectorLayerById } from "../../utils/feature";
-import { getFeaturesById, fitToFeature, fitToFeatures } from "./interactions/addPanToFeature";
+import {
+  getFeaturesById,
+  fitToFeature,
+  fitToFeatures,
+} from "./interactions/addPanToFeature";
 import { polygonToOLFeature } from "../../utils/polygons";
 import { mapLegacyConfigToLayers } from "../../utils/legacy";
+import { ensureMarkerIconsLoaded } from "../../utils/markerIconLoader";
 
+export const BasicMapV2 = React.forwardRef<
+  BasicMapV2Handle,
+  BasicMapProperties
+>((props, ref) => {
+  const [layers, setLayers] = useState<BaseLayer[]>([]);
+  const mapInstance = useRef<Map | null>(null);
 
-export const BasicMapV2 = React.forwardRef<BasicMapV2Handle, BasicMapProperties>((props, ref) => {
-	const [layers, setLayers] = useState<BaseLayer[]>([]);
-	const mapInstance = useRef<Map | null>(null);
+  const showLayerSelector = props.controls?.showLayerSelector ?? true;
 
-	const showLayerSelector =
-		props.controls?.showLayerSelector ?? true;
+  const effectiveLayers = useMemo(() => {
+    const baseLayers =
+      Array.isArray(props.layers) && props.layers.length > 0
+        ? props.layers
+        : props.mapStyleOptions && Object.keys(props.mapStyleOptions).length > 0
+        ? mapLegacyConfigToLayers(props.mapStyleOptions)
+        : [];
 
-	const effectiveLayers = useMemo(() => {
-		const baseLayers =
-			Array.isArray(props.layers) && props.layers.length > 0
-				? props.layers
-				: props.mapStyleOptions && Object.keys(props.mapStyleOptions).length > 0
-					? mapLegacyConfigToLayers(props.mapStyleOptions)
-					: [];
+    const overlayVectorLayers: LayerConfig[] = [
+      // Marker layer
+      {
+        kind: "overlay-vector",
+        id: MARKER_LAYER_ID,
+        data: [],
+        visible: true,
+      },
+      // Polygon layer
+      {
+        kind: "overlay-vector",
+        id: POLYGON_LAYER_ID,
+        data: [],
+        visible: true,
+      },
+    ];
+    return [...baseLayers, ...overlayVectorLayers];
+  }, [props.layers]);
 
-		const overlayVectorLayers: LayerConfig[] = [
-			// Marker layer
-			{
-				kind: "overlay-vector",
-				id: MARKER_LAYER_ID,
-				data: [],
-				visible: true
-			},
-			// Polygon layer
-			{
-				kind: "overlay-vector",
-				id: POLYGON_LAYER_ID,
-				data: [],
-				visible: true,
-			},
-		];
-		return [...baseLayers, ...overlayVectorLayers];
-	}, [props.layers]);
+  useEffect(() => {
+    let cancelled = false;
 
+    (async () => {
+      try {
+        const layers = await ensureLayers(effectiveLayers);
+        if (!cancelled) {
+          setLayers(layers);
+        }
+      } catch (e) {
+        console.error("ensureLayers failed", e);
+        return;
+      }
+    })();
 
-	useEffect(() => {
-		let cancelled = false;
+    return () => {
+      cancelled = true;
+    };
+  }, [effectiveLayers]);
 
-		(async () => {
-			try {
-				const layers = await ensureLayers(effectiveLayers);
-				if (!cancelled) {
-					setLayers(layers)
-				}
-			} catch (e) {
-				console.error("ensureLayers failed", e);
-				return
-			}
-		})();
+  useEffect(() => {
+    if (layers.length < 1) return;
+    props?.onLayersReady?.(true);
+  }, [layers]);
 
-		return () => {
-			cancelled = true;
-		};
-	}, [effectiveLayers]);
+  useEffect(() => {
+    return () => {
+      props.onLayersReady?.(false);
+    };
+  }, []);
 
-	useEffect(() => {
-		if (layers.length < 1) return;
-		props?.onLayersReady?.(true);
-	}, [layers])
+  useEffect(() => {
+    if (!mapInstance.current) return;
+    const markerLayer = findVectorLayerById(layers, MARKER_LAYER_ID);
+    if (!markerLayer) {
+      console.debug("No marker layer found");
+      return;
+    }
 
-	useEffect(() => {
-		return () => {
-			props.onLayersReady?.(false);
-		};
-	}, [])
+    const source = markerLayer.getSource();
+    if (!source) {
+      console.debug("Could not find layer source");
+      return;
+    }
 
-	useEffect(() => {
-		if (!mapInstance.current) return;
-		const markerLayer = findVectorLayerById(layers, MARKER_LAYER_ID);
-		if (!markerLayer) {
-			console.debug("No marker layer found");
-			return;
-		}
+    /* source.clear(); */
+    /* const markerFeatures = props.markers.map(markerToOLFeature); */
+    /* source.addFeatures(markerFeatures); */
+    let cancelled = false;
 
-		const source = markerLayer.getSource();
-		if (!source) {
-			console.debug("Could not find layer source");
-			return;
-		}
+    (async () => {
+      await ensureMarkerIconsLoaded(props.markers);
 
-		source.clear();
-		const markerFeatures = props.markers.map(markerToOLFeature);
-		source.addFeatures(markerFeatures);
+      if (cancelled) return;
 
-		const polygonFeatures = props.polygons.map(polygonToOLFeature);
-		source.addFeatures(polygonFeatures);
+      source.clear();
 
-		const features = [...markerFeatures, ...polygonFeatures]
+      const markerFeatures = props.markers.map(markerToOLFeature);
+      source.addFeatures(markerFeatures);
 
-		if (features.length === 1) {
-			fitToFeature(mapInstance.current, features[0])
-		} else {
-			fitToFeatures(mapInstance.current, features)
-		}
-	}, [props.markers, props.polygons, layers])
+      const polygonFeatures = props.polygons.map(polygonToOLFeature);
+      source.addFeatures(polygonFeatures);
 
-	useEffect(() => {
-		const map = mapInstance.current;
-		if (!map) return;
+      const features = [...markerFeatures, ...polygonFeatures];
 
-		const markerLayer = findVectorLayerById(layers, MARKER_LAYER_ID);
-		const polygonLayer = findVectorLayerById(layers, POLYGON_LAYER_ID);
+      if (features.length === 1) {
+        fitToFeature(mapInstance.current!, features[0]);
+      } else {
+        fitToFeatures(mapInstance.current!, features);
+      }
+    })();
 
-		const markerFeatures =
-			markerLayer?.getSource()?.getFeatures() ?? [];
-		const polygonFeatures =
-			polygonLayer?.getSource()?.getFeatures() ?? [];
+    return () => {
+      cancelled = true;
+    };
+  }, [props.markers, props.polygons, layers]);
 
-		const features = [...markerFeatures, ...polygonFeatures];
-		if (!features.length) return;
+  useEffect(() => {
+    const map = mapInstance.current;
+    if (!map) return;
 
-		if (features.length === 1) {
-			fitToFeature(map, features[0]);
-		} else {
-			fitToFeatures(map, features);
-		}
-	}, [props.markers, props.polygons, layers]);
+    const markerLayer = findVectorLayerById(layers, MARKER_LAYER_ID);
+    const polygonLayer = findVectorLayerById(layers, POLYGON_LAYER_ID);
 
-	useImperativeHandle(ref, () => ({
-		zoomIn: () => {
-			const view = mapInstance.current?.getView();
-			if (!view) {
-				console.warn("Map view is not ready yet");
-				return;
-			}
+    const markerFeatures = markerLayer?.getSource()?.getFeatures() ?? [];
+    const polygonFeatures = polygonLayer?.getSource()?.getFeatures() ?? [];
 
-			const currentZoom = view.getZoom() ?? 0;
-			view.setZoom(currentZoom + 1);
-		},
-		zoomOut: () => {
-			const view = mapInstance.current?.getView();
-			if (!view) {
-				console.warn("Map view is not ready yet");
-				return;
-			}
+    const features = [...markerFeatures, ...polygonFeatures];
+    if (!features.length) return;
 
-			const currentZoom = view.getZoom() ?? 0;
-			view.setZoom(currentZoom - 1);
-		},
-		panToFeature: (id: string) => {
-			if (!mapInstance.current) {
-				console.warn("Map is not ready yet");
-				return;
-			}
+    if (features.length === 1) {
+      fitToFeature(map, features[0]);
+    } else {
+      fitToFeatures(map, features);
+    }
+  }, [props.markers, props.polygons, layers]);
 
-			const features = getFeaturesById(layers, [id])
-			if (features.length === 0) return;
-			fitToFeature(mapInstance.current, features[0]);
-		},
-		panToFeatures: (ids: string[]) => {
-			if (!mapInstance.current) {
-				console.warn("Map is not ready yet");
-				return;
-			}
+  useImperativeHandle(
+    ref,
+    () => ({
+      zoomIn: () => {
+        const view = mapInstance.current?.getView();
+        if (!view) {
+          console.warn("Map view is not ready yet");
+          return;
+        }
 
-			const features = getFeaturesById(layers, ids)
-			if (features.length === 0) return;
-			fitToFeature(mapInstance.current, features[0]);
-		},
-		layers
-	}), [mapInstance.current, layers])
+        const currentZoom = view.getZoom() ?? 0;
+        view.setZoom(currentZoom + 1);
+      },
+      zoomOut: () => {
+        const view = mapInstance.current?.getView();
+        if (!view) {
+          console.warn("Map view is not ready yet");
+          return;
+        }
 
-	const { layers: _ignored, ...restProps } = props;
-	return <>
-		<MapCanvasV2 layers={layers} mapInstanceRef={mapInstance} {...restProps} />
-		{showLayerSelector &&
-			<LayerSelectorV2 layers={layers} />
-		}
-	</>
-})
+        const currentZoom = view.getZoom() ?? 0;
+        view.setZoom(currentZoom - 1);
+      },
+      panToFeature: (id: string) => {
+        if (!mapInstance.current) {
+          console.warn("Map is not ready yet");
+          return;
+        }
+
+        const features = getFeaturesById(layers, [id]);
+        if (features.length === 0) return;
+        fitToFeature(mapInstance.current, features[0]);
+      },
+      panToFeatures: (ids: string[]) => {
+        if (!mapInstance.current) {
+          console.warn("Map is not ready yet");
+          return;
+        }
+
+        const features = getFeaturesById(layers, ids);
+        if (features.length === 0) return;
+        fitToFeature(mapInstance.current, features[0]);
+      },
+      layers,
+    }),
+    [mapInstance.current, layers]
+  );
+
+  const { layers: _ignored, ...restProps } = props;
+  return (
+    <>
+      <MapCanvasV2
+        layers={layers}
+        mapInstanceRef={mapInstance}
+        {...restProps}
+      />
+      {showLayerSelector && <LayerSelectorV2 layers={layers} />}
+    </>
+  );
+});

--- a/src/component-library/Map/v2/styles/__tests__/markers.test.ts
+++ b/src/component-library/Map/v2/styles/__tests__/markers.test.ts
@@ -5,223 +5,248 @@ jest.mock("ol/style");
 jest.mock("ol/Feature");
 jest.mock("ol/geom/Point");
 jest.mock("../../utils/faIconResolver", () => ({
-  resolveFaIconPath: jest.fn(),
-  ensureFaIconPath: jest.fn(() => Promise.resolve(undefined)),
+    resolveFaIconPath: jest.fn(),
+    ensureFaIconPath: jest.fn(() => Promise.resolve(undefined)),
 }));
 
 import {
-  getGeneratedOlIcon,
-  getPathBBox,
-  extractPathD,
-  makeCircleSvg,
+    getGeneratedOlIcon,
+    getPathBBox,
+    extractPathD,
+    makeCircleSvg,
 } from "../markers";
 import {
-  ensureFaIconPath,
-  resolveFaIconPath,
+    ensureFaIconPath,
+    resolveFaIconPath,
 } from "../../utils/faIconResolver";
 const decodeSvg = (src: string) => decodeURIComponent(src.split(",")[1]);
 
 describe("marker icon generation (with __mocks__)", () => {
-  const SIMPLE_PATH = "M10 10 H 20 V 20 H 10 Z";
+    const SIMPLE_PATH = "M10 10 H 20 V 20 H 10 Z";
 
-  describe("fallback text marker", () => {
-    it("uses fallback SVG when innerSvg is missing", () => {
-      const style = getGeneratedOlIcon({
-        fallbackText: "A",
-        backgroundColor: "#123456",
-        color: "#ffffff",
-      }) as any;
+    describe("fallback text marker", () => {
+        it("uses fallback SVG when innerSvg is missing", () => {
+            const style = getGeneratedOlIcon({
+                fallbackText: "A",
+                backgroundColor: "#123456",
+                color: "#ffffff",
+            }) as any;
 
-      expect(style).toHaveProperty("props");
-      expect(style.props).toHaveProperty("image");
-      expect(style.props.image).toHaveProperty("props");
+            expect(style).toHaveProperty("props");
+            expect(style.props).toHaveProperty("image");
+            expect(style.props.image).toHaveProperty("props");
 
-      const decoded = decodeSvg(style.props.image.props.src);
-      expect(decoded).toContain("<svg");
-      expect(decoded).toContain(">A<");
-      expect(decoded).toContain('font-size="8"');
-    });
-  });
-
-  describe("markerType safety", () => {
-    it("defaults to pin when markerType is undefined", () => {
-      const style = getGeneratedOlIcon({}) as any;
-
-      expect(style.props.image.props.scale).toBe(1.5);
+            const decoded = decodeSvg(style.props.image.props.src);
+            expect(decoded).toContain("<svg");
+            expect(decoded).toContain(">A<");
+            expect(decoded).toContain('font-size="8"');
+        });
     });
 
-    it("falls back safely when markerType is invalid", () => {
-      const style = getGeneratedOlIcon({
-        markerType: "triangle" as any,
-      }) as any;
+    describe("markerType safety", () => {
+        it("defaults to pin when markerType is undefined", () => {
+            const style = getGeneratedOlIcon({}) as any;
 
-      expect(style.props.image.props.scale).toBe(1.5);
+            expect(style.props.image.props.scale).toBe(1.5);
+        });
+
+        it("falls back safely when markerType is invalid", () => {
+            const style = getGeneratedOlIcon({
+                markerType: "triangle" as any,
+            }) as any;
+
+            expect(style.props.image.props.scale).toBe(1.5);
+        });
     });
-  });
 
-  describe("marker scaling rules", () => {
-    it("scales pin markers to 1.5", () => {
-      const style = getGeneratedOlIcon({
-        markerType: "pin",
-      }) as any;
+    describe("marker scaling rules", () => {
+        it("scales pin markers to 1.5", () => {
+            const style = getGeneratedOlIcon({
+                markerType: "pin",
+            }) as any;
 
-      expect(style.props.image.props.scale).toBe(1.5);
+            expect(style.props.image.props.scale).toBe(1.5);
+        });
     });
-  });
 
-  describe("innerSvg handling", () => {
-    it("does not double-wrap resolved icon path with <g> elements", () => {
-      (resolveFaIconPath as jest.Mock).mockReturnValue({
-        status: "ready",
-        path: SIMPLE_PATH,
-      });
+    describe("innerSvg handling", () => {
+        it("does not double-wrap resolved icon path with <g> elements", () => {
+            (resolveFaIconPath as jest.Mock).mockReturnValue({
+                status: "ready",
+                path: SIMPLE_PATH,
+            });
 
-      const style = getGeneratedOlIcon({
-        markerType: "pin",
-        faIcon: "fa-solid fa-test",
-      }) as any;
+            const style = getGeneratedOlIcon({
+                markerType: "pin",
+                faIcon: "fa-solid fa-test",
+            }) as any;
 
-      const decoded = decodeSvg(style.props.image.props.src);
+            const decoded = decodeSvg(style.props.image.props.src);
 
-      const scaledGroups = decoded.match(/<g[^>]*scale\(/g) || [];
+            const scaledGroups = decoded.match(/<g[^>]*scale\(/g) || [];
 
-      expect(scaledGroups.length).toBe(1);
+            expect(scaledGroups.length).toBe(1);
+        });
     });
-  });
 
-  describe("icon caching", () => {
-    it("returns identical src for identical styles", () => {
-      const styleA = getGeneratedOlIcon({
-        markerType: "circle",
-      }) as any;
+    describe("icon caching", () => {
+        it("returns identical src for identical styles", () => {
+            const styleA = getGeneratedOlIcon({
+                markerType: "circle",
+            }) as any;
 
-      const styleB = getGeneratedOlIcon({
-        markerType: "circle",
-      }) as any;
+            const styleB = getGeneratedOlIcon({
+                markerType: "circle",
+            }) as any;
 
-      expect(styleA.props.image.props.src).toBe(styleB.props.image.props.src);
+            expect(styleA.props.image.props.src).toBe(
+                styleB.props.image.props.src
+            );
+        });
     });
-  });
 
-  describe("extractPathD", () => {
-    it("extracts d attribute from a <path> element", () => {
-      const svg = `
+    describe("extractPathD", () => {
+        it("extracts d attribute from a <path> element", () => {
+            const svg = `
       <svg>
         <path d="M10 10 L20 20 Z" fill="red" />
       </svg>
     `;
 
-      const d = extractPathD(svg);
-      expect(d).toBe("M10 10 L20 20 Z");
+            const d = extractPathD(svg);
+            expect(d).toBe("M10 10 L20 20 Z");
+        });
+
+        it("returns raw path data when given path commands only", () => {
+            const raw = "M0 0 L10 0 L10 10 Z";
+
+            const d = extractPathD(raw);
+            expect(d).toBe(raw);
+        });
+
+        it("throws when no path data can be found", () => {
+            const svg = `<svg><circle cx="5" cy="5" r="2" /></svg>`;
+
+            expect(() => extractPathD(svg)).toThrow(
+                "No path data found in SVG"
+            );
+        });
     });
 
-    it("returns raw path data when given path commands only", () => {
-      const raw = "M0 0 L10 0 L10 10 Z";
+    describe("getPathBBox", () => {
+        it("computes bounding box for a simple rectangle path", () => {
+            const d = "M0 0 L10 0 L10 20 L0 20 Z";
 
-      const d = extractPathD(raw);
-      expect(d).toBe(raw);
+            const bbox = getPathBBox(d);
+
+            expect(bbox.minX).toBe(0);
+            expect(bbox.minY).toBe(0);
+            expect(bbox.maxX).toBe(10);
+            expect(bbox.maxY).toBe(20);
+            expect(bbox.width).toBe(10);
+            expect(bbox.height).toBe(20);
+        });
+
+        it("handles paths with negative coordinates", () => {
+            const d = "M-10 -5 L5 -5 L5 15 L-10 15 Z";
+
+            const bbox = getPathBBox(d);
+
+            expect(bbox.minX).toBe(-10);
+            expect(bbox.minY).toBe(-5);
+            expect(bbox.maxX).toBe(5);
+            expect(bbox.maxY).toBe(15);
+            expect(bbox.width).toBe(15);
+            expect(bbox.height).toBe(20);
+        });
+
+        it("handles paths with curves (x1/x2 control points)", () => {
+            const d = "M0 0 C10 20, 20 10, 30 0";
+
+            const bbox = getPathBBox(d);
+
+            expect(bbox.minX).toBe(0);
+            expect(bbox.minY).toBe(0);
+            expect(bbox.maxX).toBe(30);
+            expect(bbox.maxY).toBe(20);
+        });
+    });
+    describe("SVG utilities", () => {
+        const SIMPLE_PATH = '<path d="M0 0 L10 0 L10 10 Z" />';
+
+        it("extracts path from full svg", () => {
+            expect(extractPathD(SIMPLE_PATH)).toBe("M0 0 L10 0 L10 10 Z");
+        });
+
+        it("extracts raw path commands", () => {
+            expect(extractPathD("M1 2 L3 4")).toBe("M1 2 L3 4");
+        });
+
+        it("computes bounding box", () => {
+            const bbox = getPathBBox("M0 0 L10 0 L10 10 Z");
+            expect(bbox.width).toBe(10);
+            expect(bbox.height).toBe(10);
+        });
+
+        it("throws when no path data", () => {
+            expect(() => extractPathD("<svg></svg>")).toThrow();
+        });
     });
 
-    it("throws when no path data can be found", () => {
-      const svg = `<svg><circle cx="5" cy="5" r="2" /></svg>`;
+    describe("generator fallbacks", () => {
+        it("falls back to pin scale", () => {
+            const style = getGeneratedOlIcon({
+                markerType: "unknown" as any,
+            }) as any;
+            expect(style).toBeTruthy();
+        });
 
-      expect(() => extractPathD(svg)).toThrow("No path data found in SVG");
+        it("falls back to pin generator", () => {
+            const svg = makeCircleSvg({}); // covers default params
+            expect(svg).toContain("<circle");
+        });
     });
-  });
+    describe("getGeneratedOlIcon pure styling", () => {
+        beforeEach(() => {
+            jest.clearAllMocks();
+        });
 
-  describe("getPathBBox", () => {
-    it("computes bounding box for a simple rectangle path", () => {
-      const d = "M0 0 L10 0 L10 20 L0 20 Z";
+        it("synchronously renders a fallback if the icon is not ready", () => {
+            // Simulate the resolver saying "I don't have this yet" (or it's an invalid icon)
+            (resolveFaIconPath as jest.Mock).mockReturnValue({
+                status: "missing",
+            });
 
-      const bbox = getPathBBox(d);
+            // Notice we no longer pass a 'feature' mock!
+            const style = getGeneratedOlIcon({
+                faIcon: "fa-solid fa-user",
+                fallbackText: "U",
+            });
 
-      expect(bbox.minX).toBe(0);
-      expect(bbox.minY).toBe(0);
-      expect(bbox.maxX).toBe(10);
-      expect(bbox.maxY).toBe(20);
-      expect(bbox.width).toBe(10);
-      expect(bbox.height).toBe(20);
+            // 1. It should NOT attempt to fetch the icon
+            expect(ensureFaIconPath).not.toHaveBeenCalled();
+
+            // 2. It should return a valid style containing the fallback text
+            const src = (style as any).props.image.props.src;
+
+            // The data URL should contain our fallback text 'U'
+            expect(decodeURIComponent(src)).toContain(">U<");
+        });
+
+        it("synchronously renders the SVG if the icon is ready in the cache", () => {
+            // Simulate the resolver saying "I have it, here is the path"
+            (resolveFaIconPath as jest.Mock).mockReturnValue({
+                status: "ready",
+                path: "M0 0 L10 10 Z",
+            });
+
+            const style = getGeneratedOlIcon({ faIcon: "fa-solid fa-user" });
+            // 1. It should NOT attempt to fetch the icon (it's already ready)
+            expect(ensureFaIconPath).not.toHaveBeenCalled();
+
+            // 2. It should return a valid style containing the actual SVG path
+            const src = (style as any).props.image.props.src;
+            expect(decodeURIComponent(src)).toContain("M0 0 L10 10 Z");
+        });
     });
-
-    it("handles paths with negative coordinates", () => {
-      const d = "M-10 -5 L5 -5 L5 15 L-10 15 Z";
-
-      const bbox = getPathBBox(d);
-
-      expect(bbox.minX).toBe(-10);
-      expect(bbox.minY).toBe(-5);
-      expect(bbox.maxX).toBe(5);
-      expect(bbox.maxY).toBe(15);
-      expect(bbox.width).toBe(15);
-      expect(bbox.height).toBe(20);
-    });
-
-    it("handles paths with curves (x1/x2 control points)", () => {
-      const d = "M0 0 C10 20, 20 10, 30 0";
-
-      const bbox = getPathBBox(d);
-
-      expect(bbox.minX).toBe(0);
-      expect(bbox.minY).toBe(0);
-      expect(bbox.maxX).toBe(30);
-      expect(bbox.maxY).toBe(20);
-    });
-  });
-  describe("SVG utilities", () => {
-    const SIMPLE_PATH = '<path d="M0 0 L10 0 L10 10 Z" />';
-
-    it("extracts path from full svg", () => {
-      expect(extractPathD(SIMPLE_PATH)).toBe("M0 0 L10 0 L10 10 Z");
-    });
-
-    it("extracts raw path commands", () => {
-      expect(extractPathD("M1 2 L3 4")).toBe("M1 2 L3 4");
-    });
-
-    it("computes bounding box", () => {
-      const bbox = getPathBBox("M0 0 L10 0 L10 10 Z");
-      expect(bbox.width).toBe(10);
-      expect(bbox.height).toBe(10);
-    });
-
-    it("throws when no path data", () => {
-      expect(() => extractPathD("<svg></svg>")).toThrow();
-    });
-  });
-
-  describe("generator fallbacks", () => {
-    it("falls back to pin scale", () => {
-      const style = getGeneratedOlIcon({ markerType: "unknown" as any }) as any;
-      expect(style).toBeTruthy();
-    });
-
-    it("falls back to pin generator", () => {
-      const svg = makeCircleSvg({}); // covers default params
-      expect(svg).toContain("<circle");
-    });
-  });
-
-  describe("faIcon async branch", () => {
-    it("triggers async load once and re-applies style", async () => {
-      const feature = { setStyle: jest.fn() } as any;
-
-      let callCount = 0;
-
-      (resolveFaIconPath as jest.Mock).mockImplementation(() => {
-        callCount++;
-        return callCount === 1
-          ? { status: "missing" }
-          : { status: "ready", path: "M0 0 L10 10 Z" };
-      });
-
-      (ensureFaIconPath as jest.Mock).mockResolvedValue("M0 0 L10 10 Z");
-
-      getGeneratedOlIcon({ faIcon: "fa-solid fa-user" }, feature);
-
-      await Promise.resolve(); // flush microtask
-
-      expect(ensureFaIconPath).toHaveBeenCalledTimes(1);
-      expect(feature.setStyle).toHaveBeenCalledTimes(1);
-    });
-  });
 });

--- a/src/component-library/Map/v2/styles/markers.ts
+++ b/src/component-library/Map/v2/styles/markers.ts
@@ -1,5 +1,4 @@
-import { ensureFaIconPath, resolveFaIconPath } from "../utils/faIconResolver";
-import type { IconDefinition } from "@fortawesome/fontawesome-common-types";
+import { resolveFaIconPath } from "../utils/faIconResolver";
 import { parseSVG, makeAbsolute } from "svg-path-parser";
 import { MarkerStyle, MarkerType } from "../types/markers";
 import Style from "ol/style/Style";
@@ -10,39 +9,39 @@ import Point from "ol/geom/Point";
 const iconCache = new Map<string, string>();
 
 type InternalMarkerStyle = MarkerStyle & {
-  innerSvg?: string;
+    innerSvg?: string;
 };
 type IconPlacement = {
-  cx: number;
-  cy: number;
-  size: number;
+    cx: number;
+    cy: number;
+    size: number;
 };
 
 const ICON_PLACEMENT: IconPlacement = {
-  cx: 12,
-  cy: 12,
-  size: 12,
+    cx: 12,
+    cy: 12,
+    size: 12,
 };
 
 // Convert SVG string to data URL
 const svgToDataUrl = (svg: string) =>
-  `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+    `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
 
 const makePinSvg = ({
-  size = 28,
-  backgroundColor = "#FF6600",
-  color = "#fff",
-  innerSvg,
+    size = 28,
+    backgroundColor = "#FF6600",
+    color = "#fff",
+    innerSvg,
 }: InternalMarkerStyle): string => {
-  const icon = innerSvg
-    ? scaleAndCenterPath(innerSvg, color, {
-        cx: 12,
-        cy: 9,
-        size: 9,
-      })
-    : "";
+    const icon = innerSvg
+        ? scaleAndCenterPath(innerSvg, color, {
+              cx: 12,
+              cy: 9,
+              size: 9,
+          })
+        : "";
 
-  return `
+    return `
 <svg
   xmlns="http://www.w3.org/2000/svg"
   width="${size}"
@@ -72,70 +71,70 @@ const makePinSvg = ({
 };
 
 export const extractPathD = (rawSvg: string): string => {
-  // If this already looks like a <g> with a <path>, extract the path
-  const pathMatch = rawSvg.match(/<path[^>]*d="([^"]+)"/);
-  if (pathMatch) {
-    return pathMatch[1];
-  }
+    // If this already looks like a <g> with a <path>, extract the path
+    const pathMatch = rawSvg.match(/<path[^>]*d="([^"]+)"/);
+    if (pathMatch) {
+        return pathMatch[1];
+    }
 
-  // Otherwise assume raw path commands
-  const dMatch = rawSvg.match(/M[\s\S]+/);
-  if (dMatch) {
-    return dMatch[0];
-  }
+    // Otherwise assume raw path commands
+    const dMatch = rawSvg.match(/M[\s\S]+/);
+    if (dMatch) {
+        return dMatch[0];
+    }
 
-  throw new Error("No path data found in SVG");
+    throw new Error("No path data found in SVG");
 };
 
 /**
  * Compute the bounding box of a path `d` string.
  */
 export const getPathBBox = (d: string) => {
-  const commands = makeAbsolute(parseSVG(d));
-  let minX = Infinity,
-    minY = Infinity,
-    maxX = -Infinity,
-    maxY = -Infinity;
+    const commands = makeAbsolute(parseSVG(d));
+    let minX = Infinity,
+        minY = Infinity,
+        maxX = -Infinity,
+        maxY = -Infinity;
 
-  commands.forEach((c) => {
-    const points: [number, number][] = [];
-    if ("x" in c && "y" in c) points.push([c.x, c.y]);
-    if ("x1" in c && "y1" in c) points.push([c.x1, c.y1]);
-    if ("x2" in c && "y2" in c) points.push([c.x2, c.y2]);
-    points.forEach(([x, y]) => {
-      if (x != null && y != null) {
-        minX = Math.min(minX, x);
-        minY = Math.min(minY, y);
-        maxX = Math.max(maxX, x);
-        maxY = Math.max(maxY, y);
-      }
+    commands.forEach((c) => {
+        const points: [number, number][] = [];
+        if ("x" in c && "y" in c) points.push([c.x, c.y]);
+        if ("x1" in c && "y1" in c) points.push([c.x1, c.y1]);
+        if ("x2" in c && "y2" in c) points.push([c.x2, c.y2]);
+        points.forEach(([x, y]) => {
+            if (x != null && y != null) {
+                minX = Math.min(minX, x);
+                minY = Math.min(minY, y);
+                maxX = Math.max(maxX, x);
+                maxY = Math.max(maxY, y);
+            }
+        });
     });
-  });
 
-  return { minX, minY, maxX, maxY, width: maxX - minX, height: maxY - minY };
+    return { minX, minY, maxX, maxY, width: maxX - minX, height: maxY - minY };
 };
 
 /**
  * Scale, center, and color the inner path into a target viewBox.
  */
 const scaleAndCenterPath = (
-  rawSvg: string,
-  color = "#F092D5",
-  placement: IconPlacement
+    rawSvg: string,
+    color = "#F092D5",
+    placement: IconPlacement
 ) => {
-  const d = extractPathD(rawSvg);
-  const bbox = getPathBBox(d);
+    const d = extractPathD(rawSvg);
+    const bbox = getPathBBox(d);
 
-  // scale to fit inside targetSize
-  const scale = Math.min(
-    placement.size / bbox.width,
-    placement.size / bbox.height
-  );
+    // scale to fit inside targetSize
+    const scale = Math.min(
+        placement.size / bbox.width,
+        placement.size / bbox.height
+    );
 
-  const cx = bbox.minX + bbox.width / 2;
-  const cy = bbox.minY + bbox.height / 2;
+    const cx = bbox.minX + bbox.width / 2;
+    const cy = bbox.minY + bbox.height / 2;
 
-  return `
+    return `
     <g
       transform="
         translate(${placement.cx}, ${placement.cy})
@@ -150,17 +149,17 @@ const scaleAndCenterPath = (
 };
 
 export const makeCircleSvg = ({
-  size = 28,
-  backgroundColor = "#FF6600",
-  color = "#fff",
-  strokeWidth = 2,
-  innerSvg,
+    size = 28,
+    backgroundColor = "#FF6600",
+    color = "#fff",
+    strokeWidth = 2,
+    innerSvg,
 }: InternalMarkerStyle): string => {
-  const inner = innerSvg
-    ? scaleAndCenterPath(innerSvg, color, ICON_PLACEMENT)
-    : "";
+    const inner = innerSvg
+        ? scaleAndCenterPath(innerSvg, color, ICON_PLACEMENT)
+        : "";
 
-  return `
+    return `
 <svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 24 24">
   <circle cx="12" cy="12" r="10"
           fill="${backgroundColor}" stroke="${color}" stroke-width="${strokeWidth}"/>
@@ -170,15 +169,15 @@ export const makeCircleSvg = ({
 };
 
 const makeIconOnlySvg = ({
-  size = 28,
-  innerSvg,
-  color = "#FF6600",
+    size = 28,
+    innerSvg,
+    color = "#FF6600",
 }: InternalMarkerStyle): string => {
-  const inner = innerSvg
-    ? scaleAndCenterPath(innerSvg, color, ICON_PLACEMENT)
-    : "";
+    const inner = innerSvg
+        ? scaleAndCenterPath(innerSvg, color, ICON_PLACEMENT)
+        : "";
 
-  return `
+    return `
 <svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 24 24" fill="${color}">
     ${inner}
 </svg>
@@ -186,103 +185,92 @@ const makeIconOnlySvg = ({
 };
 
 const iconGenerators: Record<MarkerType, (s: MarkerStyle) => string> = {
-  pin: makePinSvg,
-  circle: makeCircleSvg,
-  icon: makeIconOnlySvg,
+    pin: makePinSvg,
+    circle: makeCircleSvg,
+    icon: makeIconOnlySvg,
 };
 
 const MARKER_SCALE: Record<MarkerType, number> = {
-  pin: 1.5,
-  circle: 1.0,
-  icon: 1.0,
+    pin: 1.5,
+    circle: 1.0,
+    icon: 1.0,
 };
 
 const getMarkerScale = (type?: unknown): number => {
-  if (typeof type === "string" && type in MARKER_SCALE) {
-    return MARKER_SCALE[type as MarkerType];
-  }
-  return MARKER_SCALE.pin; // safe default
+    if (typeof type === "string" && type in MARKER_SCALE) {
+        return MARKER_SCALE[type as MarkerType];
+    }
+    return MARKER_SCALE.pin; // safe default
 };
 
 const getIconGenerator = (
-  type?: unknown
+    type?: unknown
 ): ((s: InternalMarkerStyle) => string) => {
-  if (typeof type === "string" && type in iconGenerators) {
-    return iconGenerators[type as MarkerType];
-  }
-  return iconGenerators.pin;
+    if (typeof type === "string" && type in iconGenerators) {
+        return iconGenerators[type as MarkerType];
+    }
+    return iconGenerators.pin;
 };
 
 export const getGeneratedOlIcon = (
-  style: MarkerStyle = {},
-  feature?: Feature
+    style: MarkerStyle = {},
+    feature?: Feature
 ): Style => {
-  // The markerType are for ontology app, not anything to do with maps.
-  const type = "pin";
+    // The markerType are for ontology app, not anything to do with maps.
+    const type = "pin";
 
-  let inner: string | undefined;
+    let inner: string | undefined;
 
-  if (style.faIcon) {
-    const result = resolveFaIconPath(style.faIcon);
-    if (result.status === "ready") {
-      inner = result.path;
-    } else if (
-      typeof style.faIcon === "string" &&
-      result.status === "missing"
-    ) {
-      // Trigger async load
-      ensureFaIconPath(style.faIcon).then(() => {
-        if (feature) {
-          // Re-apply style once icon becomes available
-          feature.setStyle(getGeneratedOlIcon(style, feature));
+    if (style.faIcon) {
+        const result = resolveFaIconPath(style.faIcon);
+        if (result.status === "ready") {
+            inner = result.path;
         }
-      });
     }
-  }
-  const useFallback = !inner && style.fallbackText;
+    const useFallback = !inner && style.fallbackText;
 
-  let svg: string;
+    let svg: string;
 
-  if (useFallback) {
-    // fallback text inside a circle
-    svg = `
+    if (useFallback) {
+        // fallback text inside a circle
+        svg = `
       <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" viewBox="0 0 28 28">
         <circle cx="12" cy="12" r="10" fill="${
-          style.backgroundColor ?? "#FF6600"
+            style.backgroundColor ?? "#FF6600"
         }" stroke="${style.color ?? "#fff"}" stroke-width="2"/>
         <text x="12" y="13" text-anchor="middle" dominant-baseline="middle" font-size="8" font-weight="600" fill="${
-          style.color ?? "#fff"
+            style.color ?? "#fff"
         }">${style.fallbackText}</text>
       </svg>
     `;
-  } else {
-    // pin/circle/icon SVG with HTML inside
-    const generator = getIconGenerator(type);
-    svg = generator({ ...style, innerSvg: inner });
-  }
+    } else {
+        // pin/circle/icon SVG with HTML inside
+        const generator = getIconGenerator(type);
+        svg = generator({ ...style, innerSvg: inner });
+    }
 
-  const key = `${type}|${inner}|${JSON.stringify(style)}`;
-  let url = iconCache.get(key);
-  if (!url) {
-    url = svgToDataUrl(svg);
-    iconCache.set(key, url);
-  }
+    const key = `${type}|${inner}|${JSON.stringify(style)}`;
+    let url = iconCache.get(key);
+    if (!url) {
+        url = svgToDataUrl(svg);
+        iconCache.set(key, url);
+    }
 
-  return new Style({
-    image: new Icon({ src: url, scale: getMarkerScale(type) }),
-  });
+    return new Style({
+        image: new Icon({ src: url, scale: getMarkerScale(type) }),
+    });
 };
 
 // Create OL Feature with style
 export const createOlMarker = (
-  id: string,
-  coords: [number, number],
-  style: MarkerStyle
+    id: string,
+    coords: [number, number],
+    style: MarkerStyle
 ): Feature<Point> => {
-  const feature = new Feature({
-    geometry: new Point(coords),
-    id,
-  });
-  feature.setStyle(getGeneratedOlIcon(style));
-  return feature;
+    const feature = new Feature({
+        geometry: new Point(coords),
+        id,
+    });
+    feature.setStyle(getGeneratedOlIcon(style));
+    return feature;
 };

--- a/src/component-library/Map/v2/styles/markers.ts
+++ b/src/component-library/Map/v2/styles/markers.ts
@@ -71,16 +71,30 @@ const makePinSvg = ({
 };
 
 export const extractPathD = (rawSvg: string): string => {
-    // If this already looks like a <g> with a <path>, extract the path
-    const pathMatch = rawSvg.match(/<path[^>]*d="([^"]+)"/);
-    if (pathMatch) {
-        return pathMatch[1];
+    const cleanSvg = rawSvg.trim();
+
+    // 1. If it already looks like raw path commands (starts with M)
+    if (cleanSvg.startsWith("M")) {
+        return cleanSvg;
     }
 
-    // Otherwise assume raw path commands
-    const dMatch = rawSvg.match(/M[\s\S]+/);
-    if (dMatch) {
-        return dMatch[0];
+    // 2. Safely extract the 'd' attribute using string indices (O(n), ReDoS impossible)
+    const pathTagStart = cleanSvg.indexOf("<path");
+
+    if (pathTagStart !== -1) {
+        // Look for the d attribute AFTER the <path tag
+        const dAttrStart = cleanSvg.indexOf('d="', pathTagStart);
+
+        if (dAttrStart !== -1) {
+            // The actual path data starts 3 characters after the 'd'
+            const dataStart = dAttrStart + 3;
+            // Find the closing quote
+            const dataEnd = cleanSvg.indexOf('"', dataStart);
+
+            if (dataEnd !== -1) {
+                return cleanSvg.slice(dataStart, dataEnd);
+            }
+        }
     }
 
     throw new Error("No path data found in SVG");

--- a/src/component-library/Map/v2/utils/__tests__/markerIconLoader.test.ts
+++ b/src/component-library/Map/v2/utils/__tests__/markerIconLoader.test.ts
@@ -1,0 +1,33 @@
+// src/component-library/Map/v2/utils/__tests__/markerIconLoader.test.ts
+
+import { ensureMarkerIconsLoaded } from "../markerIconLoader";
+import { ensureFaIconPath } from "../faIconResolver"; // Adjust this path if needed!
+
+// 1. ADD THIS LINE!
+// The path string here must exactly match the path string in the import above.
+jest.mock("../faIconResolver");
+
+describe("ensureMarkerIconsLoaded", () => {
+  // Clear mocks before each test to prevent test pollution
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("extracts unique icons and awaits their resolution", async () => {
+    // 2. Because of jest.mock() above, ensureFaIconPath is now a recognized mock
+    (ensureFaIconPath as jest.Mock).mockResolvedValue("M0 0 L10 10 Z");
+
+    const mockMarkers = [
+      { style: { faIcon: "fa-solid fa-church" } },
+      { style: { faIcon: "fa-solid fa-church" } }, // Duplicate!
+      { style: { faIcon: "fa-solid fa-tree" } },
+    ] as any;
+
+    await ensureMarkerIconsLoaded(mockMarkers);
+
+    // 3. Assertions
+    expect(ensureFaIconPath).toHaveBeenCalledTimes(2); // Should only be called 2 times, not 3!
+    expect(ensureFaIconPath).toHaveBeenCalledWith("fa-solid fa-church");
+    expect(ensureFaIconPath).toHaveBeenCalledWith("fa-solid fa-tree");
+  });
+});

--- a/src/component-library/Map/v2/utils/markerIconLoader.ts
+++ b/src/component-library/Map/v2/utils/markerIconLoader.ts
@@ -1,0 +1,32 @@
+import { ensureFaIconPath } from "../utils/faIconResolver";
+import { MarkerFeature } from "../types/markers";
+
+/**
+ * Extract unique FontAwesome icons used by markers
+ */
+export const extractMarkerIcons = (markers: MarkerFeature[]): string[] => {
+    const icons = new Set<string>();
+
+    for (const marker of markers) {
+        const icon = marker.style?.faIcon;
+
+        if (typeof icon === "string") {
+            icons.add(icon);
+        }
+    }
+
+    return [...icons];
+};
+
+/**
+ * Ensure all marker icons are loaded before rendering
+ */
+export const ensureMarkerIconsLoaded = async (
+    markers: MarkerFeature[]
+): Promise<void> => {
+    const icons = extractMarkerIcons(markers);
+
+    if (icons.length === 0) return;
+
+    await Promise.all(icons.map((icon) => ensureFaIconPath(icon)));
+};

--- a/src/components/TypeIcon/TypeIcon.tsx
+++ b/src/components/TypeIcon/TypeIcon.tsx
@@ -1,0 +1,60 @@
+import React, { ReactNode } from "react";
+import { Avatar } from "@mui/material";
+
+// Note: You might want to rename TeliTypeIconSizeProp to TypeIconSizeProp in your utils eventually!
+import {
+  getDisabledStyles,
+  getSizeProps,
+  TypeIconSizeProp,
+} from "./type-icon-utils";
+
+export interface TypeIconProps {
+  /** Text for screen readers and tooltips */
+  alt: string;
+  /** Initials or text to show if no icon node is provided */
+  fallbackText?: string;
+  /** Primary color for the icon/text */
+  color?: string;
+  /** Background color for the avatar */
+  backgroundColor?: string;
+  /** Overrides the default border color */
+  borderColor?: string;
+  /** Accepts ANY valid React element (SVG, Material Icon, FontAwesome wrapper, etc.) */
+  iconNode?: ReactNode;
+  /** If true, the component will be rendered in a disabled state */
+  disabled?: boolean;
+  /** Controls the size of the component */
+  size?: TypeIconSizeProp;
+}
+
+const TypeIcon: React.FC<TypeIconProps> = ({
+  alt,
+  fallbackText = "",
+  color,
+  backgroundColor,
+  borderColor,
+  iconNode,
+  disabled = false,
+  size = "base",
+}) => {
+  return (
+    <Avatar
+      alt={alt}
+      aria-label={alt}
+      sx={{
+        borderWidth: 2,
+        borderStyle: "solid",
+        borderColor: borderColor ?? color,
+        color: color,
+        backgroundColor: backgroundColor,
+        ...getDisabledStyles(disabled),
+        ...getSizeProps(size),
+      }}
+    >
+      {/* It just renders whatever you give it, or falls back to text */}
+      {iconNode ? iconNode : <p>{fallbackText}</p>}
+    </Avatar>
+  );
+};
+
+export default TypeIcon;

--- a/src/components/TypeIcon/type-icon-utils.ts
+++ b/src/components/TypeIcon/type-icon-utils.ts
@@ -1,0 +1,40 @@
+export type TypeIconSizeProp = "xs" | "sm" | "base" | "lg";
+
+export const getSizeProps = (size: TypeIconSizeProp) => {
+    const base = {
+        width: 48,
+        height: 48,
+    };
+
+    switch (size) {
+        case "xs":
+            return {
+                width: 24,
+                height: 24,
+                fontSize: 8,
+            };
+        case "sm":
+            return {
+                width: 36,
+                height: 36,
+                fontSize: 10,
+            };
+        case "lg":
+            return {
+                width: 62,
+                height: 62,
+                fontSize: 22,
+            };
+        default:
+            return base;
+    }
+};
+
+export const getDisabledStyles = (isDisabled: boolean) => {
+    const disabledStyles = {
+        filter: "grayscale(0.7)",
+        opacity: "80%",
+    };
+
+    return isDisabled ? disabledStyles : {};
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -10,19 +10,26 @@ export { default as TeliButton } from "./TeliButton/TeliButton";
 export { default as TeliChip } from "./TeliChip/TeliChip";
 export { default as TeliCheckbox } from "./TeliCheckbox/TeliCheckbox";
 export { default as TeliHeader } from "./TeliHeader/TeliHeader";
-export { default as TeliSelect, type SelectChangeEvent } from "./TeliSelect/TeliSelect";
+export {
+    default as TeliSelect,
+    type SelectChangeEvent,
+} from "./TeliSelect/TeliSelect";
 export { default as TeliSpinner } from "./TeliSpinner/TeliSpinner";
 export { default as TeliSwitch } from "./TeliSwitch/TeliSwitch";
 export { default as TeliTextField } from "./TeliTextField/TeliTextField";
 export { default as TeliInput } from "./TeliTextField/TeliInput";
 export { default as TeliToolbar } from "./TeliToolbar/TeliToolbar";
-export { default as TeliTypeIcon, type TeliTypeIconProps } from "./TeliTypeIcon/TeliTypeIcon";
+export {
+    default as TeliTypeIcon,
+    type TeliTypeIconProps,
+} from "./TeliTypeIcon/TeliTypeIcon";
 export { default as TeliTypeahead } from "./TeliTypeahead/TeliTypeahead";
 export { default as TeliUserProfile } from "./TeliUserProfile/TeliUserProfile";
 export { default as OntologyHierarchy } from "./OntologyHierarchy/OntologyHierarchy";
 export { checkOntology } from "./OntologyHierarchy/OntologyHierarchyFunctions";
 export type { OntologyInputHierarchy } from "./OntologyHierarchy/OntologyHierarchy";
 export * from "./SearchAutocompleteDialog";
+export { default as TypeIcon, type TypeIconProps } from "./TypeIcon/TypeIcon";
 export * from "./TeliIcons";
 export * from "./TeliDialog/TeliDialog";
 export * from "./TeliList/TeliList";


### PR DESCRIPTION
Bug raised from user testing.

Some icons weren't getting rendered in time

<img width="1258" height="796" alt="Screenshot 2026-03-09 at 14 06 40" src="https://github.com/user-attachments/assets/c409a024-f214-4805-80fc-52261c7b1239" />


## The fix

Rather than try to load the markers straight away the map waits until it has fetched the required icons and then gets the map to render them.

<img width="913" height="1133" alt="Screenshot 2026-03-09 at 14 10 25" src="https://github.com/user-attachments/assets/b582260d-2e81-4b08-88f8-fc0dfc04b5c5" />
