### PR TITLE
chore: replace acled ontology references with telicent ontology

### DIFF
--- a/src/feature-components/Map/primitives/ResultsMarkers/ResultMarkers.test.tsx
+++ b/src/feature-components/Map/primitives/ResultsMarkers/ResultMarkers.test.tsx
@@ -57,7 +57,7 @@ describe("Result Markers component", () => {
     });
 
     test("renders marker without icons when ontology styles are not matched", () => {
-      expect(screen.queryByText("Mad")).toBeVisible();
+      expect(screen.queryByText("mad")).toBeVisible();
       expect(qs('[data-name="Non event. Not important"] [data-icon]')).not.toBeTruthy();
       expect(
         qs('[data-name="Non event. Not important"]')?.childNodes[0].firstChild

--- a/src/feature-components/Map/utils/sampleData/markers.ts
+++ b/src/feature-components/Map/utils/sampleData/markers.ts
@@ -1,20 +1,20 @@
 export const BOULAY_ATTACK = {
   geohash: "http://geohash.org/sd37f",
-  type: "http://acleddata.com/ontology#Attack",
+  type: "http://telicent.io/ontology#attack",
   uri: "http://telicent.io/data#SUD11217",
   name: "Attack in Boulay, Sudan",
 };
 
 export const ARGA_ATTACK = {
   geohash: "http://geohash.org/sd30t",
-  type: "http://acleddata.com/ontology#Attack",
+  type: "http://telicent.io/ontology#attack",
   uri: "http://telicent.io/data#SUD11675",
   name: "Attack in Arga, Sudan",
 };
 
 export const MADE_UP_MARKER = {
   geohash: "http://geohash.org/sd30t",
-  type: "http://acleddata.com/ontology#MadeUp",
+  type: "http://telicent.io/ontology#madeUp",
   uri: "http://telicent.io/data#MUP11675",
   name: "Non event. Not important",
 };


### PR DESCRIPTION
## Summary
- Replace `http://acleddata.com/ontology#Attack` with `http://telicent.io/ontology#attack` in the Map sample marker fixtures (`BOULAY_ATTACK`, `ARGA_ATTACK`).
- Replace `http://acleddata.com/ontology#MadeUp` with `http://telicent.io/ontology#madeUp` on `MADE_UP_MARKER` (kept distinct from `#attack` so the ResultMarkers "no match" test branch still works).
- Update `ResultMarkers.test.tsx` assertion from `"Mad"` to `"mad"` — the marker icon label is derived from the URI term via `getLabelCharacters`, which now resolves to lowercase.

## Test plan
- [x] `jest src/feature-components/Map/primitives/ResultsMarkers/ResultMarkers.test.tsx`
- [x] `jest src/feature-components/Map/utils/helper/helper.test.ts`
- [x] `jest src/feature-components/Map/composites/FeatureMap/__tests__/FeatureMap.test.tsx`
- [x] Full suite: 247 passed, 7 skipped
- [x] `grep -ri acled src` returns no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)