### PR TITLE
fix: app bar changes

### DIFF
--- a/src/v1/components/buttons/Button/Button.stories.tsx
+++ b/src/v1/components/buttons/Button/Button.stories.tsx
@@ -4,11 +4,15 @@ import Box from "@mui/material/Box";
 
 import Button from "./Button";
 import DataSetIcon from "../../data-display/Icons/DataSetIcon";
+import { figmaDesign } from "../../../../../.storybook/figmaDesign";
 
 const meta = {
   title: "Buttons/Button",
   component: Button,
   parameters: {
+    ...figmaDesign(
+      "https://www.figma.com/design/DTHPiGn1VDLvUpiuxSqC0h/MUI-for-Figma-Material-UI-v5.16.0?node-id=6065-28532&m=dev",
+    ),
     docs: {
       description: {
         component: `

--- a/src/v1/components/buttons/Link/Link.stories.tsx
+++ b/src/v1/components/buttons/Link/Link.stories.tsx
@@ -1,12 +1,16 @@
 import { Meta, StoryObj } from "@storybook/react";
 import Link from "./LinkButton";
 import { Box } from "@mui/material";
+import { figmaDesign } from "../../../../../.storybook/figmaDesign";
 
 const meta: Meta<typeof Link> = {
   title: "Buttons/Link",
   component: Link,
   tags: ["autodocs"],
   parameters: {
+    ...figmaDesign(
+      "https://www.figma.com/design/DTHPiGn1VDLvUpiuxSqC0h/MUI-for-Figma-Material-UI-v5.16.0?node-id=6068-28559&m=dev",
+    ),
     docs: {
       description: {
         component: `

--- a/src/v1/components/inputs/Checkbox/Checkbox.stories.tsx
+++ b/src/v1/components/inputs/Checkbox/Checkbox.stories.tsx
@@ -2,12 +2,16 @@ import { Meta, StoryObj } from "@storybook/react";
 import Checkbox from "./Checkbox";
 import { Box } from "@mui/material";
 import { useState } from "react";
+import { figmaDesign } from "../../../../../.storybook/figmaDesign";
 
 const meta: Meta<typeof Checkbox> = {
   title: "Inputs/Checkbox",
   component: Checkbox,
   tags: ["autodocs"],
   parameters: {
+    ...figmaDesign(
+      "https://www.figma.com/design/DTHPiGn1VDLvUpiuxSqC0h/MUI-for-Figma-Material-UI-v5.16.0?node-id=6164-17320&m=dev",
+    ),
     docs: {
       description: {
         component: `

--- a/src/v1/components/surfaces/AppBar/AppBar.stories.tsx
+++ b/src/v1/components/surfaces/AppBar/AppBar.stories.tsx
@@ -1,11 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { Box } from "@mui/material";
 
 import AppBar from "./AppBar";
 import { AppSwitch, Divider, TitleAndContent, UserProfile } from "../../data-display";
 import { Button } from "../../buttons";
 import { appList } from "../../data-display/AppSwitch/AppSwitch.stories";
 import { figmaDesign } from "../../../../../.storybook/figmaDesign";
-import { Box } from "@mui/material";
 
 const meta: Meta<typeof AppBar> = {
   title: "Surfaces/AppBar",
@@ -14,34 +14,105 @@ const meta: Meta<typeof AppBar> = {
   parameters: {
     docs: {
       description: {
-        component: "The AppBar component provides a top navigation bar that supports branding, actions, and more.",
+        component: `
+A branded top-level navigation component built on MUI's \`<AppBar>\` with Telicent design-system styling. 
+It supports a centered brand area, optional application name, version label, and flexible content areas on the left and right for things like app switching, user profile actions, or sign-out buttons.
+
+---
+
+### When & How to use it
+- **Application headers:** Use at the top of a product or platform page.
+- **Branding + navigation:** Ideal when you need consistent Telicent branding with contextual actions.
+- **Flexible layouts:** Use \`startChild\` for left-side content such as an app switcher, and \`endChild\` for right-side content such as a user profile or action buttons.
+- **Clickable:** Pass \`href\` to make this component clickabout, out of the box it opens in a blank tab.
+
+\`\`\`jsx
+<AppBar
+  appName="Catalogue"
+  isElevated
+  href="/"
+  startChild={<AppSwitch apps={appList} />}
+  endChild={
+    <Button color="primary" variant="contained">
+      Sign Out
+    </Button>
+  }
+/>
+\`\`\`
+
+---
+
+### Layout behaviour
+The AppBar uses a three-column grid layout:
+
+- left area for supporting actions
+- centered brand area
+- right area for user actions
+
+This keeps the brand visually centered while allowing flexible content on either side.
+`,
       },
     },
-
     ...figmaDesign(
       "https://www.figma.com/design/DTHPiGn1VDLvUpiuxSqC0h/MUI-for-Figma-Material-UI-v5.16.0?node-id=5870-18322&t=M1U919ZxRbInOHt7-4",
     ),
     layout: "fullscreen",
   },
-};
+  decorators: [
+    (Story) => (
+      <Box sx={{ width: "100%" }}>
+        <Story />
+      </Box>
+    ),
+  ],
+  argTypes: {
+    appName: {
+      control: "text",
+      description: "Optional application name displayed alongside the Telicent brand.",
+    },
+    version: {
+      control: "text",
+      description: "Optional version label displayed next to the brand area.",
+    },
+    href: {
+      control: "text",
+      description: "Optional URL that turns the centered brand area into a link.",
+    },
+    target: {
+      control: "text",
+      description: "Target browsing context for the brand link.",
+    },
+
+    beta: {
+      control: "boolean",
+      description: "If true, displays a beta badge next to the branding.",
+    },
+    isElevated: {
+      control: "boolean",
+      description: "If true, applies elevation to the AppBar.",
+    },
+    disableBrand: {
+      control: "boolean",
+      description: "If true, hides the Telicent branding elements.",
+    },
+    position: {
+      control: "select",
+      options: ["fixed", "absolute", "sticky", "static", "relative"],
+      description: "Controls the CSS position of the AppBar.",
+    },
+  },
+} satisfies Meta<typeof AppBar>;
+
 export default meta;
 
 type Story = StoryObj<typeof AppBar>;
 
-export const Example: Story = {};
-
-export const WithAppName: Story = {
-  args: {
-    appName: "Catalogue",
-  },
-};
-
 const UserProfileExample = (
-  <UserProfile fullName="VeryLongEmailAddress@LongCompanyName.com">
-    <TitleAndContent title={"Username"} content={"Han Solo"} />
-    <TitleAndContent title={"Email"} content={"han.solo@rebel-alliance.com"} />
-    <TitleAndContent title={"Deployed Organisation"} content={"Rebel Alliance"} />
-    <TitleAndContent title={"Version number"} content={"1.2.3"} />
+  <UserProfile fullName="JohnDoe@company.co.uk">
+    <TitleAndContent title="Username" content="John Doe" />
+    <TitleAndContent title="Email" content="JohnDoe@company.co.uk" />
+    <TitleAndContent title="Deployed Organisation" content="Company UK" />
+    <TitleAndContent title="Version number" content="1.2.3" />
     <Divider />
     <Box sx={{ pt: 1 }}>
       <Button
@@ -57,25 +128,13 @@ const UserProfileExample = (
   </UserProfile>
 );
 
-export const WithUserProfileAndAppSwitch: Story = {
-  args: {
-    isElevated: true,
-    ...WithAppName.args,
-    startChild: <AppSwitch apps={appList} />,
-    endChild: UserProfileExample,
-  },
-};
-
-export const WithVersionNumber: Story = {
-  args: {
-    appName: "Design System",
-    version: "1.2.0",
-  },
+export const Default: Story = {
+  args: {},
 };
 
 export const WithSignOutButton: Story = {
   args: {
-    ...WithAppName.args,
+    appName: "Catalogue",
     endChild: (
       <Button color="primary" variant="contained" startIcon={<i className="fa-solid fa-arrow-right-from-bracket" />}>
         Sign Out
@@ -86,9 +145,33 @@ export const WithSignOutButton: Story = {
 
 export const WithNoBrand: Story = {
   args: {
-    ...WithAppName.args,
     disableBrand: true,
     startChild: <AppSwitch apps={appList} />,
     endChild: UserProfileExample,
+  },
+};
+
+export const ClickableBrand: Story = {
+  args: {
+    appName: "Catalogue",
+    href: "https://telicent.io",
+    target: "_blank",
+  },
+};
+
+export const UsageExample: Story = {
+  args: {
+    appName: "Catalogue",
+    isElevated: true,
+    startChild: <AppSwitch apps={appList} />,
+    endChild: UserProfileExample,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Recommended application-header setup with branding, app navigation on the left, and a primary action on the right.",
+      },
+    },
   },
 };

--- a/src/v1/components/surfaces/AppBar/AppBar.test.tsx
+++ b/src/v1/components/surfaces/AppBar/AppBar.test.tsx
@@ -4,57 +4,56 @@ import AppBar from "./AppBar";
 import { screen, within } from "@testing-library/dom";
 
 describe("AppBar Component", () => {
+  test("should render the appName", () => {
+    setup(<AppBar appName="AppBar Test" />);
 
-    test("should render the appName", () => {
-      setup(<AppBar appName="AppBar Test" />);
-
-      expect(screen.getByText("APPBAR TEST")).toBeInTheDocument();
-    });
-
-    test("should render the startChild component", () => {
-      setup(<AppBar appName="Design System" startChild={<div id="start-child">Start Child</div>} />);
-
-      expect(screen.getByTestId("start-child")).toBeInTheDocument();
-      expect(screen.getByText("Start Child")).toBeInTheDocument();
-    });
-
-    test("should render the endChild component", () => {
-      setup(<AppBar appName="Design System" endChild={<div id="end-child">End Child</div>} />);
-
-      expect(screen.getByTestId("end-child")).toBeInTheDocument();
-      expect(screen.getByText("End Child")).toBeInTheDocument();
-    });
-
-    test("should render both startChild and endChild components", () => {
-      setup(
-        <AppBar
-          appName="Design System"
-          startChild={<div id="start-child">Start Child</div>}
-          endChild={<div id="end-child">End Child</div>}
-        />
-      );
-
-      expect(screen.getByTestId("start-child")).toBeInTheDocument();
-      expect(screen.getByText("Start Child")).toBeInTheDocument();
-
-      expect(screen.getByTestId("end-child")).toBeInTheDocument();
-      expect(screen.getByText("End Child")).toBeInTheDocument();
-    });
-
-    test("shoult render the version number", () => {
-      setup(<AppBar version="1.2.3" />);
-
-      expect(screen.getByText("1.2.3")).toBeInTheDocument();
-    });
-
-    test("on click function", async () => {
-      const handleClick = jest.fn();
-      const { user } = setup(<AppBar appName="Test App" onClick={handleClick} />);
-
-      const appBar = screen.getByText("TEST APP");
-
-      await user.click(appBar);
-
-      expect(handleClick).toHaveBeenCalledTimes(1);
-    });
+    expect(screen.getByText("APPBAR TEST")).toBeInTheDocument();
   });
+
+  test("should render the startChild component", () => {
+    setup(<AppBar appName="Design System" startChild={<div id="start-child">Start Child</div>} />);
+
+    expect(screen.getByTestId("start-child")).toBeInTheDocument();
+    expect(screen.getByText("Start Child")).toBeInTheDocument();
+  });
+
+  test("should render the endChild component", () => {
+    setup(<AppBar appName="Design System" endChild={<div id="end-child">End Child</div>} />);
+
+    expect(screen.getByTestId("end-child")).toBeInTheDocument();
+    expect(screen.getByText("End Child")).toBeInTheDocument();
+  });
+
+  test("should render both startChild and endChild components", () => {
+    setup(
+      <AppBar
+        appName="Design System"
+        startChild={<div id="start-child">Start Child</div>}
+        endChild={<div id="end-child">End Child</div>}
+      />,
+    );
+
+    expect(screen.getByTestId("start-child")).toBeInTheDocument();
+    expect(screen.getByText("Start Child")).toBeInTheDocument();
+
+    expect(screen.getByTestId("end-child")).toBeInTheDocument();
+    expect(screen.getByText("End Child")).toBeInTheDocument();
+  });
+
+  test("shoult render the version number", () => {
+    setup(<AppBar version="1.2.3" />);
+
+    expect(screen.getByText("1.2.3")).toBeInTheDocument();
+  });
+
+  test("on click function", async () => {
+    const address = "https://telicent.io";
+    setup(<AppBar appName="Test App" href={address} />);
+
+    const appBar = screen.getByText("TEST APP");
+
+    const link = screen.getByRole("link");
+
+    expect(link).toHaveAttribute("href", address);
+  });
+});

--- a/src/v1/components/surfaces/AppBar/AppBar.tsx
+++ b/src/v1/components/surfaces/AppBar/AppBar.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { common } from "@mui/material/colors";
 import MUIAppBar, { AppBarProps as MUIAppBarProps } from "@mui/material/AppBar";
 import MUIBox from "@mui/material/Box";
 import MUIStack from "@mui/material/Stack";
@@ -16,6 +15,7 @@ export type AppBarProps = Partial<{
   position: MUIAppBarProps["position"];
   version?: string;
   onClick?: (event?: Event | React.SyntheticEvent) => void;
+  href?: string;
   isElevated?: boolean;
   disableBrand?: boolean;
 }>;
@@ -27,9 +27,9 @@ const AppBar: React.FC<AppBarProps> = ({
   startChild,
   endChild,
   version,
-  onClick,
   isElevated,
   disableBrand,
+  href,
 }) => {
   const theme = useExtendedTheme();
 
@@ -57,6 +57,10 @@ const AppBar: React.FC<AppBarProps> = ({
         </MUIBox>
       )}
       <MUIStack
+        component={href ? "a" : "div"}
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
         direction="row"
         spacing={1}
         alignItems="center"
@@ -64,10 +68,9 @@ const AppBar: React.FC<AppBarProps> = ({
           position: "absolute",
           top: "50%",
           left: "50%",
-          transform: "translate(-50%, -50%);",
-          cursor: onClick ? "pointer" : "default",
+          transform: "translate(-50%, -50%)",
+          cursor: href ? "pointer" : "default",
         }}
-        onClick={onClick}
       >
         {!disableBrand && (
           <>
@@ -76,9 +79,9 @@ const AppBar: React.FC<AppBarProps> = ({
             <MUITypography
               variant="h1"
               color="primary"
-              sx={{ fontFamily: "Figtree", fontSize: 30, fontWeight: 400, pt: "2px" }}
+              sx={{ fontFamily: "Figtree", fontSize: 30, fontWeight: 400, pt: "2px", textTransform: "uppercase" }}
             >
-              {appName?.toUpperCase()}
+              {appName}
             </MUITypography>
           </>
         )}

--- a/src/v1/components/surfaces/AppBar/AppBar.tsx
+++ b/src/v1/components/surfaces/AppBar/AppBar.tsx
@@ -13,11 +13,11 @@ export type AppBarProps = Partial<{
   startChild: React.ReactNode;
   endChild: React.ReactNode;
   position: MUIAppBarProps["position"];
-  version?: string;
-  onClick?: (event?: Event | React.SyntheticEvent) => void;
-  href?: string;
-  isElevated?: boolean;
-  disableBrand?: boolean;
+  version: string;
+  href: string;
+  target: React.HTMLAttributeAnchorTarget;
+  isElevated: boolean;
+  disableBrand: boolean;
 }>;
 
 const AppBar: React.FC<AppBarProps> = ({
@@ -27,94 +27,117 @@ const AppBar: React.FC<AppBarProps> = ({
   startChild,
   endChild,
   version,
-  isElevated,
-  disableBrand,
+  isElevated = false,
+  disableBrand = false,
   href,
+  target = "_blank",
 }) => {
   const theme = useExtendedTheme();
+
+  const isInteractive = Boolean(href);
+
+  const linkProps = href
+    ? {
+        component: "a" as const,
+        href,
+        target,
+        rel: "noopener noreferrer",
+      }
+    : {
+        component: "div" as const,
+      };
 
   return (
     <MUIAppBar
       color="inherit"
       position={position}
+      elevation={isElevated ? 4 : 0}
       sx={{
         borderRadius: 0,
-        backgroundColor: theme.palette.mode === "dark" ? theme.palette.background.default : "#ffffff",
+        backgroundColor: theme.palette.mode === "dark" ? theme.palette.background.default : "#fff",
       }}
-      elevation={isElevated ? 4 : 0}
     >
-      {startChild && (
-        <MUIBox
-          id="app-switch-container"
-          sx={{
-            position: "absolute",
-            top: "50%",
-            left: 16,
-            transform: "translate(0, -50%)",
-          }}
-        >
-          {startChild}
-        </MUIBox>
-      )}
-      <MUIStack
-        component={href ? "a" : "div"}
-        href={href}
-        target="_blank"
-        rel="noopener noreferrer"
-        direction="row"
-        spacing={1}
-        alignItems="center"
+      <MUIBox
         sx={{
-          position: "absolute",
-          top: "50%",
-          left: "50%",
-          transform: "translate(-50%, -50%)",
-          cursor: href ? "pointer" : "default",
+          display: "grid",
+          gridTemplateColumns: "1fr auto 1fr",
+          alignItems: "center",
+          minHeight: 64,
+          px: 2,
         }}
       >
-        {!disableBrand && (
-          <>
-            <TelicentMark fontSize="large" />
-            <TelicentBrand />
-            <MUITypography
-              variant="h1"
-              color="primary"
-              sx={{ fontFamily: "Figtree", fontSize: 30, fontWeight: 400, pt: "2px", textTransform: "uppercase" }}
-            >
-              {appName}
-            </MUITypography>
-          </>
-        )}
+        <MUIBox sx={{ justifySelf: "start", minWidth: 0 }}>{startChild}</MUIBox>
 
-        {version && (
-          <MUIBox
-            position="absolute"
-            bottom={5}
-            fontSize={12}
-            left="calc(100% - 12px)"
-            paddingInline={0.5}
-            sx={{
-              color: theme.palette.secondary.contrastText,
-              whiteSpace: "nowrap",
-              marginLeft: "-4px",
-            }}
-          >
-            {version}
-          </MUIBox>
-        )}
-      </MUIStack>
-      {endChild && (
         <MUIStack
+          {...linkProps}
+          direction="row"
+          spacing={1}
+          alignItems="center"
           sx={{
-            position: "absolute",
-            top: "50%",
-            right: 16,
-            transform: "translate(0, -50%)",
+            justifySelf: "center",
+            cursor: isInteractive ? "pointer" : "default",
+            textDecoration: "none",
+            color: "inherit",
+            position: "relative",
+            minWidth: 0,
           }}
         >
-          {endChild}
+          {!disableBrand && (
+            <>
+              <TelicentMark fontSize="large" />
+              <TelicentBrand />
+              {appName && (
+                <MUITypography
+                  variant="h1"
+                  component="span"
+                  color="primary"
+                  sx={{
+                    fontFamily: "Figtree",
+                    fontSize: 30,
+                    fontWeight: 400,
+                    pt: "2px",
+                    textTransform: "uppercase",
+                  }}
+                >
+                  {appName}
+                </MUITypography>
+              )}
+              {beta && (
+                <MUIBox
+                  component="span"
+                  sx={{
+                    px: 0.75,
+                    py: 0.25,
+                    borderRadius: 1,
+                    bgcolor: theme.palette.primary.main,
+                    color: theme.palette.primary.contrastText,
+                    fontSize: 12,
+                    fontWeight: 700,
+                    lineHeight: 1,
+                  }}
+                >
+                  BETA
+                </MUIBox>
+              )}
+            </>
+          )}
+
+          {version && (
+            <MUITypography
+              component="span"
+              variant="caption"
+              sx={{
+                color: theme.palette.secondary.contrastText,
+                whiteSpace: "nowrap",
+              }}
+            >
+              {version}
+            </MUITypography>
+          )}
         </MUIStack>
-      )}
+
+        <MUIBox sx={{ justifySelf: "end", minWidth: 0 }}>{endChild}</MUIBox>
+      </MUIBox>
     </MUIAppBar>
   );
 };

--- a/src/v1/components/surfaces/AppBar/AppBar.tsx
+++ b/src/v1/components/surfaces/AppBar/AppBar.tsx
@@ -98,7 +98,7 @@ const AppBar: React.FC<AppBarProps> = ({
                     pt: "2px",
                   }}
                 >
-                  {appName.toUpperCase()}
+                  {appName?.toUpperCase()}
                 </MUITypography>
               )}
               {beta && (

--- a/src/v1/components/surfaces/AppBar/AppBar.tsx
+++ b/src/v1/components/surfaces/AppBar/AppBar.tsx
@@ -96,10 +96,9 @@ const AppBar: React.FC<AppBarProps> = ({
                     fontSize: 30,
                     fontWeight: 400,
                     pt: "2px",
-                    textTransform: "uppercase",
                   }}
                 >
-                  {appName}
+                  {appName.toUpperCase()}
                 </MUITypography>
               )}
               {beta && (


### PR DESCRIPTION
Ticket: https://telicent.atlassian.net/browse/TELFE-1065

### Goal

The issue was that the AppBar "link" couldn't be opened in a new tab via right-click ->"Open link in a new tab" or middle mouse click. 

This was caused by the the component handling navigation via `onClick`, which prevented the browser from treating as a normal link. 

This PR updates the component so that when a `href` is provided the brand area renders as an anchor element `<a>`.
 

<!-- The Goal. -->

### Work Completed

When `href` is provided the brand area now renders as  `<a>`. This allows native browser behaviour. 

While working on this I've also made a few improvements to make the layout and API more robust. 

Layout
Replaced the previous absolute positioning with a 3 column grid  layout (1fr auto 1fr)

Now that brand can be an anchor tag and be opened with _blank, I hardcoded `rel= "noopener noreferrer"` for secutiry and privacy. 

Improved Story documentation. 

Updated Unit Test. 
I've also tested locally using verdaccio on all our existing apps, this changes doesn't break anything. 

Other changes: Included figma file to some other components. 


https://github.com/user-attachments/assets/1c9fc96e-0506-40c5-9ac3-1e1d4eb2ecd4



---

<details>
  <summary><strong>🕵️ Review Guidance</strong></summary>

---

General guidance

- Generally, approve a PR if it makes the system better, even if it's not perfect. — [Google: The Standard of Code Review](https://google.github.io/eng-practices/review/reviewer/standard.html)
- The aim of both PR AUTHOR and PR REVIEWER is to get the code merged
- Aim for consensus, defined as _everyone can live with the outcome_
- PR with changes requires 2 approvals
- PR with no changes requires 1 approvals

For PR REVIEWER:

1. Read the ticket & description
2. [Review the code](https://google.github.io/eng-practices/review/reviewer/looking-for.html)
3. Request any changes that are essential.
4. For non-essential comments:
   - Use prefixes, e.g. "**nit:** change to Pascal case"
     - **nit:** small, non-essential change
     - **obs:** just an observation, doesn't affect the PR
     - **idea:** a suggestion to think about
     - **q:** questions
   - Use modifiers, e.g. "**obs**`[pr-owner-resolve]`: Jim is also editing this file"
     - `pr-author-resolve` PR author can resolve after reading
     - `pr-author-delete` (rare) delete after reading to avoid confusion
5. try to add _at least_ a helpful comment per ~500 lines; less if the PR is already busy

For PR AUTHOR:

1. Aim for enough detail in PR description for things to go smoothly
2. After requested changes, [re-request a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews#re-requesting-a-review) (so the PR shows up in [reviews-requested:@me](https://github.com/pulls?q=is%3Apr+is%3Aopen+archived%3Afalse+sort%3Aupdated-desc+review-requested%3A%40me+))

</details>
