### PR TITLE
feat!: add tertiary button and update buttons api

### DIFF
--- a/src/candidate-packages/authorize-flow-deprecated/AuthModal.tsx
+++ b/src/candidate-packages/authorize-flow-deprecated/AuthModal.tsx
@@ -48,10 +48,10 @@ export const AuthModal: React.FC<AuthRedirectModalProps> = ({ signOutUrl, deboun
         <Text>Please login again to continue.</Text>
         <Text sx={{ pt: 4 }}>If you continue to have issues, contact your system administrator.</Text>
         <FlexBox ml="auto" mt={2} gap={1} direction="row">
-          <Button color="primary" variant="outlined" disableElevation onClick={handleCloseClick} size="large">
+          <Button variant="secondary" disableElevation onClick={handleCloseClick} size="large">
             Close
           </Button>
-          <Button color="primary" variant="contained" onClick={handleLoginClick} size="large">
+          <Button variant="primary" onClick={handleLoginClick} size="large">
             Login
           </Button>
         </FlexBox>

--- a/src/candidate-packages/authorize-flow/components/AuthModal.tsx
+++ b/src/candidate-packages/authorize-flow/components/AuthModal.tsx
@@ -39,7 +39,7 @@ export const AuthModal: React.FC<AuthRedirectModalProps> = ({ debounceMs = 5000 
   };
 
   return (
-    <Modal hideCloseButton onClose={() => { }} sx={{ m: 2, p: 2 }} open={isOpen}>
+    <Modal hideCloseButton onClose={() => {}} sx={{ m: 2, p: 2 }} open={isOpen}>
       <FlexBox sx={{ p: 2, overflowY: "auto" }}>
         <H3>You are not signed in</H3>
         <Text sx={{ pt: 4 }}>
@@ -48,10 +48,10 @@ export const AuthModal: React.FC<AuthRedirectModalProps> = ({ debounceMs = 5000 
         <Text>Please login to continue.</Text>
         <Text sx={{ pt: 4 }}>If you continue to have issues, contact your system administrator.</Text>
         <FlexBox ml="auto" mt={2} gap={1} direction="row">
-          <Button color="primary" variant="outlined" disableElevation onClick={handleCloseClick} size="large">
+          <Button variant="secondary" disableElevation onClick={handleCloseClick} size="large">
             Close
           </Button>
-          <Button color="primary" variant="contained" onClick={handleLoginClick} size="large">
+          <Button variant="primary" onClick={handleLoginClick} size="large">
             Login
           </Button>
         </FlexBox>

--- a/src/component-library/Map/primitives/LayerSelector/composites/LayerSelectorInsetInMap/LayerSelectorInsetInMap.test.tsx
+++ b/src/component-library/Map/primitives/LayerSelector/composites/LayerSelectorInsetInMap/LayerSelectorInsetInMap.test.tsx
@@ -81,8 +81,7 @@ describe("PresentationalButton snapshotdiff", () => {
         {...base}
         selectedIndex={1}
         anchorEl={{} as any}
-        color="primary"
-        variant="contained"
+        variant="primary"
         sx={{ m: 1 }}
       />
     ).asFragment();
@@ -92,17 +91,16 @@ describe("PresentationalButton snapshotdiff", () => {
       - First value
       + Second value
 
-      @@ -4,39 +4,42 @@
+      @@ -4,39 +4,41 @@
           >
             <div
               class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-1ps6pg7-MuiPaper-root"
             >
               <button
       +         aria-describedby="layer-selector-popover"
-      +         color="primary"
                 id="layer-selector"
                 sx="[object Object]"
-      +         variant="contained"
+      +         variant="primary"
               >
                 <div
                   class="MuiBox-root css-1f388k3"

--- a/src/component-library/Map/primitives/LayerSelector/primitives/LayerSelectorPresentational.stories.tsx
+++ b/src/component-library/Map/primitives/LayerSelector/primitives/LayerSelectorPresentational.stories.tsx
@@ -16,7 +16,7 @@ const sampleData: LayerOption[] = [
 const Presentational: React.FC<PresentationalProps> = (props) => {
   return (
     <div>
-      <LayerSelectorPresentationalButton color="secondary" variant="outlined" {...props} />
+      <LayerSelectorPresentationalButton variant="secondary" {...props} />
       <style>
         {`
           body {

--- a/src/story-coverage.test.ts
+++ b/src/story-coverage.test.ts
@@ -64,6 +64,8 @@ it("looks for components that appear to be missing a story - snapshots these com
       "./src/v1/components/buttons/Button/IconButton.tsx",
       "./src/v1/components/buttons/Button/PrimaryButton.tsx",
       "./src/v1/components/buttons/Button/SecondaryButton.tsx",
+      "./src/v1/components/buttons/Button/TertiaryButton.tsx",
+      "./src/v1/components/buttons/Button/TextButoton.tsx",
       "./src/v1/components/data-display/DropdownButton/assets/TestIcons.tsx",
       "./src/v1/components/data-display/FontAwesomeIcons/ClockIcon.tsx",
       "./src/v1/components/data-display/FontAwesomeIcons/DownArrowIcon.tsx",

--- a/src/story-coverage.test.ts
+++ b/src/story-coverage.test.ts
@@ -65,6 +65,7 @@ it("looks for components that appear to be missing a story - snapshots these com
       "./src/v1/components/buttons/Button/PrimaryButton.tsx",
       "./src/v1/components/buttons/Button/SecondaryButton.tsx",
       "./src/v1/components/buttons/Button/TertiaryButton.tsx",
+      "./src/v1/components/buttons/Button/TextButton.tsx",
       "./src/v1/components/data-display/DropdownButton/assets/TestIcons.tsx",
       "./src/v1/components/data-display/FontAwesomeIcons/ClockIcon.tsx",
       "./src/v1/components/data-display/FontAwesomeIcons/DownArrowIcon.tsx",

--- a/src/story-coverage.test.ts
+++ b/src/story-coverage.test.ts
@@ -65,7 +65,6 @@ it("looks for components that appear to be missing a story - snapshots these com
       "./src/v1/components/buttons/Button/PrimaryButton.tsx",
       "./src/v1/components/buttons/Button/SecondaryButton.tsx",
       "./src/v1/components/buttons/Button/TertiaryButton.tsx",
-      "./src/v1/components/buttons/Button/TextButoton.tsx",
       "./src/v1/components/data-display/DropdownButton/assets/TestIcons.tsx",
       "./src/v1/components/data-display/FontAwesomeIcons/ClockIcon.tsx",
       "./src/v1/components/data-display/FontAwesomeIcons/DownArrowIcon.tsx",

--- a/src/v1/components/buttons/Button/Button.stories.tsx
+++ b/src/v1/components/buttons/Button/Button.stories.tsx
@@ -2,9 +2,10 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { fn } from "@storybook/test";
 import Box from "@mui/material/Box";
 
-import Button from "./Button";
+import Button, { ButtonProps } from "./Button";
 import DataSetIcon from "../../data-display/Icons/DataSetIcon";
 import { figmaDesign } from "../../../../../.storybook/figmaDesign";
+import { FlexBox } from "../../layout";
 
 const meta = {
   title: "Buttons/Button",
@@ -16,27 +17,43 @@ const meta = {
     docs: {
       description: {
         component: `
-A styled button component built on top of MUI’s \`<Button>\`, using our design system overrides. It supports standard variants (contained, outlined, text) as well as a custom \`style="base"\` variant.
+A styled button component built on top of MUI's \`<Button>\`, using our design system overrides.
+
+---
+
+### Supported Variants
+
+**Standard MUI Variants:**
+- \`contained\`, \`outlined\`, \`text\` - standard MUI variants, work with \`color\` prop
+
+**Custom Design System Variants:**
+- \`primary\` - main action button (contained + primary color)
+- \`secondary\` - secondary action button (contained + secondary color)
+- \`tertiary\` - tertiary action button with neutral grey (outlined + custom tertiary color)
 
 ---
 
 ### Supported Props
 
-- **Variants:** \`contained\`, \`outlined\`, \`text\`
-- **Styles:** Our \`style="base"\` prop render a base button with no styles at all.
+- **Variants:** \`contained\`, \`outlined\`, \`text\`, \`primary\`, \`secondary\`, \`tertiary\`
+- **Colors:** \`primary\`, \`secondary\`, \`error\`, \`info\`, \`success\`, \`warning\` (for standard MUI variants)
 - **Sizes:** \`small\`, \`medium\`, \`large\`
-- **Icons:** Use \`startIcon\` or \`endIcon\` to enhance buttons visually.
-- **Disable Elevation:** Optional \`disableElevation\` removes box-shadow.
-- **Full Width:** Use \`fullWidth\` for block-style buttons.
+- **Icons:** Use \`startIcon\` or \`endIcon\` to enhance buttons visually
+- **Style:** Use \`style="base"\` to render an unstyled button
+- **Full Width:** Use \`fullWidth\` for block-style buttons
 
 ---
 
 ### Example
 
 \`\`\`tsx
-<Button variant="contained" color="primary">
-  Text
-</Button>
+// Standard MUI
+<Button variant="contained" color="primary">Text</Button>
+
+// Custom variants
+<Button variant="primary">Primary</Button>
+<Button variant="secondary">Secondary</Button>
+<Button variant="tertiary">Tertiary</Button>
 \`\`\`
         `,
       },
@@ -58,17 +75,16 @@ A styled button component built on top of MUI’s \`<Button>\`, using our design
 } satisfies Meta<typeof Button>;
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<ButtonProps>;
 
 export const Primary: Story = {
   args: {
-    color: "primary",
-    variant: "contained",
+    variant: "primary",
   },
   parameters: {
     docs: {
       description: {
-        story: "To match Primary style in the design use `color=primary ` and `variant=contained`",
+        story: 'Primary button using custom variant `variant="primary"`',
       },
     },
   },
@@ -76,39 +92,63 @@ export const Primary: Story = {
 
 export const Secondary: Story = {
   args: {
-    color: "primary",
-    variant: "outlined",
+    variant: "secondary",
   },
   parameters: {
     docs: {
       description: {
-        story: "To match Secondary style in the design use `color=primary ` and `variant=outlined`",
+        story: 'Secondary button using custom variant `variant="secondary"`',
       },
     },
   },
 };
 
-export const Text: Story = {
+export const Tertiary: Story = {
+  args: {
+    variant: "tertiary",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Tertiary button using custom variant `variant="tertiary"` - uses neutral grey color',
+      },
+    },
+  },
+};
+
+export const StandardMUIVariants: Story = {
   render: (args) => (
     <>
-      <Button variant="text">{args.children}</Button>
-      <Button variant="text" disabled>
-        {args.children}
+      <Button variant="contained" color="primary">
+        Contained Primary
+      </Button>
+      <Button variant="outlined" color="primary">
+        Outlined Primary
+      </Button>
+      <Button variant="text" color="primary">
+        Text Primary
       </Button>
     </>
   ),
+  parameters: {
+    docs: {
+      description: {
+        story: "Standard MUI variants (contained, outlined, text) with color prop",
+      },
+    },
+  },
 };
 
 export const Sizes: Story = {
   render: (args) => (
     <>
-      <Button size="large" variant="contained">
+      <Button size="large" variant="primary">
         {args.children}
       </Button>
-      <Button size="medium" variant="contained">
+      <Button size="medium" variant="primary">
         {args.children}
       </Button>
-      <Button size="small" variant="contained">
+      <Button size="small" variant="primary">
         {args.children}
       </Button>
     </>
@@ -123,11 +163,19 @@ export const Sizes: Story = {
 };
 
 export const StartIcon: Story = {
-  args: {
-    color: "primary",
-    variant: "contained",
-    startIcon: <DataSetIcon />,
-  },
+  render: (args) => (
+    <>
+      <Button variant="primary" startIcon={<DataSetIcon />}>
+        Primary Button
+      </Button>
+      <Button variant="secondary" startIcon={<DataSetIcon />}>
+        Secondary Button
+      </Button>
+      <Button variant="tertiary" startIcon={<DataSetIcon />}>
+        Tertiary Button
+      </Button>
+    </>
+  ),
   parameters: {
     docs: {
       description: {
@@ -138,25 +186,42 @@ export const StartIcon: Story = {
 };
 
 export const EndIcon: Story = {
-  args: {
-    color: "primary",
-    variant: "contained",
-    endIcon: <DataSetIcon />,
-  },
+  render: (args) => (
+    <>
+      <Button variant="primary" endIcon={<DataSetIcon />}>
+        Primary Button
+      </Button>
+      <Button variant="secondary" endIcon={<DataSetIcon />}>
+        Secondary Button
+      </Button>
+      <Button variant="tertiary" endIcon={<DataSetIcon />}>
+        Tertiary Button
+      </Button>
+    </>
+  ),
   parameters: {
     docs: {
       description: {
-        story: "Use `endIcon={<IconComponent />}` to place it after the label",
+        story: "Use `endIcon={<IconComponent />}` to place an icon after the button label",
       },
     },
   },
 };
 
 export const FullWidth: Story = {
-  args: {
-    fullWidth: true,
-    variant: "contained",
-  },
+  render: (args) => (
+    <FlexBox direction="column" spacing={2}>
+      <Button variant="primary" fullWidth>
+        Primary Button
+      </Button>
+      <Button variant="secondary" fullWidth>
+        Secondary Button
+      </Button>
+      <Button variant="tertiary" fullWidth>
+        Tertiary Button
+      </Button>
+    </FlexBox>
+  ),
   parameters: {
     docs: {
       description: {

--- a/src/v1/components/buttons/Button/Button.stories.tsx
+++ b/src/v1/components/buttons/Button/Button.stories.tsx
@@ -23,55 +23,48 @@ A styled button component built on top of MUI's \`<Button>\`, using our design s
 
 ### Supported Variants
 
-**Standard MUI Variants:**
-- \`contained\`, \`outlined\`, \`text\` - standard MUI variants, work with \`color\` prop
-
-**Custom Design System Variants:**
-- \`primary\` - main action button (contained + primary color)
-- \`secondary\` - secondary action button (contained + secondary color)
-- \`tertiary\` - tertiary action button with neutral grey (outlined + custom tertiary color)
+- \`primary\` - main action button
+- \`secondary\` - secondary action button
+- \`tertiary\` - tertiary action button with neutral colour
+- \`base\` - unstyled button base
 
 ---
 
 ### Supported Props
 
-- **Variants:** \`contained\`, \`outlined\`, \`text\`, \`primary\`, \`secondary\`, \`tertiary\`
-- **Colors:** \`primary\`, \`secondary\`, \`error\`, \`info\`, \`success\`, \`warning\` (for standard MUI variants)
+- **Variants:** \`primary\`, \`secondary\`, \`tertiary\`, \`base\`
 - **Sizes:** \`small\`, \`medium\`, \`large\`
 - **Icons:** Use \`startIcon\` or \`endIcon\` to enhance buttons visually
-- **Style:** Use \`style="base"\` to render an unstyled button
 - **Full Width:** Use \`fullWidth\` for block-style buttons
+- **SX Overrides:** Use \`sx\` for small visual adjustments where needed
 
 ---
 
 ### Example
 
 \`\`\`tsx
-// Standard MUI
-<Button variant="contained" color="primary">Text</Button>
-
-// Custom variants
 <Button variant="primary">Primary</Button>
 <Button variant="secondary">Secondary</Button>
 <Button variant="tertiary">Tertiary</Button>
+<Button variant="base">Base</Button>
 \`\`\`
         `,
       },
     },
   },
   tags: ["autodocs"],
-  args: { children: "Button", onClick: fn(), color: "primary", variant: "contained" },
+  args: {
+    children: "Button",
+    onClick: fn(),
+    variant: "primary",
+  },
   argTypes: {
-    color: {
-      control: "select",
-      options: ["primary", "secondary", "error", "info", "success", "warning"],
-    },
     variant: {
       control: "select",
-      options: ["contained", "outlined", "text"],
+      options: ["primary", "secondary", "tertiary", "base"],
     },
   },
-  decorators: (Story) => <Box sx={{ button: { marginInline: 2 }, a: { marginInline: 2 } }}>{Story()}</Box>,
+  decorators: [(Story) => <Box sx={{ button: { marginInline: 2 }, a: { marginInline: 2 } }}>{Story()}</Box>],
 } satisfies Meta<typeof Button>;
 
 export default meta;
@@ -84,7 +77,7 @@ export const Primary: Story = {
   parameters: {
     docs: {
       description: {
-        story: 'Primary button using custom variant `variant="primary"`',
+        story: 'Primary button using `variant="primary"`',
       },
     },
   },
@@ -97,7 +90,7 @@ export const Secondary: Story = {
   parameters: {
     docs: {
       description: {
-        story: 'Secondary button using custom variant `variant="secondary"`',
+        story: 'Secondary button using `variant="secondary"`',
       },
     },
   },
@@ -110,30 +103,20 @@ export const Tertiary: Story = {
   parameters: {
     docs: {
       description: {
-        story: 'Tertiary button using custom variant `variant="tertiary"` - uses neutral grey color',
+        story: 'Tertiary button using `variant="tertiary"`',
       },
     },
   },
 };
 
-export const StandardMUIVariants: Story = {
-  render: (args) => (
-    <>
-      <Button variant="contained" color="primary">
-        Contained Primary
-      </Button>
-      <Button variant="outlined" color="primary">
-        Outlined Primary
-      </Button>
-      <Button variant="text" color="primary">
-        Text Primary
-      </Button>
-    </>
-  ),
+export const Base: Story = {
+  args: {
+    variant: "base",
+  },
   parameters: {
     docs: {
       description: {
-        story: "Standard MUI variants (contained, outlined, text) with color prop",
+        story: 'Base button using `variant="base"`',
       },
     },
   },
@@ -163,7 +146,7 @@ export const Sizes: Story = {
 };
 
 export const StartIcon: Story = {
-  render: (args) => (
+  render: () => (
     <>
       <Button variant="primary" startIcon={<DataSetIcon />}>
         Primary Button
@@ -179,14 +162,14 @@ export const StartIcon: Story = {
   parameters: {
     docs: {
       description: {
-        story: "Use `startIcon={<IconComponent />}` to place an icon before the button label",
+        story: "Use `startIcon={<IconComponent />}` to place an icon before the button label.",
       },
     },
   },
 };
 
 export const EndIcon: Story = {
-  render: (args) => (
+  render: () => (
     <>
       <Button variant="primary" endIcon={<DataSetIcon />}>
         Primary Button
@@ -202,14 +185,14 @@ export const EndIcon: Story = {
   parameters: {
     docs: {
       description: {
-        story: "Use `endIcon={<IconComponent />}` to place an icon after the button label",
+        story: "Use `endIcon={<IconComponent />}` to place an icon after the button label.",
       },
     },
   },
 };
 
 export const FullWidth: Story = {
-  render: (args) => (
+  render: () => (
     <FlexBox direction="column" spacing={2}>
       <Button variant="primary" fullWidth>
         Primary Button
@@ -225,7 +208,31 @@ export const FullWidth: Story = {
   parameters: {
     docs: {
       description: {
-        story: `Normally buttons will fill the container - including full width containers. All of these stories are surrounded by a <Box />, which constrains width. You can use \`fullWidth\` to push the box out.`,
+        story:
+          "Normally buttons will fill the container, including full width containers. These stories are surrounded by a constrained container, so `fullWidth` makes the button stretch to fill it.",
+      },
+    },
+  },
+};
+
+export const SXOverrides: Story = {
+  render: () => (
+    <>
+      <Button variant="primary" sx={{ minWidth: 220 }}>
+        Wider Primary Button
+      </Button>
+      <Button variant="secondary" sx={{ borderRadius: 8 }}>
+        Rounded Secondary Button
+      </Button>
+      <Button variant="tertiary" sx={{ px: 4 }}>
+        Padded Tertiary Button
+      </Button>
+    </>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "Use `sx` for small visual adjustments without changing the core variant styling.",
       },
     },
   },

--- a/src/v1/components/buttons/Button/Button.stories.tsx
+++ b/src/v1/components/buttons/Button/Button.stories.tsx
@@ -109,6 +109,19 @@ export const Tertiary: Story = {
   },
 };
 
+export const Text: Story = {
+  args: {
+    variant: "text",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Tertiary button using `variant="tertiary"`',
+      },
+    },
+  },
+};
+
 export const Base: Story = {
   args: {
     variant: "base",

--- a/src/v1/components/buttons/Button/Button.test.tsx
+++ b/src/v1/components/buttons/Button/Button.test.tsx
@@ -2,7 +2,10 @@ import React from "react";
 import { render, cleanup } from "@testing-library/react";
 
 import Button, { ButtonProps } from "./Button";
-import { cleanHtmlDiff, cleanSerializedDiff } from "../../../../candidate-packages/clean-diff";
+import {
+  cleanHtmlDiff,
+  cleanSerializedDiff,
+} from "../../../../candidate-packages/clean-diff";
 
 describe("Button", () => {
   let props: ButtonProps;
@@ -61,11 +64,13 @@ describe("Button", () => {
         letter-spacing: 0.02857em;
         text-transform: uppercase;
         min-width: 64px;
-        padding: 6px 8px;
+        padding: 6px 16px;
         border-radius: 4px;
         -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
         transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
-        color: #1976d2;
+        color: #fff;
+        background-color: #1976d2;
+        box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
       }
 
       .emotion-0::-moz-focus-inner {
@@ -87,17 +92,28 @@ describe("Button", () => {
       .emotion-0:hover {
         -webkit-text-decoration: none;
         text-decoration: none;
-        background-color: rgba(25, 118, 210, 0.04);
+        background-color: #1565c0;
+        box-shadow: 0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12);
       }
 
       @media (hover: none) {
         .emotion-0:hover {
-          background-color: transparent;
+          background-color: #1976d2;
         }
+      }
+
+      .emotion-0:active {
+        box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
+      }
+
+      .emotion-0.Mui-focusVisible {
+        box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
       }
 
       .emotion-0.Mui-disabled {
         color: rgba(0, 0, 0, 0.26);
+        box-shadow: none;
+        background-color: rgba(0, 0, 0, 0.12);
       }
 
       .emotion-1 {
@@ -113,7 +129,7 @@ describe("Button", () => {
       }
 
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary emotion-0"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary emotion-0"
         tabindex="0"
         type="button"
       >
@@ -126,61 +142,57 @@ describe("Button", () => {
   });
 
   it("primary variant diff", () => {
-    const { container } = render(<Button {...props} color="primary" variant="contained" />);
-    expect(cleanSerializedDiff(baseEl, container.firstChild)).toMatchInlineSnapshot(`
+    const { container } = render(
+      <Button {...props} color="primary" variant="contained" />
+    );
+    expect(cleanSerializedDiff(baseEl, container.firstChild))
+      .toMatchInlineSnapshot(`
       "- 
       + 
 
-      @@ --- --- @@
-      - padding: 6px 8px;
-      + padding: 6px 16px;
-      @@ --- --- @@
-      - color: #1976d2;
-      + color: #fff;
-      + background-color: #1976d2;
-      + box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
-      @@ --- --- @@
-      - background-color: rgba(25, 118, 210, 0.04);
-      + background-color: #1565c0;
-      + box-shadow: 0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12);
-      @@ --- --- @@
-      - background-color: transparent;
-      + background-color: #1976d2;
-      + }
-      + }
-      +
-      + .emotion-0:active {
-      + box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
-      @@ --- --- @@
-      +
-      + .emotion-0.Mui-focusVisible {
-      + box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
-      @@ --- --- @@
-      + box-shadow: none;
-      + background-color: rgba(0, 0, 0, 0.12);
       @@ --- --- @@
       - {Symbol(SameObject caches): [Object]}"
     `);
   });
 
   it("secondary variant diff", () => {
-    const { container } = render(<Button {...props} color="secondary" variant="outlined" />);
-    expect(cleanSerializedDiff(baseEl, container.firstChild)).toMatchInlineSnapshot(`
+    const { container } = render(
+      <Button {...props} color="secondary" variant="outlined" />
+    );
+    expect(cleanSerializedDiff(baseEl, container.firstChild))
+      .toMatchInlineSnapshot(`
       "- 
       + 
 
       @@ --- --- @@
-      - padding: 6px 8px;
+      - padding: 6px 16px;
       + padding: 5px 15px;
       @@ --- --- @@
-      - color: #1976d2;
+      - color: #fff;
+      - background-color: #1976d2;
+      - box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
       + border: 1px solid rgba(156, 39, 176, 0.5);
       + color: #9c27b0;
       @@ --- --- @@
-      - background-color: rgba(25, 118, 210, 0.04);
+      - background-color: #1565c0;
+      - box-shadow: 0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12);
       + background-color: rgba(156, 39, 176, 0.04);
       + border: 1px solid #9c27b0;
       @@ --- --- @@
+      - background-color: #1976d2;
+      - }
+      + background-color: transparent;
+      @@ --- --- @@
+      -
+      - .emotion-0:active {
+      - box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
+      - }
+      -
+      - .emotion-0.Mui-focusVisible {
+      - box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
+      @@ --- --- @@
+      - box-shadow: none;
+      - background-color: rgba(0, 0, 0, 0.12);
       + border: 1px solid rgba(0, 0, 0, 0.12);
       @@ --- --- @@
       - {Symbol(SameObject caches): [Object]}"
@@ -189,7 +201,8 @@ describe("Button", () => {
 
   it("noStyle variant diff", () => {
     const { container } = render(<Button {...props} style="base" />);
-    expect(cleanSerializedDiff(baseEl, container.firstChild)).toMatchInlineSnapshot(`
+    expect(cleanSerializedDiff(baseEl, container.firstChild))
+      .toMatchInlineSnapshot(`
       "- 
       + 
 
@@ -201,27 +214,40 @@ describe("Button", () => {
       - letter-spacing: 0.02857em;
       - text-transform: uppercase;
       - min-width: 64px;
-      - padding: 6px 8px;
+      - padding: 6px 16px;
       - border-radius: 4px;
       - -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
       - transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
-      - color: #1976d2;
+      - color: #fff;
+      - background-color: #1976d2;
+      - box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
       @@ --- --- @@
-      - }
       - }
       -
       - .emotion-0:hover {
       - -webkit-text-decoration: none;
       - text-decoration: none;
-      - background-color: rgba(25, 118, 210, 0.04);
-      - }
-      -
+      - background-color: #1565c0;
+      - box-shadow: 0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12);
+      @@ --- --- @@
       - @media (hover: none) {
       - .emotion-0:hover {
-      - background-color: transparent;
-      @@ --- --- @@
+      - background-color: #1976d2;
+      - }
+      - }
+      -
+      - .emotion-0:active {
+      - box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
+      - }
+      -
+      - .emotion-0.Mui-focusVisible {
+      - box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
+      - }
+      -
       - .emotion-0.Mui-disabled {
       - color: rgba(0, 0, 0, 0.26);
+      - box-shadow: none;
+      - background-color: rgba(0, 0, 0, 0.12);
       - }
       -
       @@ --- --- @@
@@ -230,19 +256,14 @@ describe("Button", () => {
   });
 
   it("unknown variant falls back to text diff", () => {
-    const { container } = render(<Button {...(props as any)} variant="unknown" />);
-    expect(cleanSerializedDiff(baseEl, container.firstChild)).toMatchInlineSnapshot(`
+    const { container } = render(
+      <Button {...(props as any)} variant="unknown" />
+    );
+    expect(cleanSerializedDiff(baseEl, container.firstChild))
+      .toMatchInlineSnapshot(`
       "- 
       + 
 
-      @@ --- --- @@
-      - padding: 6px 8px;
-      + padding: 6px 16px;
-      @@ --- --- @@
-      - color: #1976d2;
-      @@ --- --- @@
-      - background-color: rgba(25, 118, 210, 0.04);
-      + background-color: rgba(0, 0, 0, 0.04);
       @@ --- --- @@
       - {Symbol(SameObject caches): [Object]}"
     `);
@@ -250,7 +271,9 @@ describe("Button", () => {
 
   it("forwards ref and props", () => {
     const ref = React.createRef<HTMLButtonElement>();
-    const { getByText } = render(<Button {...props} size="small" disabled ref={ref} data-test="foo" />);
+    const { getByText } = render(
+      <Button {...props} size="small" disabled ref={ref} data-test="foo" />
+    );
     expect(getByText("Test Button")).toHaveAttribute("data-test", "foo");
     expect(ref.current).toBeInstanceOf(HTMLButtonElement);
   });

--- a/src/v1/components/buttons/Button/Button.test.tsx
+++ b/src/v1/components/buttons/Button/Button.test.tsx
@@ -2,7 +2,10 @@ import React from "react";
 import { render, cleanup } from "@testing-library/react";
 
 import Button, { ButtonProps } from "./Button";
-import { cleanHtmlDiff, cleanSerializedDiff } from "../../../../candidate-packages/clean-diff";
+import {
+  cleanHtmlDiff,
+  cleanSerializedDiff,
+} from "../../../../candidate-packages/clean-diff";
 
 describe("Button", () => {
   let props: ButtonProps;
@@ -140,7 +143,8 @@ describe("Button", () => {
 
   it("primary variant diff", () => {
     const { container } = render(<Button {...props} variant="primary" />);
-    expect(cleanSerializedDiff(baseEl, container.firstChild)).toMatchInlineSnapshot(`
+    expect(cleanSerializedDiff(baseEl, container.firstChild))
+      .toMatchInlineSnapshot(`
       "- 
       + 
 
@@ -151,19 +155,41 @@ describe("Button", () => {
 
   it("secondary variant diff", () => {
     const { container } = render(<Button {...props} variant="secondary" />);
-    expect(cleanSerializedDiff(baseEl, container.firstChild)).toMatchInlineSnapshot(`
+    expect(cleanSerializedDiff(baseEl, container.firstChild))
+      .toMatchInlineSnapshot(`
       "- 
       + 
 
       @@ --- --- @@
+      - padding: 6px 16px;
+      + padding: 5px 15px;
+      @@ --- --- @@
+      - color: #fff;
       - background-color: #1976d2;
-      + background-color: #9c27b0;
+      - box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
+      + border: 1px solid rgba(25, 118, 210, 0.5);
+      + color: #1976d2;
       @@ --- --- @@
       - background-color: #1565c0;
-      + background-color: #7b1fa2;
+      - box-shadow: 0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12);
+      + background-color: rgba(25, 118, 210, 0.04);
+      + border: 1px solid #1976d2;
       @@ --- --- @@
       - background-color: #1976d2;
-      + background-color: #9c27b0;
+      - }
+      + background-color: transparent;
+      @@ --- --- @@
+      -
+      - .emotion-0:active {
+      - box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
+      - }
+      -
+      - .emotion-0.Mui-focusVisible {
+      - box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
+      @@ --- --- @@
+      - box-shadow: none;
+      - background-color: rgba(0, 0, 0, 0.12);
+      + border: 1px solid rgba(0, 0, 0, 0.12);
       @@ --- --- @@
       - {Symbol(SameObject caches): [Object]}"
     `);
@@ -171,7 +197,8 @@ describe("Button", () => {
 
   it("noStyle variant diff", () => {
     const { container } = render(<Button {...props} variant="base" />);
-    expect(cleanSerializedDiff(baseEl, container.firstChild)).toMatchInlineSnapshot(`
+    expect(cleanSerializedDiff(baseEl, container.firstChild))
+      .toMatchInlineSnapshot(`
       "- 
       + 
 
@@ -225,8 +252,11 @@ describe("Button", () => {
   });
 
   it("unknown variant falls back to text diff", () => {
-    const { container } = render(<Button {...(props as any)} variant="unknown" />);
-    expect(cleanSerializedDiff(baseEl, container.firstChild)).toMatchInlineSnapshot(`
+    const { container } = render(
+      <Button {...(props as any)} variant="unknown" />
+    );
+    expect(cleanSerializedDiff(baseEl, container.firstChild))
+      .toMatchInlineSnapshot(`
       "- 
       + 
 
@@ -237,7 +267,9 @@ describe("Button", () => {
 
   it("forwards ref and props", () => {
     const ref = React.createRef<HTMLButtonElement>();
-    const { getByText } = render(<Button {...props} size="small" disabled ref={ref} data-test="foo" />);
+    const { getByText } = render(
+      <Button {...props} size="small" disabled ref={ref} data-test="foo" />
+    );
     expect(getByText("Test Button")).toHaveAttribute("data-test", "foo");
     expect(ref.current).toBeInstanceOf(HTMLButtonElement);
   });

--- a/src/v1/components/buttons/Button/Button.test.tsx
+++ b/src/v1/components/buttons/Button/Button.test.tsx
@@ -2,10 +2,7 @@ import React from "react";
 import { render, cleanup } from "@testing-library/react";
 
 import Button, { ButtonProps } from "./Button";
-import {
-  cleanHtmlDiff,
-  cleanSerializedDiff,
-} from "../../../../candidate-packages/clean-diff";
+import { cleanHtmlDiff, cleanSerializedDiff } from "../../../../candidate-packages/clean-diff";
 
 describe("Button", () => {
   let props: ButtonProps;
@@ -142,11 +139,8 @@ describe("Button", () => {
   });
 
   it("primary variant diff", () => {
-    const { container } = render(
-      <Button {...props} color="primary" variant="contained" />
-    );
-    expect(cleanSerializedDiff(baseEl, container.firstChild))
-      .toMatchInlineSnapshot(`
+    const { container } = render(<Button {...props} variant="primary" />);
+    expect(cleanSerializedDiff(baseEl, container.firstChild)).toMatchInlineSnapshot(`
       "- 
       + 
 
@@ -156,11 +150,8 @@ describe("Button", () => {
   });
 
   it("secondary variant diff", () => {
-    const { container } = render(
-      <Button {...props} color="secondary" variant="outlined" />
-    );
-    expect(cleanSerializedDiff(baseEl, container.firstChild))
-      .toMatchInlineSnapshot(`
+    const { container } = render(<Button {...props} variant="secondary" />);
+    expect(cleanSerializedDiff(baseEl, container.firstChild)).toMatchInlineSnapshot(`
       "- 
       + 
 
@@ -180,8 +171,7 @@ describe("Button", () => {
 
   it("noStyle variant diff", () => {
     const { container } = render(<Button {...props} variant="base" />);
-    expect(cleanSerializedDiff(baseEl, container.firstChild))
-      .toMatchInlineSnapshot(`
+    expect(cleanSerializedDiff(baseEl, container.firstChild)).toMatchInlineSnapshot(`
       "- 
       + 
 
@@ -235,11 +225,8 @@ describe("Button", () => {
   });
 
   it("unknown variant falls back to text diff", () => {
-    const { container } = render(
-      <Button {...(props as any)} variant="unknown" />
-    );
-    expect(cleanSerializedDiff(baseEl, container.firstChild))
-      .toMatchInlineSnapshot(`
+    const { container } = render(<Button {...(props as any)} variant="unknown" />);
+    expect(cleanSerializedDiff(baseEl, container.firstChild)).toMatchInlineSnapshot(`
       "- 
       + 
 
@@ -250,9 +237,7 @@ describe("Button", () => {
 
   it("forwards ref and props", () => {
     const ref = React.createRef<HTMLButtonElement>();
-    const { getByText } = render(
-      <Button {...props} size="small" disabled ref={ref} data-test="foo" />
-    );
+    const { getByText } = render(<Button {...props} size="small" disabled ref={ref} data-test="foo" />);
     expect(getByText("Test Button")).toHaveAttribute("data-test", "foo");
     expect(ref.current).toBeInstanceOf(HTMLButtonElement);
   });

--- a/src/v1/components/buttons/Button/Button.test.tsx
+++ b/src/v1/components/buttons/Button/Button.test.tsx
@@ -165,42 +165,21 @@ describe("Button", () => {
       + 
 
       @@ --- --- @@
-      - padding: 6px 16px;
-      + padding: 5px 15px;
-      @@ --- --- @@
-      - color: #fff;
       - background-color: #1976d2;
-      - box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
-      + border: 1px solid rgba(156, 39, 176, 0.5);
-      + color: #9c27b0;
+      + background-color: #9c27b0;
       @@ --- --- @@
       - background-color: #1565c0;
-      - box-shadow: 0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12);
-      + background-color: rgba(156, 39, 176, 0.04);
-      + border: 1px solid #9c27b0;
+      + background-color: #7b1fa2;
       @@ --- --- @@
       - background-color: #1976d2;
-      - }
-      + background-color: transparent;
-      @@ --- --- @@
-      -
-      - .emotion-0:active {
-      - box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
-      - }
-      -
-      - .emotion-0.Mui-focusVisible {
-      - box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
-      @@ --- --- @@
-      - box-shadow: none;
-      - background-color: rgba(0, 0, 0, 0.12);
-      + border: 1px solid rgba(0, 0, 0, 0.12);
+      + background-color: #9c27b0;
       @@ --- --- @@
       - {Symbol(SameObject caches): [Object]}"
     `);
   });
 
   it("noStyle variant diff", () => {
-    const { container } = render(<Button {...props} style="base" />);
+    const { container } = render(<Button {...props} variant="base" />);
     expect(cleanSerializedDiff(baseEl, container.firstChild))
       .toMatchInlineSnapshot(`
       "- 

--- a/src/v1/components/buttons/Button/Button.tsx
+++ b/src/v1/components/buttons/Button/Button.tsx
@@ -5,8 +5,9 @@ import { ButtonVariant } from "../../../tokens/button-variants";
 import PrimaryButton from "./PrimaryButton";
 import SecondaryButton from "./SecondaryButton";
 import TertiaryButton from "./TertiaryButton";
+import TextButton from "./TextButton";
 
-type SupportedVariant = ButtonVariant | "base";
+type SupportedVariant = ButtonVariant;
 
 export type ButtonProps = Omit<MUIButtonProps, "variant"> &
   Omit<ButtonBaseProps, "style"> & {
@@ -30,6 +31,10 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
 
   if (variant === "tertiary") {
     return <TertiaryButton {...buttonProps} ref={ref} />;
+  }
+
+  if (variant === "text") {
+    return <TextButton {...buttonProps} ref={ref} />;
   }
 
   return <PrimaryButton {...buttonProps} ref={ref} />;

--- a/src/v1/components/buttons/Button/Button.tsx
+++ b/src/v1/components/buttons/Button/Button.tsx
@@ -1,21 +1,64 @@
 import React, { forwardRef } from "react";
-import MUIButton, { ButtonProps as MUIButtonProps, ButtonPropsVariantOverrides } from "@mui/material/Button";
-import { ButtonBase } from "@mui/material";
+import { ButtonBase, ButtonBaseProps } from "@mui/material";
+import MUIButton, { ButtonProps as MUIButtonProps } from "@mui/material/Button";
+import { ButtonVariant } from "../../../tokens/button-variants";
+import PrimaryButton from "./PrimaryButton";
+import SecondaryButton from "./SecondaryButton";
+import TertiaryButton from "./TertiaryButton";
 
-export type ButtonProps = MUIButtonProps & {
-  style?: "base";
+type LegacyVariant = "text" | "outlined" | "contained";
+type SupportedVariant = ButtonVariant | LegacyVariant;
+
+type BaseButtonProps = ButtonBaseProps & {
+  /**
+   * Legacy compatibility prop.
+   * Kept because existing apps rely on style="base".
+   */
+  style: "base";
+  variant?: SupportedVariant;
 };
 
+type DSButtonProps = Omit<MUIButtonProps, "variant"> & {
+  variant?: SupportedVariant;
+  style?: undefined;
+};
+
+export type ButtonProps = BaseButtonProps | DSButtonProps;
+
+const LEGACY_VARIANTS = ["text", "outlined", "contained"] as const;
+
+const isLegacyVariant = (variant: SupportedVariant): variant is LegacyVariant =>
+  LEGACY_VARIANTS.includes(variant as LegacyVariant);
+
 const Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
-  const { color = "primary", style, ...buttonProps } = props;
+  if (props.style === "base") {
+    const { style, variant, ...buttonBaseProps } = props;
+    return <ButtonBase {...buttonBaseProps} ref={ref} />;
+  }
 
-  if (style === "base") return <ButtonBase {...buttonProps} ref={ref} />;
+  const { variant = "primary", ...buttonProps } = props;
 
-  return (
-    <MUIButton color={color} {...buttonProps} ref={ref}>
-      {buttonProps.children}
-    </MUIButton>
-  );
+  // Legacy passthrough (do NOT touch behavior until we stop using legacy variants in the apps)
+  if (isLegacyVariant(variant)) {
+    return <MUIButton {...buttonProps} ref={ref} variant={variant} />;
+  }
+
+  if (variant === "primary") {
+    return <PrimaryButton {...buttonProps} ref={ref} />;
+  }
+
+  if (variant === "secondary") {
+    return <SecondaryButton {...buttonProps} ref={ref} />;
+  }
+
+  if (variant === "tertiary") {
+    return <TertiaryButton {...buttonProps} ref={ref} />;
+  }
+
+  // Fallback (should never really happen, but keeps TS happy and UI safe)
+  return <PrimaryButton {...buttonProps} ref={ref} />;
 });
+
+Button.displayName = "Button";
 
 export default Button;

--- a/src/v1/components/buttons/Button/Button.tsx
+++ b/src/v1/components/buttons/Button/Button.tsx
@@ -1,40 +1,23 @@
 import React, { forwardRef } from "react";
 import { ButtonBase, ButtonBaseProps } from "@mui/material";
-import MUIButton, { ButtonProps as MUIButtonProps } from "@mui/material/Button";
+import { ButtonProps as MUIButtonProps } from "@mui/material/Button";
 import { ButtonVariant } from "../../../tokens/button-variants";
 import PrimaryButton from "./PrimaryButton";
 import SecondaryButton from "./SecondaryButton";
 import TertiaryButton from "./TertiaryButton";
 
-type LegacyVariant = "text" | "outlined" | "contained";
-type SupportedVariant = ButtonVariant | LegacyVariant;
+type SupportedVariant = ButtonVariant | "base";
 
-export type ButtonProps = Omit<MUIButtonProps, "variant"> & {
-  variant?: SupportedVariant;
-  /**
-   * Legacy compatibility prop.
-   * Kept because existing apps rely on style="base".
-   */
-  style?: MUIButtonProps["style"] | "base";
-};
-
-const LEGACY_VARIANTS = ["text", "outlined", "contained"] as const;
-
-const isLegacyVariant = (variant: SupportedVariant): variant is LegacyVariant =>
-  LEGACY_VARIANTS.includes(variant as LegacyVariant);
+export type ButtonProps = Omit<MUIButtonProps, "variant"> &
+  Omit<ButtonBaseProps, "style"> & {
+    variant?: SupportedVariant;
+  };
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
-  if (props.style === "base") {
-    const { style, variant, ...buttonBaseProps } = props;
-
-    return <ButtonBase {...(buttonBaseProps as ButtonBaseProps)} ref={ref} />;
-  }
-
   const { variant = "primary", ...buttonProps } = props;
 
-  // Legacy passthrough (do NOT touch behavior until we stop using legacy variants in the apps)
-  if (isLegacyVariant(variant)) {
-    return <MUIButton {...buttonProps} ref={ref} variant={variant} />;
+  if (variant === "base") {
+    return <ButtonBase {...buttonProps} ref={ref} />;
   }
 
   if (variant === "primary") {

--- a/src/v1/components/buttons/Button/Button.tsx
+++ b/src/v1/components/buttons/Button/Button.tsx
@@ -9,21 +9,14 @@ import TertiaryButton from "./TertiaryButton";
 type LegacyVariant = "text" | "outlined" | "contained";
 type SupportedVariant = ButtonVariant | LegacyVariant;
 
-type BaseButtonProps = ButtonBaseProps & {
+export type ButtonProps = Omit<MUIButtonProps, "variant"> & {
+  variant?: SupportedVariant;
   /**
    * Legacy compatibility prop.
    * Kept because existing apps rely on style="base".
    */
-  style: "base";
-  variant?: SupportedVariant;
+  style?: MUIButtonProps["style"] | "base";
 };
-
-type DSButtonProps = Omit<MUIButtonProps, "variant"> & {
-  variant?: SupportedVariant;
-  style?: undefined;
-};
-
-export type ButtonProps = BaseButtonProps | DSButtonProps;
 
 const LEGACY_VARIANTS = ["text", "outlined", "contained"] as const;
 
@@ -33,7 +26,8 @@ const isLegacyVariant = (variant: SupportedVariant): variant is LegacyVariant =>
 const Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
   if (props.style === "base") {
     const { style, variant, ...buttonBaseProps } = props;
-    return <ButtonBase {...buttonBaseProps} ref={ref} />;
+
+    return <ButtonBase {...(buttonBaseProps as ButtonBaseProps)} ref={ref} />;
   }
 
   const { variant = "primary", ...buttonProps } = props;
@@ -55,7 +49,6 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
     return <TertiaryButton {...buttonProps} ref={ref} />;
   }
 
-  // Fallback (should never really happen, but keeps TS happy and UI safe)
   return <PrimaryButton {...buttonProps} ref={ref} />;
 });
 

--- a/src/v1/components/buttons/Button/SecondaryButton.tsx
+++ b/src/v1/components/buttons/Button/SecondaryButton.tsx
@@ -11,7 +11,7 @@ export const SecondaryButton = forwardRef<HTMLButtonElement, SecondaryButtonProp
        * HOW change "primary" to "secondary"; Check usage
        * WHEN https://telicent.atlassian.net/browse/TELFE-1250
        * WHO anyone
-       * 
+       *
        */
       <MUIButton variant="outlined" color="primary" {...buttonProps} ref={ref}>
         {buttonProps.children}
@@ -19,7 +19,7 @@ export const SecondaryButton = forwardRef<HTMLButtonElement, SecondaryButtonProp
     );
   }
   return (
-    <MUIButton variant="outlined" color="inherit" {...buttonProps} ref={ref}>
+    <MUIButton variant="outlined" color="primary" {...buttonProps} ref={ref}>
       {buttonProps.children}
     </MUIButton>
   );

--- a/src/v1/components/buttons/Button/TertiaryButton.tsx
+++ b/src/v1/components/buttons/Button/TertiaryButton.tsx
@@ -1,0 +1,30 @@
+import React, { forwardRef } from "react";
+import MUIButton, { ButtonProps as MUIButtonProps } from "@mui/material/Button";
+import { useExtendedTheme } from "../../../../export";
+
+type TertiaryButtonProps = Omit<MUIButtonProps, "variant" | "color">;
+
+export const TertiaryButton = forwardRef<HTMLButtonElement, TertiaryButtonProps>((buttonProps, ref) => {
+  const theme = useExtendedTheme();
+
+  return (
+    <MUIButton
+      variant="contained"
+      ref={ref}
+      {...buttonProps}
+      sx={{
+        border: `1px solid ${theme.palette.tertiary?.main}`,
+        color: theme.palette.tertiary?.contrastText,
+        backgroundColor: theme.palette.mode === "dark" ? "#080808" : "#FFFFFF",
+        "&:hover": {
+          backgroundColor: `${theme.palette.tertiary?.main}14`,
+          borderColor: theme.palette.tertiary?.main,
+        },
+      }}
+    >
+      {buttonProps.children}
+    </MUIButton>
+  );
+});
+
+export default TertiaryButton;

--- a/src/v1/components/buttons/Button/TextButton.tsx
+++ b/src/v1/components/buttons/Button/TextButton.tsx
@@ -1,0 +1,12 @@
+import React, { forwardRef } from "react";
+import MUIButton, { ButtonProps as MUIButtonProps } from "@mui/material/Button";
+
+export type TextButtonProps = Omit<MUIButtonProps, "variant">;
+
+const TextButton = forwardRef<HTMLButtonElement, TextButtonProps>((buttonProps, ref) => {
+  return <MUIButton {...buttonProps} ref={ref} variant="text" />;
+});
+
+TextButton.displayName = "TextButton";
+
+export default TextButton;

--- a/src/v1/components/buttons/CopyToClipboard/CopyToClipboard.tsx
+++ b/src/v1/components/buttons/CopyToClipboard/CopyToClipboard.tsx
@@ -73,7 +73,7 @@ const CopyToClipboard: React.FC<CopyToClipboardProps> = ({
       }}
     >
       <Button
-        style="base"
+        variant="base"
         onClick={handleClick}
         aria-label={ariaLabel}
         sx={{ color: theme.palette.primary.main, padding: 0.5, borderRadius: 1, ...sx }}

--- a/src/v1/components/data-display/UserProfile/UserProfileContent/UserProfileContent.stories.tsx
+++ b/src/v1/components/data-display/UserProfile/UserProfileContent/UserProfileContent.stories.tsx
@@ -63,7 +63,7 @@ export const WithActions: Story = {
           </FlexBox>
         ))}
         <FlexBox direction="row" columnGap={2} justifyContent="end">
-          <Button variant="outlined" color="primary" disableElevation>
+          <Button variant="secondary" disableElevation>
             Action
           </Button>
           <Button disableElevation>Action</Button>

--- a/src/v1/components/inputs/SearchBox/SearchBox.tsx
+++ b/src/v1/components/inputs/SearchBox/SearchBox.tsx
@@ -3,8 +3,9 @@ import Box from "@mui/material/Box";
 import InputBase, { InputBaseProps } from "@mui/material/InputBase";
 import PrimaryButton from "../../buttons/Button/PrimaryButton";
 import { SearchIcon } from "../../data-display";
+import { SxProps } from "@mui/material";
 
-export interface SearchBoxProps<Value = string> extends React.ComponentProps<typeof InputBase>{
+export interface SearchBoxProps<Value = string> extends React.ComponentProps<typeof InputBase> {
   /**
    * If true, the input element is focused during the first mount.
    */
@@ -45,6 +46,7 @@ export interface SearchBoxProps<Value = string> extends React.ComponentProps<typ
    */
   value?: Value;
   width?: number;
+  sx?: SxProps;
 }
 
 export const SearchBox: React.FC<SearchBoxProps> = ({
@@ -58,16 +60,10 @@ export const SearchBox: React.FC<SearchBoxProps> = ({
   onSearch,
   disabled,
   width = 600,
+  sx,
   ...rest
 }) => (
-  <Box
-    height={44}
-    width={width}
-    display="flex"
-    alignItems="center"
-    component="form"
-    onSubmit={onSearch}
-  >
+  <Box height={44} width={width} display="flex" alignItems="center" component="form" onSubmit={onSearch}>
     <InputBase
       data-test-handle="search-box-input"
       type="search"
@@ -80,6 +76,7 @@ export const SearchBox: React.FC<SearchBoxProps> = ({
         borderStyle: "solid",
         borderTopLeftRadius: 4,
         borderBottomLeftRadius: 4,
+        ...sx,
       }}
       inputProps={{ sx: { paddingInline: 1.5 } }}
       ref={inputRef}

--- a/src/v1/components/layout/FlexGrid.stories.tsx
+++ b/src/v1/components/layout/FlexGrid.stories.tsx
@@ -23,16 +23,12 @@ BasicColumns.args = {
     <>
       <FlexGridItem xs={6} style={{ backgroundColor: "#f77", padding: 20 }}>
         <Text>Left Column</Text>
-        <Button variant="contained" color="primary">
-          Action 1
-        </Button>
+        <Button variant="primary">Action 1</Button>
         <Text>More text underneath the button to show stacking.</Text>
       </FlexGridItem>
       <FlexGridItem xs={6} style={{ backgroundColor: "#77f", padding: 20 }}>
         <Text>Right Column</Text>
-        <Button variant="outlined" color="secondary">
-          Action 2
-        </Button>
+        <Button variant="secondary">Action 2</Button>
         <Text>Additional description for context.</Text>
       </FlexGridItem>
     </>

--- a/src/v1/components/surfaces/AppBar/AppBar.stories.tsx
+++ b/src/v1/components/surfaces/AppBar/AppBar.stories.tsx
@@ -33,7 +33,7 @@ It supports a centered brand area, optional application name, version label, and
   href="/"
   startChild={<AppSwitch apps={appList} />}
   endChild={
-    <Button color="primary" variant="contained">
+    <Button variant="primary">
       Sign Out
     </Button>
   }
@@ -117,8 +117,7 @@ const UserProfileExample = (
     <Box sx={{ pt: 1 }}>
       <Button
         onClick={() => console.log("Sign Out clicked")}
-        color="primary"
-        variant="contained"
+        variant="primary"
         startIcon={<i className="fa-solid fa-arrow-right-from-bracket" />}
         data-testid="signOut"
       >
@@ -136,7 +135,7 @@ export const WithSignOutButton: Story = {
   args: {
     appName: "Catalogue",
     endChild: (
-      <Button color="primary" variant="contained" startIcon={<i className="fa-solid fa-arrow-right-from-bracket" />}>
+      <Button variant="primary" startIcon={<i className="fa-solid fa-arrow-right-from-bracket" />}>
         Sign Out
       </Button>
     ),

--- a/src/v1/components/surfaces/AppBar/AppBar.tsx
+++ b/src/v1/components/surfaces/AppBar/AppBar.tsx
@@ -126,7 +126,7 @@ const AppBar: React.FC<AppBarProps> = ({
               component="span"
               variant="caption"
               sx={{
-                color: theme.palette.secondary.contrastText,
+                color: theme.palette.mode === "dark" ? "#fff" : "#000",
                 whiteSpace: "nowrap",
               }}
             >

--- a/src/v1/components/surfaces/Card/Card.stories.tsx
+++ b/src/v1/components/surfaces/Card/Card.stories.tsx
@@ -26,9 +26,7 @@ export const OutlinedCard: Story = {
           American paddock!
         </Text>
         <CardActions>
-          <Button color="secondary" variant="contained">
-            Share
-          </Button>
+          <Button variant="secondary">Share</Button>
         </CardActions>
       </CardContent>
     ),

--- a/src/v1/components/surfaces/Toolbar/Toolbar.tsx
+++ b/src/v1/components/surfaces/Toolbar/Toolbar.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { ToolbarProps, useTheme } from "@mui/material";
 import { Toolbar as MuiToolbar } from "@mui/material";
-import { FlexBox } from "../../layout";
 
 const Toolbar: React.FC<ToolbarProps> = ({ children, sx, ...rest }) => {
   const theme = useTheme();
@@ -9,7 +8,7 @@ const Toolbar: React.FC<ToolbarProps> = ({ children, sx, ...rest }) => {
     <MuiToolbar
       disableGutters={true}
       variant="dense"
-      sx={{ backgroundColor: theme.palette.mode === "dark" ? "#2e2e2e" : "#eeeeee", paddingX: 2, paddingY: 1, ...sx }}
+      sx={{ backgroundColor: theme.palette.mode === "dark" ? "#2e2e2e" : "#FFFFFF", paddingX: 2, paddingY: 1, ...sx }}
       {...rest}
     >
       {children}

--- a/src/v1/theme/colors/palette/createDarkPalette.ts
+++ b/src/v1/theme/colors/palette/createDarkPalette.ts
@@ -1,4 +1,4 @@
-import { ThemeOptions } from "@mui/material";
+import { alpha, ThemeOptions } from "@mui/material";
 import { grey } from "@mui/material/colors";
 import THEME_COLORS, { UITheme } from "../theme-colors";
 import merge from "lodash.merge";
@@ -8,10 +8,10 @@ const createDarkPalette = (uiTheme: UITheme): ThemeOptions["palette"] =>
   merge(createLightPalette(uiTheme), {
     mode: "dark",
     primary: THEME_COLORS[uiTheme].primary,
-    secondary: {
-      main: "#8a8a8a",
-      light: "#A1A1A1",
-      dark: "#606060",
+    tertiary: {
+      main: "#6B6B6B",
+      dark: alpha("#6B6B6B", 0.7),
+      light: alpha("#6B6B6B", 0.5),
       contrastText: "#FFFFFF",
     },
     text: {

--- a/src/v1/theme/colors/palette/createLightPalette.ts
+++ b/src/v1/theme/colors/palette/createLightPalette.ts
@@ -4,8 +4,15 @@ import THEME_COLORS, { UITheme } from "../theme-colors";
 const createLightPalette = (uiTheme: UITheme): ThemeOptions["palette"] => ({
   mode: "light",
   primary: THEME_COLORS[uiTheme].primary,
-  secondary: {
-    main: "#F9F9F9",
+  // secondary: {
+  //   main: "#F9F9F9",
+  // },
+
+  tertiary: {
+    main: "#8094A3",
+    dark: alpha("#8094A3", 0.7),
+    light: alpha("#8094A3", 0.5),
+    contrastText: "#252525",
   },
   text: {
     primary: "#000000",
@@ -13,7 +20,7 @@ const createLightPalette = (uiTheme: UITheme): ThemeOptions["palette"] => ({
     disabled: "#999999",
   },
   background: {
-    default: "#e3e3e3",
+    default: "#F9F9F9",
   },
 });
 

--- a/src/v1/theme/colors/palette/createLightPalette.ts
+++ b/src/v1/theme/colors/palette/createLightPalette.ts
@@ -4,10 +4,6 @@ import THEME_COLORS, { UITheme } from "../theme-colors";
 const createLightPalette = (uiTheme: UITheme): ThemeOptions["palette"] => ({
   mode: "light",
   primary: THEME_COLORS[uiTheme].primary,
-  // secondary: {
-  //   main: "#F9F9F9",
-  // },
-
   tertiary: {
     main: "#8094A3",
     dark: alpha("#8094A3", 0.7),

--- a/src/v1/theme/colors/palette/createLightPalette.ts
+++ b/src/v1/theme/colors/palette/createLightPalette.ts
@@ -4,6 +4,10 @@ import THEME_COLORS, { UITheme } from "../theme-colors";
 const createLightPalette = (uiTheme: UITheme): ThemeOptions["palette"] => ({
   mode: "light",
   primary: THEME_COLORS[uiTheme].primary,
+  // secondary: {
+  //   main: "#F9F9F9",
+  // },
+
   tertiary: {
     main: "#8094A3",
     dark: alpha("#8094A3", 0.7),

--- a/src/v1/theme/colors/theme-colors.ts
+++ b/src/v1/theme/colors/theme-colors.ts
@@ -23,6 +23,12 @@ const THEME_COLORS: Record<
       light?: string;
       contrastText?: string;
     };
+    tertiary?: {
+      main?: string;
+      dark?: string;
+      light?: string;
+      contrastText?: string;
+    };
   }
 > = {
   DataNavy,

--- a/src/v1/theme/createTheme.test.ts
+++ b/src/v1/theme/createTheme.test.ts
@@ -44,7 +44,7 @@ test("tmp theme diffs via unified patches", () => {
     ===================================================================
     --- 0	DataNavy (light)
     +++ 0	DataNavy (dark)
-    @@ -93,45 +93,25 @@
+    @@ -93,45 +93,28 @@
          },
          "MuiCssBaseline": {}
        },
@@ -57,12 +57,15 @@ test("tmp theme diffs via unified patches", () => {
            "light": "rgba(47, 68, 202, 0.5)",
            "contrastText": "#FFFFFF"
          },
-         "secondary": {
-    -      "main": "#8a8a8a",
-    -      "light": "#A1A1A1",
-    -      "dark": "#606060",
+         "tertiary": {
+    -      "main": "#6B6B6B",
+    -      "dark": "rgba(107, 107, 107, 0.7)",
+    -      "light": "rgba(107, 107, 107, 0.5)",
     -      "contrastText": "#FFFFFF"
-    +      "main": "#F9F9F9"
+    +      "main": "#8094A3",
+    +      "dark": "rgba(128, 148, 163, 0.7)",
+    +      "light": "rgba(128, 148, 163, 0.5)",
+    +      "contrastText": "#252525"
          },
          "text": {
     -      "primary": "#ececec",
@@ -90,7 +93,7 @@ test("tmp theme diffs via unified patches", () => {
     -      "A200": "#eeeeee",
     -      "A400": "#bdbdbd",
     -      "A700": "#616161"
-    +      "default": "#e3e3e3"
+    +      "default": "#F9F9F9"
          }
        },
        "typography": {
@@ -126,9 +129,9 @@ test("tmp theme diffs via unified patches", () => {
     +      "light": "rgba(245, 106, 170, 0.5)",
     +      "contrastText": "#000"
          },
-         "secondary": {
-           "main": "#8a8a8a",
-           "light": "#A1A1A1",
+         "tertiary": {
+           "main": "#6B6B6B",
+           "dark": "rgba(107, 107, 107, 0.7)",
 
 
     Index: 2
@@ -146,7 +149,7 @@ test("tmp theme diffs via unified patches", () => {
              }
            ],
            "styleOverrides": {}
-    @@ -93,45 +93,25 @@
+    @@ -93,45 +93,28 @@
          },
          "MuiCssBaseline": {}
        },
@@ -163,12 +166,15 @@ test("tmp theme diffs via unified patches", () => {
     +      "light": "rgba(245, 106, 170, 0.5)",
     +      "contrastText": "#000"
          },
-         "secondary": {
-    -      "main": "#8a8a8a",
-    -      "light": "#A1A1A1",
-    -      "dark": "#606060",
+         "tertiary": {
+    -      "main": "#6B6B6B",
+    -      "dark": "rgba(107, 107, 107, 0.7)",
+    -      "light": "rgba(107, 107, 107, 0.5)",
     -      "contrastText": "#FFFFFF"
-    +      "main": "#F9F9F9"
+    +      "main": "#8094A3",
+    +      "dark": "rgba(128, 148, 163, 0.7)",
+    +      "light": "rgba(128, 148, 163, 0.5)",
+    +      "contrastText": "#252525"
          },
          "text": {
     -      "primary": "#ececec",
@@ -196,7 +202,7 @@ test("tmp theme diffs via unified patches", () => {
     -      "A200": "#eeeeee",
     -      "A400": "#bdbdbd",
     -      "A700": "#616161"
-    +      "default": "#e3e3e3"
+    +      "default": "#F9F9F9"
          }
        },
        "typography": {
@@ -232,9 +238,9 @@ test("tmp theme diffs via unified patches", () => {
     +      "light": "rgba(242, 166, 75, 0.5)",
     +      "contrastText": "#000"
          },
-         "secondary": {
-           "main": "#8a8a8a",
-           "light": "#A1A1A1",
+         "tertiary": {
+           "main": "#6B6B6B",
+           "dark": "rgba(107, 107, 107, 0.7)",
 
 
     Index: 4
@@ -252,7 +258,7 @@ test("tmp theme diffs via unified patches", () => {
              }
            ],
            "styleOverrides": {}
-    @@ -93,45 +93,25 @@
+    @@ -93,45 +93,28 @@
          },
          "MuiCssBaseline": {}
        },
@@ -269,12 +275,15 @@ test("tmp theme diffs via unified patches", () => {
     +      "light": "rgba(242, 166, 75, 0.5)",
     +      "contrastText": "#000"
          },
-         "secondary": {
-    -      "main": "#8a8a8a",
-    -      "light": "#A1A1A1",
-    -      "dark": "#606060",
+         "tertiary": {
+    -      "main": "#6B6B6B",
+    -      "dark": "rgba(107, 107, 107, 0.7)",
+    -      "light": "rgba(107, 107, 107, 0.5)",
     -      "contrastText": "#FFFFFF"
-    +      "main": "#F9F9F9"
+    +      "main": "#8094A3",
+    +      "dark": "rgba(128, 148, 163, 0.7)",
+    +      "light": "rgba(128, 148, 163, 0.5)",
+    +      "contrastText": "#252525"
          },
          "text": {
     -      "primary": "#ececec",
@@ -302,7 +311,7 @@ test("tmp theme diffs via unified patches", () => {
     -      "A200": "#eeeeee",
     -      "A400": "#bdbdbd",
     -      "A700": "#616161"
-    +      "default": "#e3e3e3"
+    +      "default": "#F9F9F9"
          }
        },
        "typography": {
@@ -338,9 +347,9 @@ test("tmp theme diffs via unified patches", () => {
     +      "light": "rgba(32, 188, 250, 0.5)",
     +      "contrastText": "#000"
          },
-         "secondary": {
-           "main": "#8a8a8a",
-           "light": "#A1A1A1",
+         "tertiary": {
+           "main": "#6B6B6B",
+           "dark": "rgba(107, 107, 107, 0.7)",
 
 
     Index: 6
@@ -358,7 +367,7 @@ test("tmp theme diffs via unified patches", () => {
              }
            ],
            "styleOverrides": {}
-    @@ -93,45 +93,25 @@
+    @@ -93,45 +93,28 @@
          },
          "MuiCssBaseline": {}
        },
@@ -375,12 +384,15 @@ test("tmp theme diffs via unified patches", () => {
     +      "light": "rgba(32, 188, 250, 0.5)",
     +      "contrastText": "#000"
          },
-         "secondary": {
-    -      "main": "#8a8a8a",
-    -      "light": "#A1A1A1",
-    -      "dark": "#606060",
+         "tertiary": {
+    -      "main": "#6B6B6B",
+    -      "dark": "rgba(107, 107, 107, 0.7)",
+    -      "light": "rgba(107, 107, 107, 0.5)",
     -      "contrastText": "#FFFFFF"
-    +      "main": "#F9F9F9"
+    +      "main": "#8094A3",
+    +      "dark": "rgba(128, 148, 163, 0.7)",
+    +      "light": "rgba(128, 148, 163, 0.5)",
+    +      "contrastText": "#252525"
          },
          "text": {
     -      "primary": "#ececec",
@@ -408,7 +420,7 @@ test("tmp theme diffs via unified patches", () => {
     -      "A200": "#eeeeee",
     -      "A400": "#bdbdbd",
     -      "A700": "#616161"
-    +      "default": "#e3e3e3"
+    +      "default": "#F9F9F9"
          }
        },
        "typography": {
@@ -444,9 +456,9 @@ test("tmp theme diffs via unified patches", () => {
     +      "light": "rgba(0, 0, 0, 0.5)",
     +      "contrastText": "#fff"
          },
-         "secondary": {
-           "main": "#8a8a8a",
-           "light": "#A1A1A1",
+         "tertiary": {
+           "main": "#6B6B6B",
+           "dark": "rgba(107, 107, 107, 0.7)",
 
 
     Index: 8
@@ -464,7 +476,7 @@ test("tmp theme diffs via unified patches", () => {
              }
            ],
            "styleOverrides": {}
-    @@ -93,45 +93,25 @@
+    @@ -93,45 +93,28 @@
          },
          "MuiCssBaseline": {}
        },
@@ -481,12 +493,15 @@ test("tmp theme diffs via unified patches", () => {
     +      "light": "rgba(0, 0, 0, 0.5)",
     +      "contrastText": "#fff"
          },
-         "secondary": {
-    -      "main": "#8a8a8a",
-    -      "light": "#A1A1A1",
-    -      "dark": "#606060",
+         "tertiary": {
+    -      "main": "#6B6B6B",
+    -      "dark": "rgba(107, 107, 107, 0.7)",
+    -      "light": "rgba(107, 107, 107, 0.5)",
     -      "contrastText": "#FFFFFF"
-    +      "main": "#F9F9F9"
+    +      "main": "#8094A3",
+    +      "dark": "rgba(128, 148, 163, 0.7)",
+    +      "light": "rgba(128, 148, 163, 0.5)",
+    +      "contrastText": "#252525"
          },
          "text": {
     -      "primary": "#ececec",
@@ -514,7 +529,7 @@ test("tmp theme diffs via unified patches", () => {
     -      "A200": "#eeeeee",
     -      "A400": "#bdbdbd",
     -      "A700": "#616161"
-    +      "default": "#e3e3e3"
+    +      "default": "#F9F9F9"
          }
        },
        "typography": {

--- a/src/v1/tokens/button-variants.ts
+++ b/src/v1/tokens/button-variants.ts
@@ -20,6 +20,10 @@ export const BUTTON_VARIANTS = {
     label: "Base",
     description: "Unstyled button base",
   },
+  text: {
+    label: "Text",
+    description: "Text button with no background",
+  },
 } as const;
 
 export type ButtonVariant = keyof typeof BUTTON_VARIANTS;

--- a/src/v1/tokens/button-variants.ts
+++ b/src/v1/tokens/button-variants.ts
@@ -1,0 +1,29 @@
+/**
+ * Button variant tokens - framework agnostic
+ * These define our component contract, independent of MUI or any framework
+ */
+
+export const BUTTON_VARIANTS = {
+  primary: {
+    label: "Primary",
+    description: "Main action button",
+  },
+  secondary: {
+    label: "Secondary",
+    description: "Secondary action button",
+  },
+  tertiary: {
+    label: "Tertiary",
+    description: "Tertiary action button with neutral color",
+  },
+} as const;
+
+export type ButtonVariant = keyof typeof BUTTON_VARIANTS;
+
+export const BUTTON_SIZES = {
+  small: "small",
+  medium: "medium",
+  large: "large",
+} as const;
+
+export type ButtonSize = keyof typeof BUTTON_SIZES;

--- a/src/v1/tokens/button-variants.ts
+++ b/src/v1/tokens/button-variants.ts
@@ -16,6 +16,10 @@ export const BUTTON_VARIANTS = {
     label: "Tertiary",
     description: "Tertiary action button with neutral color",
   },
+  base: {
+    label: "Base",
+    description: "Unstyled button base",
+  },
 } as const;
 
 export type ButtonVariant = keyof typeof BUTTON_VARIANTS;


### PR DESCRIPTION
Ticket: https://telicent.atlassian.net/browse/TELFE-1248

### Refactor Button to use DS-owned variants (breaking)

This PR updates the `Button` component to use design system–owned variants instead of relying on MUI’s `variant` API.

#### Why

Historically, our DS aligned closely with MUI’s API (`contained`, `outlined`, `text`). This made adoption easier early on, but it also meant we didn’t fully own our component contracts.

As we move towards a more framework-agnostic design system, it’s important that the DS defines its own semantics. This change is part of that shift, allowing us to:

* Own the API contract of our components
* Decouple from MUI-specific concepts
* Provide a more consistent, semantic API across the DS

#### What changed

* Removed support for MUI variants:

  * `contained`
  * `outlined`
  * `text` (MUI usage)

* Introduced DS variants:

  * `primary`
  * `secondary`
  * `tertiary`
  * `text` (DS-defined)
  * `base` (unstyled button using `ButtonBase`)

* Internally, each variant maps to a dedicated component:

  * `PrimaryButton`
  * `SecondaryButton`
  * `TertiaryButton`
  * `TextButton`
  * `ButtonBase` for `base`

#### Breaking change

Consumers must migrate from:

```tsx
<Button variant="contained" />
<Button variant="outlined" />
<Button variant="text" />
<Button style="base" />
```

to:

```tsx
<Button variant="primary" />
<Button variant="secondary" />
<Button variant="tertiary" />
<Button variant="text" />
<Button variant="base" />
```

#### Notes

This simplifies the API and removes ambiguity around `variant`, ensuring it represents DS semantics only.

---


Other changes: 

fixed light colour on toolbar 
fixed version number text colour
updated dark and light theme to include tertiary colour group
update any component that uses `<button>`


---

<details>
  <summary><strong>🕵️ Review Guidance</strong></summary>

---

General guidance

- Generally, approve a PR if it makes the system better, even if it's not perfect. — [Google: The Standard of Code Review](https://google.github.io/eng-practices/review/reviewer/standard.html)
- The aim of both PR AUTHOR and PR REVIEWER is to get the code merged
- Aim for consensus, defined as _everyone can live with the outcome_
- PR with changes requires 2 approvals
- PR with no changes requires 1 approvals

For PR REVIEWER:

1. Read the ticket & description
2. [Review the code](https://google.github.io/eng-practices/review/reviewer/looking-for.html)
3. Request any changes that are essential.
4. For non-essential comments:
   - Use prefixes, e.g. "**nit:** change to Pascal case"
     - **nit:** small, non-essential change
     - **obs:** just an observation, doesn't affect the PR
     - **idea:** a suggestion to think about
     - **q:** questions
   - Use modifiers, e.g. "**obs**`[pr-owner-resolve]`: Jim is also editing this file"
     - `pr-author-resolve` PR author can resolve after reading
     - `pr-author-delete` (rare) delete after reading to avoid confusion
5. try to add _at least_ a helpful comment per ~500 lines; less if the PR is already busy

For PR AUTHOR:

1. Aim for enough detail in PR description for things to go smoothly
2. After requested changes, [re-request a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews#re-requesting-a-review) (so the PR shows up in [reviews-requested:@me](https://github.com/pulls?q=is%3Apr+is%3Aopen+archived%3Afalse+sort%3Aupdated-desc+review-requested%3A%40me+))

</details>
