### PR TITLE
fix: preserve body and headers on 401 retry in withSessionHandling

### DIFF
--- a/scripts/local-publish.sh
+++ b/scripts/local-publish.sh
@@ -52,10 +52,10 @@ bump_prerelease() {
 publish_prerelease() {
   if $DRY_RUN; then
     echo "Would run: yarn build"
-    echo "Would run: npm publish --registry http://localhost:4873 --prepatch"
+    echo "Would run: npm publish --registry http://localhost:4873 --tag prerelease"
   else
     yarn build
-    npm publish --registry http://localhost:4873 --prepatch
+    npm publish --registry http://localhost:4873 --tag prerelease
   fi
 }
 

--- a/src/utils/authorize-flow/services/__tests__/withSessionHandling.retry.test.ts
+++ b/src/utils/authorize-flow/services/__tests__/withSessionHandling.retry.test.ts
@@ -1,0 +1,95 @@
+import axios, { AxiosAdapter, AxiosHeaders } from "axios";
+import { withSessionHandling } from "../withSessionHandling";
+import { AuthEvent } from "../broadcastChannelService";
+
+jest.mock("../broadcastChannelService", () => {
+  const mockListeners = new Set<Function>();
+  return {
+    AuthEvent: {
+      AUTHENTICATED: "authenticated",
+      REAUTHENTICATED: "reauthenticated",
+      USER_CHANGED: "user-changed",
+      UNAUTHORIZED: "unauthorized",
+    },
+    onAuthEvent: (cb: Function) => {
+      mockListeners.add(cb);
+      return () => mockListeners.delete(cb);
+    },
+    broadcastAuthEvent: jest.fn(),
+    __fire: (e: string) => mockListeners.forEach((cb) => cb(e)),
+  };
+});
+
+const { __fire } = jest.requireMock("../broadcastChannelService") as {
+  __fire: (event: string) => void;
+};
+
+type CapturedCall = {
+  body: unknown;
+  headers: Record<string, unknown> | undefined;
+  method: string | undefined;
+};
+
+const flushMicrotasks = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("withSessionHandling 401 retry", () => {
+  it("preserves body and headers on the retry after re-auth", async () => {
+    const calls: CapturedCall[] = [];
+
+    const authClient = {
+      makeAuthenticatedRequest: async (
+        _url: string,
+        options: Record<string, unknown>
+      ) => {
+        calls.push({
+          body: options.body,
+          headers: options.headers as Record<string, unknown> | undefined,
+          method: options.method as string | undefined,
+        });
+
+        if (calls.length === 1) {
+          return new Response(null, { status: 401 });
+        }
+        return new Response("{}", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    };
+
+    const instance = axios.create();
+    withSessionHandling(
+      instance,
+      { queryClient: undefined, keysToInvalidate: [] },
+      authClient as any
+    );
+
+    const adapter = instance.defaults.adapter as AxiosAdapter;
+
+    const requestPromise = adapter({
+      url: "/documents",
+      method: "post",
+      data: { title: "hello" },
+      headers: new AxiosHeaders({
+        "Content-Type": "application/x-www-form-urlencoded",
+        "X-Custom-Header": "my-value",
+      }),
+    });
+
+    await flushMicrotasks();
+
+    __fire(AuthEvent.AUTHENTICATED);
+
+    await requestPromise;
+
+    expect(calls).toHaveLength(2);
+    expect(calls[1].body).toEqual(calls[0].body);
+    expect(calls[1].headers).toEqual(calls[0].headers);
+    expect(calls[1].method).toEqual(calls[0].method);
+    expect(calls[1].body).toBe("title=hello");
+    expect(calls[1].headers).toMatchObject({
+      "Content-Type": "application/x-www-form-urlencoded",
+      "X-Custom-Header": "my-value",
+    });
+  });
+});

--- a/src/utils/authorize-flow/services/withSessionHandling.ts
+++ b/src/utils/authorize-flow/services/withSessionHandling.ts
@@ -58,14 +58,18 @@ export function withSessionHandling(
         : `${config.baseURL || ""}${config.url || ""}`;
 
       try {
-        const headers = new AxiosHeaders(config.headers).toJSON();
+        const sendOnce = () =>
+          authClient.makeAuthenticatedRequest(fullUrl, {
+            body: formatPayload(config.headers, config.data),
+            headers: new AxiosHeaders(config.headers).toJSON() as Record<
+              string,
+              string
+            >,
+            method: config.method,
+            skipAutoLogout: true,
+          });
 
-        const response = await authClient.makeAuthenticatedRequest(fullUrl, {
-          body: formatPayload(config.headers, config.data),
-          headers: headers as Record<string, string>,
-          method: config.method,
-          skipAutoLogout: true,
-        });
+        const response = await sendOnce();
 
         if (response.status === 401) {
           if (!fullUrl.includes("/session/check")) {
@@ -76,11 +80,7 @@ export function withSessionHandling(
             let unsubscribe: (() => void) | null = null;
 
             const retryAfterAuth = () => {
-              authClient
-                .makeAuthenticatedRequest(fullUrl, {
-                  method: config.method,
-                  skipAutoLogout: true,
-                })
+              sendOnce()
                 .then((retryResponse: Response) => {
                   return retryResponse.text().then((retryText: string) => {
                     const retryData = retryText ? JSON.parse(retryText) : null;


### PR DESCRIPTION
### Goal

POSTs whose session expired in-flight were reaching the backend with no body after re-auth, producing `400 Missing Request Body`. The retry path in `withSessionHandling` had drifted from the initial-call path and was dropping `body` and `headers` before reissuing the request. This affected consumer-side `POST /documents`, `/facets`, `/typeahead`, and `/documents/text-lookup` calls in `telicent-apps`, which had pre-stringified payloads as a workaround.

### Work Completed

- Extracted a `sendOnce()` closure in `withSessionHandling.ts` used by both the initial call and the post-reauth retry, so the two paths can no longer diverge on body/headers/method.
- Added a Jest regression test that mocks the broadcast service, fires `AUTHENTICATED` after a 401, and asserts call #2 has the same `body`, `headers`, and `method` as call #1 (specifically that the form-urlencoded body is not `undefined`).
- Drive-by fix to `scripts/local-publish.sh`: `npm publish --prepatch` is not a valid flag (`--prepatch` is an `npm version` bump type). Replaced with `--tag prerelease`, which is what npm requires when publishing a prerelease version.

### Design Testing

No UI changes — backend-only fix in the auth/retry middleware. Design checklist will be `[-]`.

- Pre-release version: _e.g. v1.2.3-JIRA-123.0_
- [ ] This PR is setup for easy assessment of "<strong>Design approval areas</strong>")

<details>
  <summary><strong>Design approval areas</strong></summary>

  <hr />
  
  A _indicative_ list of suggested screenshots or videos.

Action each: Mark "`[x]`" (click) for _complete_, or "`[-]`" for _not-applicable_.

- [ ] UI content:
  - [ ] **Ideal** - show UI with "happy content" i.e. what Figma considers typical
  - [ ] **Empty** - show UI with empty (or minimum) content
  - [ ] **Full** - show UI with all (or technically maximum) content
- [ ] UI States:
  - [ ] **Form validation** - show UI for validation errors, hints and success
  - [ ] **Network states** - show UI for fetch failures and success
  - [ ] **env-config errors** - show release-engineer UI for app config errors
- [ ] Responsiveness:
  - [ ] **Min width** - show UI with minimum width supported by parent container, or [most common desktop](https://www.google.com/search?q=most+common+desktop+screen+resolution+now) split screen
  - [ ] **Min height** - show UI with minimum height supported by parent container, or [most common desktop](https://www.google.com/search?q=most+common+desktop+screen+resolution+now) half height
- [ ] Accessibility: new issues introduced this PR (perhaps include report before, and report after)

</details>

### Testing Method

1. `npx jest src/utils/authorize-flow/services/__tests__/withSessionHandling` — both files pass (3 tests, including the new retry regression).
2. End-to-end against the consumer apps: ran `yarn local-publish`, which built `@telicent-oss/ds@3.0.1-1` to local verdaccio (`http://localhost:4873`) and propagated the bump into `telicent-graph`, `telicent-query`, `telicent-search`, `telicent-admin`, and `catalogue`. Then exercised a POST → forced session expiry → re-auth flow and confirmed the second request now reaches the backend with body + headers intact (no `400 Missing Request Body`).

### Code Review Tips

The behavioural change is entirely in the `sendOnce` extraction in `src/utils/authorize-flow/services/withSessionHandling.ts`. Diff-reading order:

1. `withSessionHandling.ts` — confirm both `await sendOnce()` (initial) and `sendOnce()` (retry) read the same closure-captured config.
2. `withSessionHandling.retry.test.ts` — the broadcast service is mocked because the real `BroadcastChannel` delivery is task-queue async and flakey in jsdom; `__fire` lets us trigger `AUTHENTICATED` deterministically.
3. `scripts/local-publish.sh` — independent two-line flag fix; unrelated to the bug but needed to publish the fix locally.

### Engineering Notes

Once this ships and consumers bump, the `qs.stringify(...)` pre-stringification workaround in `telicent-apps` (commit `5a2c5eb6`) is no longer needed — that body-survival hack was compensating for this exact drop. No FE follow-up required on `telicent-apps` PR #42 (TELFE-1588).

---

<details>
  <summary><strong>🕵️ Review Guidance</strong></summary>

---

General guidance

- Generally, approve a PR if it makes the system better, even if it's not perfect. — [Google: The Standard of Code Review](https://google.github.io/eng-practices/review/reviewer/standard.html)
- The aim of both PR AUTHOR and PR REVIEWER is to get the code merged
- Aim for consensus, defined as _everyone can live with the outcome_
- PR with changes requires 2 approvals
- PR with no changes requires 1 approvals

For PR REVIEWER:

1. Read the ticket & description
2. [Review the code](https://google.github.io/eng-practices/review/reviewer/looking-for.html)
3. Request any changes that are essential.
4. For non-essential comments:
   - Use prefixes, e.g. "**nit:** change to Pascal case"
     - **nit:** small, non-essential change
     - **obs:** just an observation, doesn't affect the PR
     - **idea:** a suggestion to think about
     - **q:** questions
   - Use modifiers, e.g. "**obs**`[pr-owner-resolve]`: Jim is also editing this file"
     - `pr-author-resolve` PR author can resolve after reading
     - `pr-author-delete` (rare) delete after reading to avoid confusion
5. try to add _at least_ a helpful comment per ~500 lines; less if the PR is already busy

For PR AUTHOR:

1. Aim for enough detail in PR description for things to go smoothly
2. After requested changes, [re-request a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews#re-requesting-a-review) (so the PR shows up in [reviews-requested:@me](https://github.com/pulls?q=is%3Apr+is%3Aopen+archived%3Afalse+sort%3Aupdated-desc+review-requested%3A%40me+))

</details>
