### PR TITLE
feat: theme colour refactor, Select footer slot, optional UserProfile fullName

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/telicent-oss/telicent-ds.git"
   },
   "type": "module",
-  "version": "3.0.2-0",
+  "version": "3.0.1",
   "private": false,
   "dependencies": {
     "@emotion/react": "^11.10.6",

--- a/src/components/data-display/UserProfile/UserProfile.tsx
+++ b/src/components/data-display/UserProfile/UserProfile.tsx
@@ -9,7 +9,7 @@ import UserIcon from "../Icons/UserIcon";
 import DownArrowIcon from "../FontAwesomeIcons/DownArrowIcon";
 
 export type UserProfileProps = PropsWithChildren & {
-  fullName: string;
+  fullName?: string;
 };
 
 const UserProfile: React.FC<UserProfileProps> = ({ fullName, children }) => {

--- a/src/components/inputs/Select/Select.stories.tsx
+++ b/src/components/inputs/Select/Select.stories.tsx
@@ -2,6 +2,8 @@ import { Meta, StoryObj } from "@storybook/react-vite";
 import Select, { Options } from "./Select";
 import { Box, SelectChangeEvent } from "@mui/material";
 import { useState } from "react";
+import Button from "../../buttons/Button/Button";
+import PlusCircleIcon from "../../data-display/Icons/PlusCircleIcon";
 
 const OPTIONS: Options[] = [
   { value: "option1", label: "Option 1" },
@@ -32,6 +34,8 @@ A lightweight dropdown component built on Mui's \`<Select>\` with our design-sys
  - **Label is optional:** only renders the label if you pass the \`label\` prop. You can choose to omit the prop for a cleaner label-free form.
  
  - **Min Width:** It has a min width by default that can be customized by using the \`width\` prop.
+
+ - **Footer slot:** pass the optional \`footer\` prop to render an action below the options (e.g. a "+ Create new …" button), separated by a divider. The footer is **not** selectable as a value. Use the render-function form \`footer={({ closeMenu }) => …}\` to dismiss the dropdown from your handler (see the **WithFooter** story), or pass a plain node when you don't need to close the menu yourself.
 
 
 \`\`\`jsx
@@ -133,5 +137,47 @@ export const ExampleWithOnChange: Story = {
   args: {
     width: 250,
     disabled: false,
+  },
+};
+
+const OWNER_OPTIONS: Options[] = [
+  { value: "mcga", label: "Maritime Coastguard Agency" },
+  { value: "ukho", label: "UK Hydrographic Office" },
+  { value: "imo", label: "IMO" },
+];
+
+/**
+ * The `footer` prop renders an action below the option list, separated by a
+ * divider — typically a "+ Create new …" button. The footer is **not**
+ * selectable as a value; clicking it will not fire `onChange`.
+ *
+ * There are two forms:
+ *
+ * - **Render function** — `footer={({ closeMenu }) => …}` receives `closeMenu`,
+ *   so your click handler can dismiss the dropdown before acting (e.g. before
+ *   opening a "create" modal). This is the common case, shown below.
+ * - **Plain node** — `footer={<MyAction />}` when you don't need to close the
+ *   menu yourself (the menu stays open until the user clicks away).
+ */
+export const WithFooter: Story = {
+  args: {
+    label: "Owner",
+    value: "mcga",
+    width: 300,
+    onChange: () => {},
+    options: OWNER_OPTIONS,
+    footer: ({ closeMenu }) => (
+      <Button
+        variant="text"
+        startIcon={<PlusCircleIcon />}
+        onClick={() => {
+          closeMenu();
+          // A host app would open its "create new owner" modal here.
+        }}
+        sx={{ width: "100%", justifyContent: "flex-start", textTransform: "none" }}
+      >
+        Create new owner
+      </Button>
+    ),
   },
 };

--- a/src/components/inputs/Select/Select.test.tsx
+++ b/src/components/inputs/Select/Select.test.tsx
@@ -1,0 +1,138 @@
+import React from "react";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+
+import Select, { Options } from "./Select";
+import { setup } from "../../../test-utils";
+
+const OPTIONS: Options[] = [
+  { value: "option1", label: "Option 1" },
+  { value: "option2", label: "Option 2" },
+  { value: "option3", label: "Option 3" },
+];
+
+describe("Select footer slot", () => {
+  afterEach(cleanup);
+
+  it("existing behaviour unchanged — no footer element or divider when footer is not provided", async () => {
+    const { user } = setup(
+      <Select label="Owner" value="" onChange={() => {}} options={OPTIONS} />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+
+    const listbox = await screen.findByRole("listbox");
+    // No footer wrapper and no separator inside the option list.
+    expect(listbox.querySelector('[role="separator"]')).toBeNull();
+    expect(listbox.querySelector('[role="presentation"]')).toBeNull();
+  });
+
+  it("renders the footer beneath the options, preceded by a divider", async () => {
+    const { user } = setup(
+      <Select
+        label="Owner"
+        value=""
+        onChange={() => {}}
+        options={OPTIONS}
+        footer={<button type="button">Create new owner</button>}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+
+    const listbox = await screen.findByRole("listbox");
+    const footerButton = screen.getByRole("button", {
+      name: "Create new owner",
+    });
+    expect(footerButton).toBeInTheDocument();
+
+    const separator = listbox.querySelector(".MuiDivider-root");
+    expect(separator).not.toBeNull();
+
+    // The divider must come before the footer in document order.
+    expect(
+      separator!.compareDocumentPosition(footerButton) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("clicking the footer does not change the value", async () => {
+    const onChange = jest.fn();
+    const { user } = setup(
+      <Select
+        label="Owner"
+        value="option1"
+        onChange={onChange}
+        options={OPTIONS}
+        footer={<button type="button">Create new owner</button>}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("button", { name: "Create new owner" }));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("passes closeMenu to the render-prop form so the footer can dismiss the menu", async () => {
+    const { user } = setup(
+      <Select
+        label="Owner"
+        value=""
+        onChange={() => {}}
+        options={OPTIONS}
+        footer={({ closeMenu }) => (
+          <button type="button" onClick={closeMenu}>
+            Create new owner
+          </button>
+        )}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    expect(await screen.findByRole("listbox")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Create new owner" }));
+
+    // Menu dismissed — the option list is removed from the DOM.
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("Enter on a focused footer button does not change the value", async () => {
+    const onChange = jest.fn();
+    const { user } = setup(
+      <Select
+        label="Owner"
+        value="option1"
+        onChange={onChange}
+        options={OPTIONS}
+        footer={<button type="button">Create new owner</button>}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+
+    const footerButton = screen.getByRole("button", {
+      name: "Create new owner",
+    });
+    fireEvent.keyDown(footerButton, { key: "Enter", code: "Enter" });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("does not surface the footer in the trigger's displayed value", () => {
+    render(
+      <Select
+        label="Owner"
+        value="option1"
+        onChange={() => {}}
+        options={OPTIONS}
+        footer={<button type="button">Create new owner</button>}
+      />,
+    );
+
+    // The closed trigger shows the selected option's label, not the footer.
+    const combobox = screen.getByRole("combobox");
+    expect(combobox).toHaveTextContent("Option 1");
+    expect(combobox).not.toHaveTextContent("Create new owner");
+  });
+});

--- a/src/components/inputs/Select/Select.test.tsx
+++ b/src/components/inputs/Select/Select.test.tsx
@@ -55,6 +55,28 @@ describe("Select footer slot", () => {
     ).toBeTruthy();
   });
 
+  it("renders the footer with no divider when there are no options", async () => {
+    const { user } = setup(
+      <Select
+        label="Owner"
+        value=""
+        onChange={() => {}}
+        options={[]}
+        footer={<button type="button">Create new owner</button>}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+
+    const listbox = await screen.findByRole("listbox");
+    // Footer is present even with an empty option list...
+    expect(
+      screen.getByRole("button", { name: "Create new owner" }),
+    ).toBeInTheDocument();
+    // ...but the divider is suppressed since there are no options above it.
+    expect(listbox.querySelector(".MuiDivider-root")).toBeNull();
+  });
+
   it("clicking the footer does not change the value", async () => {
     const onChange = jest.fn();
     const { user } = setup(

--- a/src/components/inputs/Select/Select.tsx
+++ b/src/components/inputs/Select/Select.tsx
@@ -1,4 +1,6 @@
 import {
+  Box,
+  Divider,
   FormControl,
   InputLabel,
   Select as MUISelect,
@@ -13,10 +15,30 @@ export interface Options {
   label: string;
 }
 
+/**
+ * Arguments passed to the `footer` render function.
+ */
+export type SelectFooterArgs = {
+  /** Closes the dropdown — call this before opening a modal, for example. */
+  closeMenu: () => void;
+};
+
 export type SelectProps = MuiSelectProps & {
   options: Options[];
   width?: number | string;
   helperText?: React.ReactNode;
+  /**
+   * Optional content rendered below the option list, separated by a
+   * divider. Use this for inline actions like "+ Create new …".
+   *
+   * Pass a render function to receive `closeMenu`, so your click handler
+   * can dismiss the dropdown after acting (e.g. before opening a modal).
+   * Pass a plain ReactNode if you don't need to close the menu yourself.
+   *
+   * The footer is NOT selectable as a value — clicking it will not fire
+   * `onChange`.
+   */
+  footer?: React.ReactNode | ((args: SelectFooterArgs) => React.ReactNode);
 };
 
 const Select = React.forwardRef<HTMLInputElement, SelectProps>(
@@ -34,6 +56,7 @@ const Select = React.forwardRef<HTMLInputElement, SelectProps>(
       error = false,
       required = false,
       fullWidth = false,
+      footer,
       ...rest
     },
     ref,
@@ -42,6 +65,23 @@ const Select = React.forwardRef<HTMLInputElement, SelectProps>(
     const selectedId = id ?? `select-${reactId}`;
     const labelId = label ? `${selectedId}-label` : undefined;
     const helperTextId = helperText ? `${selectedId}-helper-text` : undefined;
+
+    // Own the open state so the footer can dismiss the menu via `closeMenu`.
+    // If the caller controls `open`, defer to them and just mirror their
+    // open/close callbacks.
+    const [openInternal, setOpenInternal] = React.useState(false);
+    const isOpenControlled = "open" in rest;
+    const openProp = isOpenControlled ? rest.open : openInternal;
+
+    const handleOpen: NonNullable<MuiSelectProps["onOpen"]> = (event) => {
+      setOpenInternal(true);
+      rest.onOpen?.(event);
+    };
+    const handleClose: NonNullable<MuiSelectProps["onClose"]> = (event) => {
+      setOpenInternal(false);
+      rest.onClose?.(event);
+    };
+    const closeMenu = React.useCallback(() => setOpenInternal(false), []);
 
     return (
       <FormControl
@@ -60,6 +100,9 @@ const Select = React.forwardRef<HTMLInputElement, SelectProps>(
 
         <MUISelect
           {...rest}
+          open={openProp}
+          onOpen={handleOpen}
+          onClose={handleClose}
           color="primary"
           variant="outlined"
           labelId={labelId}
@@ -75,6 +118,35 @@ const Select = React.forwardRef<HTMLInputElement, SelectProps>(
               {option.label}
             </MenuItem>
           ))}
+          {footer && options.length > 0 && (
+            <Divider
+              key="__ds-select-footer-divider"
+              component="li"
+              role="separator"
+              sx={{ my: 0.5 }}
+            />
+          )}
+          {footer && (
+            <Box
+              key="__ds-select-footer"
+              component="li"
+              role="presentation"
+              sx={{ px: 1.5, py: 0.5, listStyle: "none" }}
+              // Stop propagation so MUI's Select doesn't treat a click inside
+              // the footer as an option selection. The footer's own onClick
+              // handlers still fire.
+              onClick={(e) => e.stopPropagation()}
+              onKeyDown={(e) => {
+                // Don't let Enter/Space inside the footer trigger Select's
+                // option-selection keyboard handlers.
+                if (e.key === "Enter" || e.key === " ") {
+                  e.stopPropagation();
+                }
+              }}
+            >
+              {typeof footer === "function" ? footer({ closeMenu }) : footer}
+            </Box>
+          )}
         </MUISelect>
         {helperText && (
           <FormHelperText error={error} id={helperTextId}>

--- a/src/components/inputs/index.ts
+++ b/src/components/inputs/index.ts
@@ -7,6 +7,7 @@ export { default as Select } from "./Select/Select";
 export { default as Autocomplete } from "./Autocomplete/Autocomplete";
 export type { SelectProps } from "./Select/Select";
 export type { Options } from "./Select/Select";
+export type { SelectFooterArgs } from "./Select/Select";
 export { default as Switch } from "./Switch/Switch";
 
 export { default as DatePicker } from "./DatePicker/DatePicker";

--- a/src/theme/colors/AdminBlue.ts
+++ b/src/theme/colors/AdminBlue.ts
@@ -6,16 +6,20 @@ const lightMain = "#2F44CA";
 
 const AdminBlue = {
   dark: {
-    main: darkMain,
-    dark: alpha(darkMain, 0.7),
-    light: alpha(darkMain, 0.5),
-    contrastText: common.black,
+    primary: {
+      main: darkMain,
+      dark: alpha(darkMain, 0.7),
+      light: alpha(darkMain, 0.5),
+      contrastText: common.black,
+    },
   },
   light: {
-    main: lightMain,
-    dark: alpha(lightMain, 0.7),
-    light: alpha(lightMain, 0.5),
-    contrastText: "#FFFFFF",
+    primary: {
+      main: lightMain,
+      dark: alpha(lightMain, 0.7),
+      light: alpha(lightMain, 0.5),
+      contrastText: "#FFFFFF",
+    },
   },
 };
 

--- a/src/theme/colors/AdminBlue.ts
+++ b/src/theme/colors/AdminBlue.ts
@@ -1,14 +1,21 @@
 import { alpha } from "@mui/material/styles";
 import { common } from "@mui/material/colors";
 
-const main = "#20BCFA";
+const darkMain = "#20BCFA";
+const lightMain = "#2F44CA";
 
 const AdminBlue = {
-  primary: {
-    main: main,
-    dark: alpha(main, 0.7),
-    light: alpha(main, 0.5),
+  dark: {
+    main: darkMain,
+    dark: alpha(darkMain, 0.7),
+    light: alpha(darkMain, 0.5),
     contrastText: common.black,
+  },
+  light: {
+    main: lightMain,
+    dark: alpha(lightMain, 0.7),
+    light: alpha(lightMain, 0.5),
+    contrastText: "#FFFFFF",
   },
 };
 

--- a/src/theme/colors/BlankTheme.ts
+++ b/src/theme/colors/BlankTheme.ts
@@ -5,10 +5,12 @@ const main = "#000000";
 
 const Blank = {
   light: {
-    main,
-    dark: alpha(main, 0.7),
-    light: alpha(main, 0.5),
-    contrastText: common.white,
+    primary: {
+      main,
+      dark: alpha(main, 0.7),
+      light: alpha(main, 0.5),
+      contrastText: common.white,
+    },
   },
 };
 

--- a/src/theme/colors/BlankTheme.ts
+++ b/src/theme/colors/BlankTheme.ts
@@ -4,8 +4,8 @@ import { alpha } from "@mui/material/styles";
 const main = "#000000";
 
 const Blank = {
-  primary: {
-    main: main,
+  light: {
+    main,
     dark: alpha(main, 0.7),
     light: alpha(main, 0.5),
     contrastText: common.white,

--- a/src/theme/colors/DataNavy.ts
+++ b/src/theme/colors/DataNavy.ts
@@ -3,15 +3,11 @@ import { alpha } from "@mui/material/styles";
 const main = "#2F44CA";
 
 const DataNavy = {
-  primary: {
-    main: "#2F44CA",
+  light: {
+    main,
     dark: alpha(main, 0.7),
     light: alpha(main, 0.5),
     contrastText: "#FFFFFF",
-  },
-  secondary: {
-    main: "#FF0000",
-    contrastText: "#000",
   },
 };
 

--- a/src/theme/colors/DataNavy.ts
+++ b/src/theme/colors/DataNavy.ts
@@ -4,10 +4,12 @@ const main = "#2F44CA";
 
 const DataNavy = {
   light: {
-    main,
-    dark: alpha(main, 0.7),
-    light: alpha(main, 0.5),
-    contrastText: "#FFFFFF",
+    primary: {
+      main,
+      dark: alpha(main, 0.7),
+      light: alpha(main, 0.5),
+      contrastText: "#FFFFFF",
+    },
   },
 };
 

--- a/src/theme/colors/DocumentPink.ts
+++ b/src/theme/colors/DocumentPink.ts
@@ -4,8 +4,8 @@ import { alpha } from "@mui/material/styles";
 const main = "#F56AAA";
 
 const DocumentPink = {
-  primary: {
-    main: "#F56AAA",
+  dark: {
+    main,
     dark: alpha(main, 0.7),
     light: alpha(main, 0.5),
     contrastText: common.black,

--- a/src/theme/colors/DocumentPink.ts
+++ b/src/theme/colors/DocumentPink.ts
@@ -5,10 +5,12 @@ const main = "#F56AAA";
 
 const DocumentPink = {
   dark: {
-    main,
-    dark: alpha(main, 0.7),
-    light: alpha(main, 0.5),
-    contrastText: common.black,
+    primary: {
+      main,
+      dark: alpha(main, 0.7),
+      light: alpha(main, 0.5),
+      contrastText: common.black,
+    },
   },
 };
 

--- a/src/theme/colors/GraphOrange.ts
+++ b/src/theme/colors/GraphOrange.ts
@@ -4,8 +4,8 @@ import { alpha } from "@mui/material/styles";
 const main = "#F2A64B";
 
 const GraphOrange = {
-  primary: {
-    main: main,
+  dark: {
+    main,
     dark: alpha(main, 0.7),
     light: alpha(main, 0.5),
     contrastText: common.black,

--- a/src/theme/colors/GraphOrange.ts
+++ b/src/theme/colors/GraphOrange.ts
@@ -5,10 +5,12 @@ const main = "#F2A64B";
 
 const GraphOrange = {
   dark: {
-    main,
-    dark: alpha(main, 0.7),
-    light: alpha(main, 0.5),
-    contrastText: common.black,
+    primary: {
+      main,
+      dark: alpha(main, 0.7),
+      light: alpha(main, 0.5),
+      contrastText: common.black,
+    },
   },
 };
 

--- a/src/theme/colors/palette/basePalette.ts
+++ b/src/theme/colors/palette/basePalette.ts
@@ -1,0 +1,42 @@
+import { grey } from "@mui/material/colors";
+import { alpha } from "@mui/material/styles";
+
+// Shared palette tokens inherited by every theme unless the theme overrides
+// them. A theme file may override any of these per mode (see ThemeModePalette);
+// tokens not overridden fall back to the values defined here.
+
+export const baseLightPalette = {
+  tertiary: {
+    main: "#8094A3",
+    dark: alpha("#8094A3", 0.7),
+    light: alpha("#8094A3", 0.5),
+    contrastText: "#252525",
+  },
+  text: {
+    primary: "#000000",
+    secondary: "#000000",
+    disabled: "#999999",
+  },
+  background: {
+    default: "#F9F9F9",
+  },
+};
+
+export const baseDarkPalette = {
+  tertiary: {
+    main: "#6B6B6B",
+    dark: alpha("#6B6B6B", 0.7),
+    light: alpha("#6B6B6B", 0.5),
+    contrastText: "#FFFFFF",
+  },
+  text: {
+    primary: "#ececec",
+    secondary: "rgba(255, 255, 255, 0.7)",
+    disabled: "#999999",
+  },
+  background: {
+    default: "#1D1D1D",
+    paper: "#252525",
+  },
+  grey,
+};

--- a/src/theme/colors/palette/createDarkPalette.ts
+++ b/src/theme/colors/palette/createDarkPalette.ts
@@ -7,7 +7,7 @@ import createLightPalette from "./createLightPalette";
 const createDarkPalette = (uiTheme: UITheme): ThemeOptions["palette"] =>
   merge(createLightPalette(uiTheme), {
     mode: "dark",
-    primary: THEME_COLORS[uiTheme].primary,
+    primary: THEME_COLORS[uiTheme].dark ?? THEME_COLORS[uiTheme].light,
     tertiary: {
       main: "#6B6B6B",
       dark: alpha("#6B6B6B", 0.7),

--- a/src/theme/colors/palette/createDarkPalette.ts
+++ b/src/theme/colors/palette/createDarkPalette.ts
@@ -1,29 +1,14 @@
-import { alpha, ThemeOptions } from "@mui/material";
-import { grey } from "@mui/material/colors";
-import THEME_COLORS, { UITheme } from "../theme-colors";
+import { ThemeOptions } from "@mui/material/styles";
 import merge from "lodash.merge";
-import createLightPalette from "./createLightPalette";
+import THEME_COLORS, { UITheme } from "../theme-colors";
+import { baseDarkPalette } from "./basePalette";
 
-const createDarkPalette = (uiTheme: UITheme): ThemeOptions["palette"] =>
-  merge(createLightPalette(uiTheme), {
-    mode: "dark",
-    primary: THEME_COLORS[uiTheme].dark ?? THEME_COLORS[uiTheme].light,
-    tertiary: {
-      main: "#6B6B6B",
-      dark: alpha("#6B6B6B", 0.7),
-      light: alpha("#6B6B6B", 0.5),
-      contrastText: "#FFFFFF",
-    },
-    text: {
-      primary: "#ececec",
-      secondary: "rgba(255, 255, 255, 0.7)",
-      disabled: "#999999",
-    },
-    background: {
-      default: "#1D1D1D",
-      paper: "#252525",
-    },
-    grey,
-  });
+const createDarkPalette = (uiTheme: UITheme): ThemeOptions["palette"] => {
+  const themePalette = THEME_COLORS[uiTheme].dark ?? THEME_COLORS[uiTheme].light;
+  // Order matters: seed establishes mode + primary, the shared base fills the
+  // remaining tokens, then the theme's own palette merges last so any per-theme
+  // overrides (tertiary, text, background) win over the base defaults.
+  return merge({ mode: "dark" as const, primary: themePalette?.primary }, baseDarkPalette, themePalette);
+};
 
 export default createDarkPalette;

--- a/src/theme/colors/palette/createLightPalette.ts
+++ b/src/theme/colors/palette/createLightPalette.ts
@@ -3,7 +3,7 @@ import THEME_COLORS, { UITheme } from "../theme-colors";
 
 const createLightPalette = (uiTheme: UITheme): ThemeOptions["palette"] => ({
   mode: "light",
-  primary: THEME_COLORS[uiTheme].primary,
+  primary: THEME_COLORS[uiTheme].light ?? THEME_COLORS[uiTheme].dark,
   tertiary: {
     main: "#8094A3",
     dark: alpha("#8094A3", 0.7),

--- a/src/theme/colors/palette/createLightPalette.ts
+++ b/src/theme/colors/palette/createLightPalette.ts
@@ -1,23 +1,14 @@
-import { alpha, ThemeOptions } from "@mui/material/styles";
+import { ThemeOptions } from "@mui/material/styles";
+import merge from "lodash.merge";
 import THEME_COLORS, { UITheme } from "../theme-colors";
+import { baseLightPalette } from "./basePalette";
 
-const createLightPalette = (uiTheme: UITheme): ThemeOptions["palette"] => ({
-  mode: "light",
-  primary: THEME_COLORS[uiTheme].light ?? THEME_COLORS[uiTheme].dark,
-  tertiary: {
-    main: "#8094A3",
-    dark: alpha("#8094A3", 0.7),
-    light: alpha("#8094A3", 0.5),
-    contrastText: "#252525",
-  },
-  text: {
-    primary: "#000000",
-    secondary: "#000000",
-    disabled: "#999999",
-  },
-  background: {
-    default: "#F9F9F9",
-  },
-});
+const createLightPalette = (uiTheme: UITheme): ThemeOptions["palette"] => {
+  const themePalette = THEME_COLORS[uiTheme].light ?? THEME_COLORS[uiTheme].dark;
+  // Order matters: seed establishes mode + primary, the shared base fills the
+  // remaining tokens, then the theme's own palette merges last so any per-theme
+  // overrides (tertiary, text, background) win over the base defaults.
+  return merge({ mode: "light" as const, primary: themePalette?.primary }, baseLightPalette, themePalette);
+};
 
 export default createLightPalette;

--- a/src/theme/colors/theme-colors.ts
+++ b/src/theme/colors/theme-colors.ts
@@ -8,20 +8,41 @@ import Blank from "./BlankTheme";
 export const UIThemeSchema = zod.enum(["DataNavy", "DocumentPink", "GraphOrange", "AdminBlue", "Blank"]);
 export type UITheme = zod.infer<typeof UIThemeSchema>;
 
-type PaletteColor = {
+export type PaletteColor = {
   main: string;
   dark: string;
   light: string;
   contrastText: string;
 };
 
-const THEME_COLORS: Record<
-  UITheme,
-  {
-    dark?: PaletteColor;
-    light?: PaletteColor;
-  }
-> = {
+export type TextPalette = {
+  primary: string;
+  secondary: string;
+  disabled: string;
+};
+
+export type BackgroundPalette = {
+  default: string;
+  paper?: string;
+};
+
+// A single mode (light or dark) of a theme. `primary` is the only required
+// token; every other token is an optional override of the shared base palette
+// (see ./palette/basePalette). Supply a partial object to tweak individual
+// fields, or a full object to replace a base token entirely.
+export type ThemeModePalette = {
+  primary: PaletteColor;
+  tertiary?: PaletteColor;
+  text?: Partial<TextPalette>;
+  background?: Partial<BackgroundPalette>;
+};
+
+export type ThemeColor = {
+  dark?: ThemeModePalette;
+  light?: ThemeModePalette;
+};
+
+const THEME_COLORS: Record<UITheme, ThemeColor> = {
   DataNavy,
   DocumentPink,
   GraphOrange,

--- a/src/theme/colors/theme-colors.ts
+++ b/src/theme/colors/theme-colors.ts
@@ -8,27 +8,18 @@ import Blank from "./BlankTheme";
 export const UIThemeSchema = zod.enum(["DataNavy", "DocumentPink", "GraphOrange", "AdminBlue", "Blank"]);
 export type UITheme = zod.infer<typeof UIThemeSchema>;
 
+type PaletteColor = {
+  main: string;
+  dark: string;
+  light: string;
+  contrastText: string;
+};
+
 const THEME_COLORS: Record<
   UITheme,
   {
-    primary: {
-      main: string;
-      dark: string;
-      light: string;
-      contrastText: string;
-    };
-    secondary?: {
-      main?: string;
-      dark?: string;
-      light?: string;
-      contrastText?: string;
-    };
-    tertiary?: {
-      main?: string;
-      dark?: string;
-      light?: string;
-      contrastText?: string;
-    };
+    dark?: PaletteColor;
+    light?: PaletteColor;
   }
 > = {
   DataNavy,

--- a/src/theme/createTheme.test.ts
+++ b/src/theme/createTheme.test.ts
@@ -44,7 +44,7 @@ test("tmp theme diffs via unified patches", () => {
     ===================================================================
     --- 0	DataNavy (light)
     +++ 0	DataNavy (dark)
-    @@ -93,45 +93,28 @@
+    @@ -88,45 +88,28 @@
          },
          "MuiCssBaseline": {}
        },
@@ -104,18 +104,7 @@ test("tmp theme diffs via unified patches", () => {
     ===================================================================
     --- 1	DataNavy (light)
     +++ 1	DocumentPink (light)
-    @@ -47,9 +47,9 @@
-               },
-               "style": {
-                 "borderWidth": 1,
-                 "borderStyle": "solid",
-    -            "borderColor": "rgba(47, 68, 202, 0.4)"
-    +            "borderColor": "rgba(245, 106, 170, 0.4)"
-               }
-             }
-           ],
-           "styleOverrides": {}
-    @@ -95,12 +95,12 @@
+    @@ -90,12 +90,12 @@
        },
        "palette": {
          "mode": "dark",
@@ -138,18 +127,7 @@ test("tmp theme diffs via unified patches", () => {
     ===================================================================
     --- 2	DataNavy (light)
     +++ 2	DocumentPink (dark)
-    @@ -47,9 +47,9 @@
-               },
-               "style": {
-                 "borderWidth": 1,
-                 "borderStyle": "solid",
-    -            "borderColor": "rgba(47, 68, 202, 0.4)"
-    +            "borderColor": "rgba(245, 106, 170, 0.4)"
-               }
-             }
-           ],
-           "styleOverrides": {}
-    @@ -93,45 +93,28 @@
+    @@ -88,45 +88,28 @@
          },
          "MuiCssBaseline": {}
        },
@@ -213,18 +191,7 @@ test("tmp theme diffs via unified patches", () => {
     ===================================================================
     --- 3	DataNavy (light)
     +++ 3	GraphOrange (light)
-    @@ -47,9 +47,9 @@
-               },
-               "style": {
-                 "borderWidth": 1,
-                 "borderStyle": "solid",
-    -            "borderColor": "rgba(47, 68, 202, 0.4)"
-    +            "borderColor": "rgba(242, 166, 75, 0.4)"
-               }
-             }
-           ],
-           "styleOverrides": {}
-    @@ -95,12 +95,12 @@
+    @@ -90,12 +90,12 @@
        },
        "palette": {
          "mode": "dark",
@@ -247,18 +214,7 @@ test("tmp theme diffs via unified patches", () => {
     ===================================================================
     --- 4	DataNavy (light)
     +++ 4	GraphOrange (dark)
-    @@ -47,9 +47,9 @@
-               },
-               "style": {
-                 "borderWidth": 1,
-                 "borderStyle": "solid",
-    -            "borderColor": "rgba(47, 68, 202, 0.4)"
-    +            "borderColor": "rgba(242, 166, 75, 0.4)"
-               }
-             }
-           ],
-           "styleOverrides": {}
-    @@ -93,45 +93,28 @@
+    @@ -88,45 +88,28 @@
          },
          "MuiCssBaseline": {}
        },
@@ -322,18 +278,7 @@ test("tmp theme diffs via unified patches", () => {
     ===================================================================
     --- 5	DataNavy (light)
     +++ 5	AdminBlue (light)
-    @@ -47,9 +47,9 @@
-               },
-               "style": {
-                 "borderWidth": 1,
-                 "borderStyle": "solid",
-    -            "borderColor": "rgba(47, 68, 202, 0.4)"
-    +            "borderColor": "rgba(32, 188, 250, 0.4)"
-               }
-             }
-           ],
-           "styleOverrides": {}
-    @@ -95,12 +95,12 @@
+    @@ -90,12 +90,12 @@
        },
        "palette": {
          "mode": "dark",
@@ -356,18 +301,7 @@ test("tmp theme diffs via unified patches", () => {
     ===================================================================
     --- 6	DataNavy (light)
     +++ 6	AdminBlue (dark)
-    @@ -47,9 +47,9 @@
-               },
-               "style": {
-                 "borderWidth": 1,
-                 "borderStyle": "solid",
-    -            "borderColor": "rgba(47, 68, 202, 0.4)"
-    +            "borderColor": "rgba(32, 188, 250, 0.4)"
-               }
-             }
-           ],
-           "styleOverrides": {}
-    @@ -93,45 +93,28 @@
+    @@ -88,45 +88,28 @@
          },
          "MuiCssBaseline": {}
        },
@@ -431,18 +365,7 @@ test("tmp theme diffs via unified patches", () => {
     ===================================================================
     --- 7	DataNavy (light)
     +++ 7	Blank (light)
-    @@ -47,9 +47,9 @@
-               },
-               "style": {
-                 "borderWidth": 1,
-                 "borderStyle": "solid",
-    -            "borderColor": "rgba(47, 68, 202, 0.4)"
-    +            "borderColor": "rgba(0, 0, 0, 0.4)"
-               }
-             }
-           ],
-           "styleOverrides": {}
-    @@ -95,12 +95,12 @@
+    @@ -90,12 +90,12 @@
        },
        "palette": {
          "mode": "dark",
@@ -465,18 +388,7 @@ test("tmp theme diffs via unified patches", () => {
     ===================================================================
     --- 8	DataNavy (light)
     +++ 8	Blank (dark)
-    @@ -47,9 +47,9 @@
-               },
-               "style": {
-                 "borderWidth": 1,
-                 "borderStyle": "solid",
-    -            "borderColor": "rgba(47, 68, 202, 0.4)"
-    +            "borderColor": "rgba(0, 0, 0, 0.4)"
-               }
-             }
-           ],
-           "styleOverrides": {}
-    @@ -93,45 +93,28 @@
+    @@ -88,45 +88,28 @@
          },
          "MuiCssBaseline": {}
        },

--- a/src/theme/createTheme.test.ts
+++ b/src/theme/createTheme.test.ts
@@ -309,14 +309,10 @@ test("tmp theme diffs via unified patches", () => {
     -    "mode": "dark",
     +    "mode": "light",
          "primary": {
-    -      "main": "#2F44CA",
-    -      "dark": "rgba(47, 68, 202, 0.7)",
-    -      "light": "rgba(47, 68, 202, 0.5)",
-    -      "contrastText": "#FFFFFF"
-    +      "main": "#20BCFA",
-    +      "dark": "rgba(32, 188, 250, 0.7)",
-    +      "light": "rgba(32, 188, 250, 0.5)",
-    +      "contrastText": "#000"
+           "main": "#2F44CA",
+           "dark": "rgba(47, 68, 202, 0.7)",
+           "light": "rgba(47, 68, 202, 0.5)",
+           "contrastText": "#FFFFFF"
          },
          "tertiary": {
     -      "main": "#6B6B6B",

--- a/src/theme/style-overrides/component-overrides/card-overrides.ts
+++ b/src/theme/style-overrides/component-overrides/card-overrides.ts
@@ -1,17 +1,17 @@
 import { alpha, ThemeOptions } from "@mui/material";
-import THEME_COLORS, { UITheme } from "../../colors/theme-colors";
+import { UITheme } from "../../colors/theme-colors";
 
-const generateCardOverrides = (uiTheme: UITheme) =>
+const generateCardOverrides = (_uiTheme: UITheme) =>
   ({
     MuiCard: {
       variants: [
         {
           props: { variant: "outlined" },
-          style: {
+          style: ({ theme }) => ({
             borderWidth: 1,
             borderStyle: "solid",
-            borderColor: alpha(THEME_COLORS[uiTheme].primary.main, 0.4),
-          },
+            borderColor: alpha(theme.palette.primary.main, 0.4),
+          }),
         },
       ],
       styleOverrides: {


### PR DESCRIPTION
## Summary
- **Theme colours — palette slots** — restructured each theme's colour object
  from `{primary, secondary, tertiary}` to `{light, dark}` palette slots,
  consumed directly by the light/dark palette builders. Removed the unused
  secondary/tertiary entries. Card outlined-variant border now derives from the
  resolved theme palette instead of the raw colour map.
- **Theme colours — shared base palette** — extracted the previously inline
  `tertiary`/`text`/`background`/`grey` tokens out of the palette builders into a
  colocated `basePalette` module. Theme files now describe a full
  `ThemeModePalette` per mode (`primary` required; `tertiary`/`text`/`background`
  optional). Builders merge `base ← theme`, so a theme inherits the shared
  defaults and can override any token — partially or wholly — without
  duplicating the palette. Also removes a latent `lodash.merge` mutation of the
  shared colour objects (dark palette is now built independently of light).
- **Select** — new optional `footer` slot rendered beneath the options behind a
  divider, with a render-prop form exposing `closeMenu`. New `SelectFooterArgs`
  export.
- **UserProfile** — `fullName` is now optional.

## Breaking changes
None to the public API. Colour objects, `THEME_COLORS`, and the new `basePalette`
are internal (not exported); `UITheme` / `UIThemeSchema` are unchanged.
`Select.footer` and the `UserProfile.fullName` widening are additive/non-breaking.

## Behavioural change (visual)
- **AdminBlue light mode** renders `primary.main` as **#2F44CA (navy)** with white
  contrast text (not `#20BCFA` cyan); dark mode is unchanged. This is the value
  MUI already produces for consumers at runtime — the base-palette refactor also
  corrects the `createTheme` snapshot, which previously baked in a mutation
  artifact showing the cyan value. All other themes resolve to identical colours.
  No app currently consumes AdminBlue light mode.

## Verification
- `tsc --noEmit` — clean
- All theme × mode palettes diffed old-vs-new — **byte-for-byte identical** (no
  colour changes from the base-palette refactor)
- `jest` full suite — 290 passed, 7 skipped, 40 snapshots
- `jest src/theme` — pass (snapshots updated for the AdminBlue mutation-artifact fix)
- jest src/components/inputs/Select — 7/7 pass (added footer + empty-options case)