### PR TITLE
fix: depracate old components

### DIFF
--- a/src/candidate-packages/authorize-flow/pages/Callback.tsx
+++ b/src/candidate-packages/authorize-flow/pages/Callback.tsx
@@ -1,5 +1,5 @@
 import { FC, useEffect } from "react";
-import { TeliSpinner } from "../../../export";
+import { Spinner } from "../../../export";
 
 interface CallbackProps {
   clientId: string;
@@ -10,11 +10,11 @@ export const Callback: FC<CallbackProps> = ({ clientId }) => {
       const event = new CustomEvent("oauth-callback", {
         detail: {
           callbackUrl: window.location.href,
-          clientId: clientId
+          clientId: clientId,
         },
       });
       window.dispatchEvent(event);
-    }, 0)
+    }, 0);
   }, [clientId]);
 
   return (
@@ -28,9 +28,8 @@ export const Callback: FC<CallbackProps> = ({ clientId }) => {
         gap: "0.5rem",
       }}
     >
-      <TeliSpinner size={64} style={{ color: "rgba(255,255,255,0.5)" }} />
+      <Spinner size={64} style={{ color: "rgba(255,255,255,0.5)" }} />
       <p>Logging you in. You'll be redirected shortly.</p>
     </div>
   );
-
-}
+};

--- a/src/components/TeliButton/TeliButton.tsx
+++ b/src/components/TeliButton/TeliButton.tsx
@@ -27,8 +27,13 @@ export interface TeliButtonProps extends TeliButtonBaseProps {
     | "top-start"
     | "top";
 }
+
+/**
+ * @deprecated TeliButton is deprecated and will be removed in a future release.
+ */
 const TeliButton = forwardRef<HTMLButtonElement, TeliButtonProps>(
   ({ tooltip, tooltipPlacement = "bottom", ...btnProps }, ref) => {
+    console.warn("TeliButton is deprecated and will be removed in a future release.");
     if (tooltip) {
       return (
         <Tooltip
@@ -53,7 +58,7 @@ const TeliButton = forwardRef<HTMLButtonElement, TeliButtonProps>(
     }
 
     return <TeliButtonBase ref={ref} {...btnProps} />;
-  }
+  },
 );
 
 export default TeliButton;

--- a/src/components/TeliCheckbox/TeliCheckbox.tsx
+++ b/src/components/TeliCheckbox/TeliCheckbox.tsx
@@ -11,16 +11,14 @@ export interface TeliCheckboxProps extends CheckboxProps {
  * If you have a single option, avoid using a checkbox and use an on/off switch instead.
  * More information about this component can be found [here](https://mui.com/material-ui/react-checkbox/)
  */
+/**
+ * @deprecated TeliCheckbox is deprecated and will be removed in a future release.
+ */
 const TeliCheckbox: FC<TeliCheckboxProps> = ({ label, ...checkboxProps }) => {
+  console.warn("TeliCheckbox is deprecated and will be removed in a future release.");
   if (!label) return <Checkbox {...checkboxProps} />;
 
-  return (
-    <FormControlLabel
-      control={<Checkbox {...checkboxProps} />}
-      label={label}
-      className="m-0"
-    />
-  );
+  return <FormControlLabel control={<Checkbox {...checkboxProps} />} label={label} className="m-0" />;
 };
 
 export default TeliCheckbox;

--- a/src/components/TeliChip/TeliChip.tsx
+++ b/src/components/TeliChip/TeliChip.tsx
@@ -11,12 +11,11 @@ export interface TeliChipProps extends MUIChipProps {
   variant?: "primary" | "secondary" | "tertiary" | "basic";
 }
 
-const TeliChip: React.FC<TeliChipProps> = ({
-  label,
-  variant = "primary",
-  className: chipClassName,
-  ...chipProps
-}) => {
+/**
+ * @deprecated TeliChip is deprecated and will be removed in a future release.
+ */
+const TeliChip: React.FC<TeliChipProps> = ({ label, variant = "primary", className: chipClassName, ...chipProps }) => {
+  console.warn("TeliChip is deprecated and will be removed in a future release.");
   const isPrimary = variant === "primary";
   const isTertiary = variant === "tertiary";
   const isFilled = isPrimary || isTertiary;
@@ -31,7 +30,7 @@ const TeliChip: React.FC<TeliChipProps> = ({
           "teli-chip--secondary": variant === "secondary",
           "teli-chip--tertiary": isTertiary,
         },
-        chipClassName
+        chipClassName,
       )}
       deleteIcon={<TeliDeleteIcon aria-label={`Delete ${label}`} />}
       {...chipProps}

--- a/src/components/TeliDialog/TeliDialog.tsx
+++ b/src/components/TeliDialog/TeliDialog.tsx
@@ -18,12 +18,11 @@ import "./telidialog.css";
  * Dialogs are purposefully interruptive, so they should be used sparingly.
  * More information about how this component can be used can be found [here](https://mui.com/material-ui/react-dialog/#scrolling-long-content)
  */
-const TeliDialog: FC<DialogProps> = ({
-  open,
-  onClose,
-  children,
-  ...otherProps
-}) => {
+/**
+ * @deprecated TeliDialog is deprecated and will be removed in a future release.
+ */
+const TeliDialog: FC<DialogProps> = ({ open, onClose, children, ...otherProps }) => {
+  console.warn("TeliDialog is deprecated and will be removed in a future release.");
   return (
     <Dialog open={open} onClose={onClose} {...otherProps}>
       {children}

--- a/src/components/TeliHeader/TeliHeader.tsx
+++ b/src/components/TeliHeader/TeliHeader.tsx
@@ -10,14 +10,16 @@ export interface TeliHeaderProps extends React.HTMLAttributes<HTMLHeadElement> {
   navProps?: NavProps;
 }
 
-const TeliHeader: React.FC<TeliHeaderProps> = ({
-  navProps,
-  children,
-  ...headerProps
-}: TeliHeaderProps) => (
-  <header {...headerProps}>
-    <nav {...navProps}>{children}</nav>
-  </header>
-);
+/**
+ * @deprecated TeliHeader is deprecated and will be removed in a future release.
+ */
+const TeliHeader: React.FC<TeliHeaderProps> = ({ navProps, children, ...headerProps }: TeliHeaderProps) => {
+  console.warn("TeliHeader is deprecated and will be removed in a future release.");
+  return (
+    <header {...headerProps}>
+      <nav {...navProps}>{children}</nav>
+    </header>
+  );
+};
 
 export default TeliHeader;

--- a/src/components/TeliIcons/AllIcons.tsx
+++ b/src/components/TeliIcons/AllIcons.tsx
@@ -16,17 +16,23 @@ const Icon: React.FC<{
   </div>
 );
 
-const AllIcons = () => (
-  <div className="grid grid-cols-12">
-    <Icon icon={<TeliAddIcon />} label="Add" />
-    <Icon icon={<TeliCloseIcon />} label="Close" />
-    <Icon icon={<TeliDeleteIcon />} label="Delete" />
-    <Icon icon={<TeliEditIcon />} label="Edit" />
-    <Icon icon={<TeliSearchIcon />} label="Search" />
-    <Icon icon={<TeliSortAZIcon />} label="Sort AZ" />
-    <Icon icon={<TeliSortZAIcon />} label="Sort ZA" />
-    <Icon icon={<ClockRotateLeft />} label="Clock rotate left" />
-  </div>
-);
+/**
+ * @deprecated AllIcons is deprecated and will be removed in a future release.
+ */
+const AllIcons = () => {
+  console.warn("AllIcons is deprecated and will be removed in a future release.");
+  return (
+    <div className="grid grid-cols-12">
+      <Icon icon={<TeliAddIcon />} label="Add" />
+      <Icon icon={<TeliCloseIcon />} label="Close" />
+      <Icon icon={<TeliDeleteIcon />} label="Delete" />
+      <Icon icon={<TeliEditIcon />} label="Edit" />
+      <Icon icon={<TeliSearchIcon />} label="Search" />
+      <Icon icon={<TeliSortAZIcon />} label="Sort AZ" />
+      <Icon icon={<TeliSortZAIcon />} label="Sort ZA" />
+      <Icon icon={<ClockRotateLeft />} label="Clock rotate left" />
+    </div>
+  );
+};
 
 export default AllIcons;

--- a/src/components/TeliList/TeliList.tsx
+++ b/src/components/TeliList/TeliList.tsx
@@ -17,22 +17,17 @@ export type TeliListProps = React.HTMLAttributes<HTMLUListElement> &
     subheader: ListProps["subheader"];
   }>;
 
-const TeliList: FC<TeliListProps> = ({
-  dense,
-  disablePadding,
-  subheader,
-  children,
-  ...ulProps
-}) => (
-  <List
-    dense={dense}
-    disablePadding={disablePadding}
-    subheader={subheader}
-    {...ulProps}
-  >
-    {children}
-  </List>
-);
+/**
+ * @deprecated TeliList is deprecated and will be removed in a future release.
+ */
+const TeliList: FC<TeliListProps> = ({ dense, disablePadding, subheader, children, ...ulProps }) => {
+  console.warn("TeliList is deprecated and will be removed in a future release.");
+  return (
+    <List dense={dense} disablePadding={disablePadding} subheader={subheader} {...ulProps}>
+      {children}
+    </List>
+  );
+};
 
 type TeliListItemButtonProps = React.HTMLAttributes<HTMLButtonElement> &
   Partial<{
@@ -44,17 +39,8 @@ type TeliListItemButtonProps = React.HTMLAttributes<HTMLButtonElement> &
     divider: ListItemButtonProps["divider"];
     selected: ListItemButtonProps["selected"];
   }>;
-const TeliListItemButton: FC<TeliListItemButtonProps> = ({
-  className,
-  children,
-  ...props
-}) => (
-  <ListItemButton
-    component="button"
-    disableRipple
-    className={classNames("flex gap-x-3", className)}
-    {...props}
-  >
+const TeliListItemButton: FC<TeliListItemButtonProps> = ({ className, children, ...props }) => (
+  <ListItemButton component="button" disableRipple className={classNames("flex gap-x-3", className)} {...props}>
     {children}
   </ListItemButton>
 );
@@ -69,8 +55,6 @@ type TeliListItemProps = React.HTMLAttributes<HTMLLIElement> &
     divider: ListItemProps["divider"];
     secondaryAction: ListItemProps["secondaryAction"];
   }>;
-const TeliListItem: FC<TeliListItemProps> = ({ children, ...props }) => (
-  <ListItem {...props}>{children}</ListItem>
-);
+const TeliListItem: FC<TeliListItemProps> = ({ children, ...props }) => <ListItem {...props}>{children}</ListItem>;
 
 export { TeliList, TeliListItemButton, TeliListItem };

--- a/src/components/TeliMenu/TeliMenu.tsx
+++ b/src/components/TeliMenu/TeliMenu.tsx
@@ -2,12 +2,11 @@ import React, { FC } from "react";
 import { Menu, MenuItem, MenuItemProps, MenuProps } from "@mui/material";
 import "./telimenu.css";
 
-const TeliMenu: FC<MenuProps> = ({
-  open,
-  onClose,
-  children,
-  ...otherProps
-}) => {
+/**
+ * @deprecated TeliMenu is deprecated and will be removed in a future release.
+ */
+const TeliMenu: FC<MenuProps> = ({ open, onClose, children, ...otherProps }) => {
+  console.warn("TeliMenu is deprecated and will be removed in a future release.");
   return (
     <Menu open={open} onClose={onClose} {...otherProps}>
       {children}
@@ -15,8 +14,6 @@ const TeliMenu: FC<MenuProps> = ({
   );
 };
 
-const TeliMenuItem: FC<MenuItemProps> = ({ children, ...props }) => (
-  <MenuItem {...props}>{children}</MenuItem>
-);
+const TeliMenuItem: FC<MenuItemProps> = ({ children, ...props }) => <MenuItem {...props}>{children}</MenuItem>;
 
 export { TeliMenu, TeliMenuItem };

--- a/src/components/TeliSelect/TeliSelect.tsx
+++ b/src/components/TeliSelect/TeliSelect.tsx
@@ -139,6 +139,9 @@ export interface TeliSelectProps {
   value?: any;
 }
 
+/**
+ * @deprecated TeliSelect is deprecated and will be removed in a future release.
+ */
 const TeliSelect: React.FC<TeliSelectProps> = ({
   id,
   selectId,
@@ -163,6 +166,7 @@ const TeliSelect: React.FC<TeliSelectProps> = ({
   onClose,
   onOpen,
 }) => {
+  console.warn("TeliSelect is deprecated and will be removed in a future release.");
   const getLabelProps = () => {
     if (hiddenLabel) {
       return { displayEmpty: true };
@@ -219,10 +223,7 @@ const TeliSelect: React.FC<TeliSelectProps> = ({
         renderValue={renderValue}
       >
         {options.map((option) => (
-          <MenuItem
-            key={option?.id || option.label}
-            value={option?.value || option.label}
-          >
+          <MenuItem key={option?.id || option.label} value={option?.value || option.label}>
             {option.label}
           </MenuItem>
         ))}

--- a/src/components/TeliSpinner/TeliSpinner.tsx
+++ b/src/components/TeliSpinner/TeliSpinner.tsx
@@ -1,7 +1,11 @@
 import React, { type FC } from "react";
 import { CircularProgress, CircularProgressProps } from "@mui/material";
 
+/**
+ * @deprecated TeliSpinner is deprecated and will be removed in a future release.
+ */
 const TeliSpinner: FC<CircularProgressProps> = (props) => {
+  console.warn("TeliSpinner is deprecated and will be removed in a future release.");
   return <CircularProgress {...props} />;
 };
 

--- a/src/components/TeliSwitch/TeliSwitch.tsx
+++ b/src/components/TeliSwitch/TeliSwitch.tsx
@@ -73,7 +73,11 @@ export interface TeliSwitchProps {
  * refer to [Checkbox vs Toggle
  * Switch](https://uxplanet.org/checkbox-vs-toggle-switch-7fc6e83f10b8)
  */
+/**
+ * @deprecated TeliSwitch is deprecated and will be removed in a future release.
+ */
 const TeliSwitch: FC<TeliSwitchProps> = ({ label, labelPlacement = "end", size = "small", ...switchProps }) => {
+  console.warn("TeliSwitch is deprecated and will be removed in a future release.");
   const switchControl = (
     <span className="teli-switch">
       <Switch size={size} {...switchProps} />

--- a/src/components/TeliTable/TeliTable.tsx
+++ b/src/components/TeliTable/TeliTable.tsx
@@ -18,20 +18,13 @@ export interface TeliTableProps extends TableProps {
   name?: string;
 }
 
-const TeliTable: React.FC<TeliTableProps> = ({
-  compact = false,
-  minWidth,
-  name,
-  children,
-  ...otherProps
-}) => {
+/**
+ * @deprecated TeliTable is deprecated and will be removed in a future release.
+ */
+const TeliTable: React.FC<TeliTableProps> = ({ compact = false, minWidth, name, children, ...otherProps }) => {
+  console.warn("TeliTable is deprecated and will be removed in a future release.");
   return (
-    <Table
-      sx={{ minWidth }}
-      size={compact ? "small" : "medium"}
-      aria-label={name}
-      {...otherProps}
-    >
+    <Table sx={{ minWidth }} size={compact ? "small" : "medium"} aria-label={name} {...otherProps}>
       {children}
     </Table>
   );

--- a/src/components/TeliTabs/TeliTab.tsx
+++ b/src/components/TeliTabs/TeliTab.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { Tab, TabProps } from "@mui/material";
-import classNames from "classnames";
 
 import "./telitabs.css";
 
@@ -8,11 +7,13 @@ interface TeliTabProps extends Omit<TabProps, "value"> {
   tabIndex: number;
 }
 
-const TeliTab: React.FC<TeliTabProps> = ({
-  tabIndex,
-  className: tabClassNames,
-  ...other
-}) => <Tab className={tabClassNames} {...a11yProps(tabIndex)} {...other} />;
+/**
+ * @deprecated TeliTab is deprecated and will be removed in a future release.
+ */
+const TeliTab: React.FC<TeliTabProps> = ({ tabIndex, className: tabClassNames, ...other }) => {
+  console.warn("TeliTab is deprecated and will be removed in a future release.");
+  return <Tab className={tabClassNames} {...a11yProps(tabIndex)} {...other} />;
+};
 
 export default TeliTab;
 

--- a/src/components/TeliTabs/TeliTabPanel.tsx
+++ b/src/components/TeliTabs/TeliTabPanel.tsx
@@ -6,22 +6,23 @@ interface TeliTabPanelProps {
   children?: React.ReactNode;
 }
 
-const TeliTabPanel: React.FC<TeliTabPanelProps> = ({
-  tabIndex,
-  selectedTabIndex,
-  children,
-  ...other
-}) => (
-  <div
-    role="tabpanel"
-    hidden={selectedTabIndex !== tabIndex}
-    id={`teli-tabpanel-${tabIndex}`}
-    aria-labelledby={`teli-tab-${tabIndex}`}
-    className="py-2"
-    {...other}
-  >
-    {children}
-  </div>
-);
+/**
+ * @deprecated TeliTabPanel is deprecated and will be removed in a future release.
+ */
+const TeliTabPanel: React.FC<TeliTabPanelProps> = ({ tabIndex, selectedTabIndex, children, ...other }) => {
+  console.warn("TeliTabPanel is deprecated and will be removed in a future release.");
+  return (
+    <div
+      role="tabpanel"
+      hidden={selectedTabIndex !== tabIndex}
+      id={`teli-tabpanel-${tabIndex}`}
+      aria-labelledby={`teli-tab-${tabIndex}`}
+      className="py-2"
+      {...other}
+    >
+      {children}
+    </div>
+  );
+};
 
 export default TeliTabPanel;

--- a/src/components/TeliTabs/TeliTabs.tsx
+++ b/src/components/TeliTabs/TeliTabs.tsx
@@ -9,14 +9,15 @@ export interface TeliTabsProps extends Omit<TabsProps, "value"> {
    */
   selectedTabIndex: number;
 }
-const TeliTabs: React.FC<TeliTabsProps> = ({ selectedTabIndex, ...other }) => (
-  <Tabs
-    className="gap-x-3"
-    textColor="secondary"
-    indicatorColor="secondary"
-    value={selectedTabIndex}
-    {...other}
-  />
-);
+
+/**
+ * @deprecated TeliTabs is deprecated and will be removed in a future release.
+ */
+const TeliTabs: React.FC<TeliTabsProps> = ({ selectedTabIndex, ...other }) => {
+  console.warn("TeliTabs is deprecated and will be removed in a future release.");
+  return (
+    <Tabs className="gap-x-3" textColor="secondary" indicatorColor="secondary" value={selectedTabIndex} {...other} />
+  );
+};
 
 export default TeliTabs;

--- a/src/components/TeliTextField/TeliTextField.tsx
+++ b/src/components/TeliTextField/TeliTextField.tsx
@@ -8,6 +8,9 @@ import "./textfield.css";
  * Text Fields let users enter and edit text. They typically appear in forms and dialogs.
  * More information about this component can be used can be found [here](https://mui.com/material-ui/react-text-field/)
  */
+/**
+ * @deprecated TeliTextField is deprecated and will be removed in a future release.
+ */
 const TeliTextField: FC<TeliTextFieldProps> = ({
   ariaLabel,
   endAdornment,
@@ -15,28 +18,27 @@ const TeliTextField: FC<TeliTextFieldProps> = ({
   pointerEvents,
   startAdornment,
   ...otherProps
-}) => (
-  <TextField
-    variant="outlined"
-    size="small"
-    maxRows={4}
-    InputProps={{
-      readOnly,
-      startAdornment: (
-        <InputAdornment position="start">{startAdornment}</InputAdornment>
-      ),
-      endAdornment: (
-        <InputAdornment position="end">{endAdornment}</InputAdornment>
-      ),
-    }}
-    InputLabelProps={{
-      shrink: pointerEvents,
-    }}
-    inputProps={{
-      "aria-label": ariaLabel,
-    }}
-    {...otherProps}
-  />
-);
+}) => {
+  console.warn("TeliTextField is deprecated and will be removed in a future release.");
+  return (
+    <TextField
+      variant="outlined"
+      size="small"
+      maxRows={4}
+      InputProps={{
+        readOnly,
+        startAdornment: <InputAdornment position="start">{startAdornment}</InputAdornment>,
+        endAdornment: <InputAdornment position="end">{endAdornment}</InputAdornment>,
+      }}
+      InputLabelProps={{
+        shrink: pointerEvents,
+      }}
+      inputProps={{
+        "aria-label": ariaLabel,
+      }}
+      {...otherProps}
+    />
+  );
+};
 
 export default TeliTextField;

--- a/src/components/TeliToolbar/TeliToolbar.tsx
+++ b/src/components/TeliToolbar/TeliToolbar.tsx
@@ -25,6 +25,9 @@ export interface TeliToolbarProps extends HTMLAttributes<HTMLUListElement> {
   children?: React.ReactNode;
 }
 
+/**
+ * @deprecated TeliToolbar is deprecated and will be removed in a future release.
+ */
 const TeliToolbar: React.FC<TeliToolbarProps> = ({
   position = "bottom-start",
   defaultControls = true,
@@ -34,13 +37,10 @@ const TeliToolbar: React.FC<TeliToolbarProps> = ({
   onZoomOut,
   children,
 }) => {
+  console.warn("TeliToolbar is deprecated and will be removed in a future release.");
   const isTertiary = variant === "tertiary";
   const tooltipPlacement: PopperPlacementType =
-    position.startsWith("bottom") && !vertical
-      ? "top"
-      : position.startsWith("bottom") && vertical
-      ? "left"
-      : "bottom";
+    position.startsWith("bottom") && !vertical ? "top" : position.startsWith("bottom") && vertical ? "left" : "bottom";
   const buttonVariant = isTertiary ? "basic" : "tertiary";
 
   const DefaultControls = () => (

--- a/src/components/TeliTypeIcon/TeliTypeIcon.tsx
+++ b/src/components/TeliTypeIcon/TeliTypeIcon.tsx
@@ -1,15 +1,8 @@
 import React from "react";
 import { Avatar } from "@mui/material";
 
-import {
-  getDisabledStyles,
-  getSizeProps,
-  TeliTypeIconSizeProp,
-} from "./type-icon-utils";
-import {
-  FlattenedStyleType,
-  FlattenedStyleTypeForFindIcon,
-} from "@telicent-oss/ontologyservice";
+import { getDisabledStyles, getSizeProps, TeliTypeIconSizeProp } from "./type-icon-utils";
+import { FlattenedStyleType, FlattenedStyleTypeForFindIcon } from "@telicent-oss/ontologyservice";
 
 export type TeliTypeIconProps = {
   icon: FlattenedStyleTypeForFindIcon | FlattenedStyleType;
@@ -33,12 +26,11 @@ export type TeliTypeIconProps = {
  * ontology. If the styles cannot be found, the initials will be rendered as a
  * fallback as demonstrated in the stories.
  */
-const TeliTypeIcon: React.FC<TeliTypeIconProps> = ({
-  icon,
-  borderColor,
-  disabled = false,
-  size = "base",
-}) => {
+/**
+ * @deprecated TeliTypeIcon is deprecated and will be removed in a future release.
+ */
+const TeliTypeIcon: React.FC<TeliTypeIconProps> = ({ icon, borderColor, disabled = false, size = "base" }) => {
+  console.warn("TeliTypeIcon is deprecated and will be removed in a future release.");
   const hasIcon = "faIcon" in icon && Boolean(icon.faIcon);
 
   return (
@@ -55,11 +47,7 @@ const TeliTypeIcon: React.FC<TeliTypeIconProps> = ({
         ...getSizeProps(size),
       }}
     >
-      {hasIcon ? (
-        <i className={icon.faIcon} title={`${icon.alt}-icon`} />
-      ) : (
-        <p>{icon.iconFallbackText}</p>
-      )}
+      {hasIcon ? <i className={icon.faIcon} title={`${icon.alt}-icon`} /> : <p>{icon.iconFallbackText}</p>}
     </Avatar>
   );
 };

--- a/src/components/TeliTypeahead/TeliTypeahead.tsx
+++ b/src/components/TeliTypeahead/TeliTypeahead.tsx
@@ -1,7 +1,5 @@
 import React, { useState } from "react";
-import TeliAutocomplete, {
-  TeliAutocompleteProps,
-} from "../TeliAutocomplete/TeliAutocomplete";
+import TeliAutocomplete, { TeliAutocompleteProps } from "../TeliAutocomplete/TeliAutocomplete";
 import useDebounce from "../../hooks/useDebounce";
 import useTypeaheadQuery from "../../hooks/useTypeahead";
 
@@ -9,22 +7,22 @@ export interface TeliTypeaheadProps<
   Value,
   Multiple extends boolean = false,
   DisableClearable extends boolean = false,
-  FreeSolo extends boolean = false
-> extends Omit<
-    TeliAutocompleteProps<Value, Multiple, DisableClearable, FreeSolo>,
-    "options"
-  > {
+  FreeSolo extends boolean = false,
+> extends Omit<TeliAutocompleteProps<Value, Multiple, DisableClearable, FreeSolo>, "options"> {
   errorMessage?: string;
   queryParamKey: string;
   url: string;
   onTransform?: (data: any) => any;
 }
 
+/**
+ * @deprecated TeliTypeahead is deprecated and will be removed in a future release.
+ */
 function TeliTypeahead<
   Value,
   Multiple extends boolean = false,
   DisableClearable extends boolean = false,
-  FreeSolo extends boolean = false
+  FreeSolo extends boolean = false,
 >({
   errorMessage,
   helperText,
@@ -34,6 +32,7 @@ function TeliTypeahead<
   onTransform,
   ...otherProps
 }: TeliTypeaheadProps<Value, Multiple, DisableClearable, FreeSolo>) {
+  console.warn("TeliTypeahead is deprecated and will be removed in a future release.");
   const [searchTerm, setSearchTerm] = useState<string>("");
   const debouncedSearchTerm = useDebounce(searchTerm);
 
@@ -44,21 +43,17 @@ function TeliTypeahead<
     ...query
   } = useTypeaheadQuery(url, queryParamKey, debouncedSearchTerm, onTransform);
 
-  const queryError =
-    query.error instanceof Error ? query.error.message : undefined;
+  const queryError = query.error instanceof Error ? query.error.message : undefined;
   const errMsg = errorMessage ?? queryError;
 
-  const handleInputChange = (
-    event: React.SyntheticEvent<Element, Event>,
-    value: string
-  ) => {
+  const handleInputChange = (event: React.SyntheticEvent<Element, Event>, value: string) => {
     setSearchTerm(value);
   };
 
   return (
     <TeliAutocomplete
       error={isError}
-      options={options ?? [] as Value[]}
+      options={options ?? ([] as Value[])}
       noOptionsText={searchTerm === "" ? "Start typing ..." : noOptionsText}
       loading={isInitialLoading}
       inputValue={searchTerm}

--- a/src/components/TeliUserProfile/TeliUserProfile.tsx
+++ b/src/components/TeliUserProfile/TeliUserProfile.tsx
@@ -2,21 +2,23 @@ import React from "react";
 
 import { TeliUserAvatarProps } from "../TeliAvatar/TeliUserAvatar";
 import TeliUserProfileButton from "./TeliUserProfileButton";
-import TeliUserProfileMenu, {
-  TeliUserProfileMenuProps,
-} from "./TeliUserProfileMenu";
+import TeliUserProfileMenu, { TeliUserProfileMenuProps } from "./TeliUserProfileMenu";
 import "./user-profile.css";
 
 export interface TeliUserProfileProps extends Partial<TeliUserAvatarProps> {
   onSettingsClick: TeliUserProfileMenuProps["onSettingsClick"];
 }
 
+/**
+ * @deprecated TeliUserProfile is deprecated and will be removed in a future release.
+ */
 const TeliUserProfile: React.FC<Partial<TeliUserProfileProps>> = ({
   firstName,
   lastName,
   onSettingsClick,
   ...userAvatarProps
 }) => {
+  console.warn("TeliUserProfile is deprecated and will be removed in a future release.");
   const [anchorEl, setAnchorEl] = React.useState(null);
   const open = Boolean(anchorEl);
 


### PR DESCRIPTION
This PR deprecates legacy components.

## What Changed

Added deprecation  messages to legacy components.
Added matching /** @deprecated ... */ JSDoc comments directly above component declarations.

<img width="880" height="307" alt="Screenshot 2026-04-17 at 11 44 00" src="https://github.com/user-attachments/assets/c44176e1-9a2d-4fa7-99da-e171d7a5aedf" />


### Why

We want to guide downstream apps away from old components and toward the newer component set, so we can safely delete the old components at a later release. 


---

<details>
  <summary><strong>🕵️ Review Guidance</strong></summary>

---

General guidance

- Generally, approve a PR if it makes the system better, even if it's not perfect. — [Google: The Standard of Code Review](https://google.github.io/eng-practices/review/reviewer/standard.html)
- The aim of both PR AUTHOR and PR REVIEWER is to get the code merged
- Aim for consensus, defined as _everyone can live with the outcome_
- PR with changes requires 2 approvals
- PR with no changes requires 1 approvals

For PR REVIEWER:

1. Read the ticket & description
2. [Review the code](https://google.github.io/eng-practices/review/reviewer/looking-for.html)
3. Request any changes that are essential.
4. For non-essential comments:
   - Use prefixes, e.g. "**nit:** change to Pascal case"
     - **nit:** small, non-essential change
     - **obs:** just an observation, doesn't affect the PR
     - **idea:** a suggestion to think about
     - **q:** questions
   - Use modifiers, e.g. "**obs**`[pr-owner-resolve]`: Jim is also editing this file"
     - `pr-author-resolve` PR author can resolve after reading
     - `pr-author-delete` (rare) delete after reading to avoid confusion
5. try to add _at least_ a helpful comment per ~500 lines; less if the PR is already busy

For PR AUTHOR:

1. Aim for enough detail in PR description for things to go smoothly
2. After requested changes, [re-request a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews#re-requesting-a-review) (so the PR shows up in [reviews-requested:@me](https://github.com/pulls?q=is%3Apr+is%3Aopen+archived%3Afalse+sort%3Aupdated-desc+review-requested%3A%40me+))

</details>
