### PR TITLE
ci(llms): render manifest diff and link it from commit status

### DIFF
--- a/.github/workflows/deploy-llms.yml
+++ b/.github/workflows/deploy-llms.yml
@@ -3,13 +3,16 @@ name: deploy-llms.yml
 # Publishes llms.txt and llms-full.txt to the GitHub Pages site. Every deploy below
 # uses publish_dir ./llms, so each of these paths gets both files.
 #
-# ref     published at
-# main    /                and /v<major>/
-# branch  /<branch>/
+# Where each ref lands is in the table at "Resolve publish target", the only step
+# that reads the ref; every step after it reads that step's outputs.
 #
 # The per-major copy lets an app stuck on an old major still fetch the manifest for
 # the version it runs. keep_files:true stops a deploy wiping paths it did not write:
 # older majors, and Storybook, which owns the same paths.
+#
+# When the manifest changes, the run also publishes llms.diff.html: a diff2html
+# render of the new manifest against the site-root one. Two commit statuses link the
+# manifest and the report, so a reviewer sees what a branch changed.
 
 on:
   workflow_dispatch:
@@ -27,6 +30,7 @@ on:
 
 permissions:
   contents: write
+  statuses: write
 
 # Serialised against upload-storybook.yml's Pages deploys: both push to the same
 # gh-pages branch, so a shared group stops concurrent non-fast-forward pushes.
@@ -37,6 +41,9 @@ concurrency:
 jobs:
   deploy-llms:
     runs-on: ubuntu-latest
+    env:
+      SITE: https://telicent-oss.github.io/telicent-ds
+      REPO: https://github.com/telicent-oss/telicent-ds
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -45,6 +52,28 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22.22
+
+      # The one place the ref decides where things go. Everything downstream reads
+      # these outputs, so main/branch is stated here and nowhere else.
+      #   main   -> dir '.'        urlpath ''            major set  (adds the v<major> copy)
+      #   branch -> dir '<branch>' urlpath '<branch>/'   major unset
+      - name: Resolve publish target
+        id: target
+        run: |
+          ref="${{ github.ref_name }}"
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            {
+              echo "dir=."
+              echo "urlpath="
+              echo "major=$(node -p 'require("./package.json").version.split(".")[0]')"
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo "dir=$ref"
+              echo "urlpath=$ref/"
+            } >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Install dependencies
         run: LOCAL_MACHINE=false yarn install --frozen-lockfile
@@ -56,38 +85,72 @@ jobs:
       - name: Generate llms.txt
         run: yarn generate:llms
 
-      - name: Deploy llms.txt to Pages root
-        if: github.ref == 'refs/heads/main'
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./llms
-          destination_dir: ./
-          keep_files: true
-
-      # A failed read would leave major empty and publish to /v/, so fail here instead.
-      - name: Read major version
-        if: github.ref == 'refs/heads/main'
-        id: major
+      # Fetch the currently-live manifest BEFORE any deploy step overwrites it,
+      # diff the freshly-built one against it, and render the diff to HTML. The
+      # report rides along in ./llms so the deploy steps publish it too.
+      #
+      # Every manifest URL carries the branch: Storybook links as /<branch>/ and
+      # source links as blob/<branch>/, so a raw diff churns on that prefix and
+      # buries real changes. Collapse both prefixes to ../ on each side and name
+      # the branch once, at the top; the published manifests keep their real URLs.
+      # The baseline is the live root, always built from main (blob/main/).
+      - name: Build llms.txt diff report
+        id: diff
+        env:
+          URLPATH: ${{ steps.target.outputs.urlpath }}
+          BRANCH: ${{ steps.target.outputs.ref }}
         run: |
-          major="$(node -p 'require("./package.json").version.split(".")[0]')"
-          : "${major:?could not read the major from package.json}"
-          echo "major=$major" >> "$GITHUB_OUTPUT"
+          mkdir -p _diff
+          code=$(curl -sSL -o _diff/a.raw -w '%{http_code}' "$SITE/llms.txt" || echo 000)
+          if [ "$code" != "200" ]; then
+            echo "baseline fetch returned HTTP $code — treating as a new file"
+            : > _diff/a.raw
+          fi
+          cp llms/llms.txt _diff/b.raw
+          { echo "Branch: /";             sed "s#$SITE/#$SITE/../#g; s#$REPO/blob/main/#$REPO/blob/../#g"           _diff/a.raw; } > _diff/a
+          { echo "Branch: ${URLPATH:-/}"; sed "s#$SITE/$URLPATH#$SITE/../#g; s#$REPO/blob/$BRANCH/#$REPO/blob/../#g" _diff/b.raw; } > _diff/b
+          if diff -q _diff/a _diff/b >/dev/null; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "manifest is identical to the published one — no report"
+            exit 0
+          fi
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          diff -u --label a/llms.txt --label b/llms.txt _diff/a _diff/b > _diff/llms.diff || true
+          npx --yes diff2html-cli@5.2.15 -i file -F llms/llms.diff.html --style side -- _diff/llms.diff
 
-      - name: Deploy llms.txt to per-major path
-        if: github.ref == 'refs/heads/main'
+      # main -> site root; any other branch -> its preview folder. Same step either way.
+      - name: Deploy llms.txt
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./llms
-          destination_dir: ./v${{ steps.major.outputs.major }}
+          destination_dir: ${{ steps.target.outputs.dir }}
           keep_files: true
 
-      - name: Deploy llms.txt to per-branch preview
-        if: github.ref != 'refs/heads/main'
+      # Only main sets major, so this pinned copy runs only on main.
+      - name: Deploy per-major copy
+        if: steps.target.outputs.major != ''
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./llms
-          destination_dir: ${{ github.ref_name }}
+          destination_dir: ./v${{ steps.target.outputs.major }}
           keep_files: true
+
+      # Two clickable links on the commit's checks: the live manifest, and the
+      # rendered diff for this change. Runs after deploy so the report URL resolves.
+      - name: Post llms.txt links to commit status
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/${{ github.repository }}/statuses/${{ github.sha }}" \
+            -f state=success \
+            -f context="llms.txt / diff report" \
+            -f description="Rendered diff vs the published manifest" \
+            -f target_url="$SITE/${{ steps.target.outputs.urlpath }}llms.diff.html"
+          gh api "repos/${{ github.repository }}/statuses/${{ github.sha }}" \
+            -f state=success \
+            -f context="llms.txt / published manifest" \
+            -f description="The currently-live llms.txt" \
+            -f target_url="$SITE/llms.txt"

--- a/.github/workflows/deploy-llms.yml
+++ b/.github/workflows/deploy-llms.yml
@@ -53,10 +53,9 @@ jobs:
         with:
           node-version: 22.22
 
-      # The one place the ref decides where things go. Everything downstream reads
-      # these outputs, so main/branch is stated here and nowhere else.
-      #   main   -> dir '.'        urlpath ''            major set  (adds the v<major> copy)
-      #   branch -> dir '<branch>' urlpath '<branch>/'   major unset
+      # ref     dir         urlpath      major      published at
+      # main    '.'         ''           <major>    /llms.txt and /v<major>/llms.txt
+      # branch  '<branch>'  '<branch>/'  unset      /<branch>/llms.txt
       - name: Resolve publish target
         id: target
         run: |
@@ -85,15 +84,14 @@ jobs:
       - name: Generate llms.txt
         run: yarn generate:llms
 
-      # Fetch the currently-live manifest BEFORE any deploy step overwrites it,
-      # diff the freshly-built one against it, and render the diff to HTML. The
-      # report rides along in ./llms so the deploy steps publish it too.
+      # Runs before the deploy steps, which overwrite the manifest it diffs against.
+      # Writes the report into ./llms so those steps publish it.
       #
-      # Every manifest URL carries the branch: Storybook links as /<branch>/ and
-      # source links as blob/<branch>/, so a raw diff churns on that prefix and
-      # buries real changes. Collapse both prefixes to ../ on each side and name
-      # the branch once, at the top; the published manifests keep their real URLs.
-      # The baseline is the live root, always built from main (blob/main/).
+      # Manifest URLs carry the branch: /<branch>/ for Storybook, blob/<branch>/ for
+      # source. A raw diff would mark every one of those lines changed, so both sides
+      # collapse the prefix to ../ and a "Branch:" line at the top says which side is
+      # which. The published manifests keep their real URLs. The site-root manifest is
+      # always built from main.
       - name: Build llms.txt diff report
         id: diff
         env:
@@ -118,7 +116,6 @@ jobs:
           diff -u --label a/llms.txt --label b/llms.txt _diff/a _diff/b > _diff/llms.diff || true
           node_modules/.bin/diff2html -i file -F llms/llms.diff.html --style side -- _diff/llms.diff
 
-      # main -> site root; any other branch -> its preview folder. Same step either way.
       - name: Deploy llms.txt
         uses: peaceiris/actions-gh-pages@v3
         with:
@@ -127,7 +124,6 @@ jobs:
           destination_dir: ${{ steps.target.outputs.dir }}
           keep_files: true
 
-      # Only main sets major, so this pinned copy runs only on main.
       - name: Deploy per-major copy
         if: steps.target.outputs.major != ''
         uses: peaceiris/actions-gh-pages@v3
@@ -137,10 +133,7 @@ jobs:
           destination_dir: ./v${{ steps.target.outputs.major }}
           keep_files: true
 
-      # Two clickable links on the commit's checks: the manifest this ref just
-      # published, and the rendered diff for this change. Both read urlpath, so on
-      # main they point at the site root and on a branch at its preview folder.
-      # Runs after deploy so both URLs resolve.
+      # Runs after the deploys so both URLs resolve.
       - name: Post llms.txt links to commit status
         if: steps.diff.outputs.changed == 'true'
         env:

--- a/.github/workflows/deploy-llms.yml
+++ b/.github/workflows/deploy-llms.yml
@@ -3,16 +3,15 @@ name: deploy-llms.yml
 # Publishes llms.txt and llms-full.txt to the GitHub Pages site. Every deploy below
 # uses publish_dir ./llms, so each of these paths gets both files.
 #
-# Where each ref lands is in the table at "Resolve publish target", the only step
-# that reads the ref; every step after it reads that step's outputs.
+# "Resolve publish target" is the only step that reads the ref; the rest read its
+# outputs. Its table says where each ref lands.
 #
 # The per-major copy lets an app stuck on an old major still fetch the manifest for
 # the version it runs. keep_files:true stops a deploy wiping paths it did not write:
 # older majors, and Storybook, which owns the same paths.
 #
-# When the manifest changes, the run also publishes llms.diff.html: a diff2html
-# render of the new manifest against the site-root one. Two commit statuses link the
-# manifest and the report, so a reviewer sees what a branch changed.
+# When the manifest changes, the run also publishes llms.diff.html, a diff2html
+# render against the site-root manifest, and links both from commit statuses.
 
 on:
   workflow_dispatch:
@@ -84,14 +83,12 @@ jobs:
       - name: Generate llms.txt
         run: yarn generate:llms
 
-      # Runs before the deploy steps, which overwrite the manifest it diffs against.
-      # Writes the report into ./llms so those steps publish it.
+      # Runs before the deploys, which overwrite the manifest it diffs against, and
+      # writes the report into ./llms so they publish it.
       #
-      # Manifest URLs carry the branch: /<branch>/ for Storybook, blob/<branch>/ for
-      # source. A raw diff would mark every one of those lines changed, so both sides
-      # collapse the prefix to ../ and a "Branch:" line at the top says which side is
-      # which. The published manifests keep their real URLs. The site-root manifest is
-      # always built from main.
+      # Both sides collapse the branch out of URLs (/<branch>/, blob/<branch>/) to ../,
+      # so the diff shows content rather than the prefix. Only these copies are
+      # rewritten; a "Branch:" line names each side.
       - name: Build llms.txt diff report
         id: diff
         env:

--- a/.github/workflows/deploy-llms.yml
+++ b/.github/workflows/deploy-llms.yml
@@ -57,19 +57,25 @@ jobs:
       # branch  '<branch>'  '<branch>/'  unset      /<branch>/llms.txt
       - name: Resolve publish target
         id: target
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          REF: ${{ github.ref }}
         run: |
-          ref="${{ github.ref_name }}"
-          echo "ref=$ref" >> "$GITHUB_OUTPUT"
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          set -o pipefail
+          echo "ref=$REF_NAME" >> "$GITHUB_OUTPUT"
+          if [ "$REF" = "refs/heads/main" ]; then
+            # An empty major would publish to /v/, so fail here instead.
+            major="$(node -p 'require("./package.json").version.split(".")[0]')"
+            : "${major:?could not read the major from package.json}"
             {
-              echo "dir=."
+              echo "dir=./"
               echo "urlpath="
-              echo "major=$(node -p 'require("./package.json").version.split(".")[0]')"
+              echo "major=$major"
             } >> "$GITHUB_OUTPUT"
           else
             {
-              echo "dir=$ref"
-              echo "urlpath=$ref/"
+              echo "dir=./$REF_NAME"
+              echo "urlpath=$REF_NAME/"
             } >> "$GITHUB_OUTPUT"
           fi
 
@@ -94,24 +100,26 @@ jobs:
         env:
           URLPATH: ${{ steps.target.outputs.urlpath }}
           BRANCH: ${{ steps.target.outputs.ref }}
+          RUNNER_TEMP: ${{ runner.temp }}
         run: |
-          mkdir -p _diff
-          code=$(curl -sSL -o _diff/a.raw -w '%{http_code}' "$SITE/llms.txt" || echo 000)
-          if [ "$code" != "200" ]; then
-            echo "baseline fetch returned HTTP $code — treating as a new file"
-            : > _diff/a.raw
-          fi
-          cp llms/llms.txt _diff/b.raw
-          { echo "Branch: /";             sed "s#$SITE/#$SITE/../#g; s#$REPO/blob/main/#$REPO/blob/../#g"           _diff/a.raw; } > _diff/a
-          { echo "Branch: ${URLPATH:-/}"; sed "s#$SITE/$URLPATH#$SITE/../#g; s#$REPO/blob/$BRANCH/#$REPO/blob/../#g" _diff/b.raw; } > _diff/b
-          if diff -q _diff/a _diff/b >/dev/null; then
+          set -o pipefail
+          d="$(mktemp -d "$RUNNER_TEMP/llms-diff.XXXXXX")"
+          # Read the baseline from gh-pages, not over HTTP: the Pages CDN serves a stale
+          # copy for minutes after a deploy, which would diff against the wrong file.
+          git fetch --depth=1 --no-tags origin gh-pages || echo "no gh-pages yet"
+          git show origin/gh-pages:llms.txt > "$d/a.raw" 2>/dev/null \
+            || { echo "no published manifest, treating it as a new file"; : > "$d/a.raw"; }
+          cp llms/llms.txt "$d/b.raw"
+          { echo "Branch: /";             sed "s#$SITE/#$SITE/../#g; s#$REPO/blob/main/#$REPO/blob/../#g"           "$d/a.raw"; } > "$d/a"
+          { echo "Branch: ${URLPATH:-/}"; sed "s#$SITE/$URLPATH#$SITE/../#g; s#$REPO/blob/$BRANCH/#$REPO/blob/../#g" "$d/b.raw"; } > "$d/b"
+          if diff -q "$d/a" "$d/b" >/dev/null; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "manifest is identical to the published one — no report"
+            echo "manifest is identical to the published one, so no report"
             exit 0
           fi
           echo "changed=true" >> "$GITHUB_OUTPUT"
-          diff -u --label a/llms.txt --label b/llms.txt _diff/a _diff/b > _diff/llms.diff || true
-          node_modules/.bin/diff2html -i file -F llms/llms.diff.html --style side -- _diff/llms.diff
+          diff -u --label a/llms.txt --label b/llms.txt "$d/a" "$d/b" > "$d/llms.diff" || true
+          node_modules/.bin/diff2html -i file -F llms/llms.diff.html --style side -- "$d/llms.diff"
 
       - name: Deploy llms.txt
         uses: peaceiris/actions-gh-pages@v3
@@ -135,14 +143,17 @@ jobs:
         if: steps.diff.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_SLUG: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          URLPATH: ${{ steps.target.outputs.urlpath }}
         run: |
-          gh api "repos/${{ github.repository }}/statuses/${{ github.sha }}" \
+          gh api "repos/$REPO_SLUG/statuses/$SHA" \
             -f state=success \
             -f context="llms.txt / diff report" \
             -f description="Rendered diff vs the published manifest" \
-            -f target_url="$SITE/${{ steps.target.outputs.urlpath }}llms.diff.html"
-          gh api "repos/${{ github.repository }}/statuses/${{ github.sha }}" \
+            -f target_url="$SITE/${URLPATH}llms.diff.html"
+          gh api "repos/$REPO_SLUG/statuses/$SHA" \
             -f state=success \
             -f context="llms.txt / published manifest" \
             -f description="The llms.txt this ref publishes" \
-            -f target_url="$SITE/${{ steps.target.outputs.urlpath }}llms.txt"
+            -f target_url="$SITE/${URLPATH}llms.txt"

--- a/.github/workflows/deploy-llms.yml
+++ b/.github/workflows/deploy-llms.yml
@@ -116,7 +116,7 @@ jobs:
           fi
           echo "changed=true" >> "$GITHUB_OUTPUT"
           diff -u --label a/llms.txt --label b/llms.txt _diff/a _diff/b > _diff/llms.diff || true
-          npx --yes diff2html-cli@5.2.15 -i file -F llms/llms.diff.html --style side -- _diff/llms.diff
+          node_modules/.bin/diff2html -i file -F llms/llms.diff.html --style side -- _diff/llms.diff
 
       # main -> site root; any other branch -> its preview folder. Same step either way.
       - name: Deploy llms.txt

--- a/.github/workflows/deploy-llms.yml
+++ b/.github/workflows/deploy-llms.yml
@@ -137,8 +137,10 @@ jobs:
           destination_dir: ./v${{ steps.target.outputs.major }}
           keep_files: true
 
-      # Two clickable links on the commit's checks: the live manifest, and the
-      # rendered diff for this change. Runs after deploy so the report URL resolves.
+      # Two clickable links on the commit's checks: the manifest this ref just
+      # published, and the rendered diff for this change. Both read urlpath, so on
+      # main they point at the site root and on a branch at its preview folder.
+      # Runs after deploy so both URLs resolve.
       - name: Post llms.txt links to commit status
         if: steps.diff.outputs.changed == 'true'
         env:
@@ -152,5 +154,5 @@ jobs:
           gh api "repos/${{ github.repository }}/statuses/${{ github.sha }}" \
             -f state=success \
             -f context="llms.txt / published manifest" \
-            -f description="The currently-live llms.txt" \
-            -f target_url="$SITE/llms.txt"
+            -f description="The llms.txt this ref publishes" \
+            -f target_url="$SITE/${{ steps.target.outputs.urlpath }}llms.txt"

--- a/.github/workflows/deploy-llms.yml
+++ b/.github/workflows/deploy-llms.yml
@@ -24,6 +24,7 @@ on:
       - scripts/extract-props.mjs
       - scripts/extract-stories.mjs
       - .github/workflows/deploy-llms.yml
+      - scripts/workflows/deploy-llms/**
       - src/**
       - package.json
 
@@ -52,32 +53,12 @@ jobs:
         with:
           node-version: 22.22
 
-      # ref     dir         urlpath      major      published at
-      # main    '.'         ''           <major>    /llms.txt and /v<major>/llms.txt
-      # branch  '<branch>'  '<branch>/'  unset      /<branch>/llms.txt
       - name: Resolve publish target
         id: target
         env:
           REF_NAME: ${{ github.ref_name }}
           REF: ${{ github.ref }}
-        run: |
-          set -o pipefail
-          echo "ref=$REF_NAME" >> "$GITHUB_OUTPUT"
-          if [ "$REF" = "refs/heads/main" ]; then
-            # An empty major would publish to /v/, so fail here instead.
-            major="$(node -p 'require("./package.json").version.split(".")[0]')"
-            : "${major:?could not read the major from package.json}"
-            {
-              echo "dir=./"
-              echo "urlpath="
-              echo "major=$major"
-            } >> "$GITHUB_OUTPUT"
-          else
-            {
-              echo "dir=./$REF_NAME"
-              echo "urlpath=$REF_NAME/"
-            } >> "$GITHUB_OUTPUT"
-          fi
+        run: scripts/workflows/deploy-llms/resolve-publish-target.sh
 
       - name: Install dependencies
         run: LOCAL_MACHINE=false yarn install --frozen-lockfile
@@ -89,37 +70,13 @@ jobs:
       - name: Generate llms.txt
         run: yarn generate:llms
 
-      # Runs before the deploys, which overwrite the manifest it diffs against, and
-      # writes the report into ./llms so they publish it.
-      #
-      # Both sides collapse the branch out of URLs (/<branch>/, blob/<branch>/) to ../,
-      # so the diff shows content rather than the prefix. Only these copies are
-      # rewritten; a "Branch:" line names each side.
       - name: Build llms.txt diff report
         id: diff
         env:
           URLPATH: ${{ steps.target.outputs.urlpath }}
           BRANCH: ${{ steps.target.outputs.ref }}
           RUNNER_TEMP: ${{ runner.temp }}
-        run: |
-          set -o pipefail
-          d="$(mktemp -d "$RUNNER_TEMP/llms-diff.XXXXXX")"
-          # Read the baseline from gh-pages, not over HTTP: the Pages CDN serves a stale
-          # copy for minutes after a deploy, which would diff against the wrong file.
-          git fetch --depth=1 --no-tags origin gh-pages || echo "no gh-pages yet"
-          git show origin/gh-pages:llms.txt > "$d/a.raw" 2>/dev/null \
-            || { echo "no published manifest, treating it as a new file"; : > "$d/a.raw"; }
-          cp llms/llms.txt "$d/b.raw"
-          { echo "Branch: /";             sed "s#$SITE/#$SITE/../#g; s#$REPO/blob/main/#$REPO/blob/../#g"           "$d/a.raw"; } > "$d/a"
-          { echo "Branch: ${URLPATH:-/}"; sed "s#$SITE/$URLPATH#$SITE/../#g; s#$REPO/blob/$BRANCH/#$REPO/blob/../#g" "$d/b.raw"; } > "$d/b"
-          if diff -q "$d/a" "$d/b" >/dev/null; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "manifest is identical to the published one, so no report"
-            exit 0
-          fi
-          echo "changed=true" >> "$GITHUB_OUTPUT"
-          diff -u --label a/llms.txt --label b/llms.txt "$d/a" "$d/b" > "$d/llms.diff" || true
-          node_modules/.bin/diff2html -i file -F llms/llms.diff.html --style side -- "$d/llms.diff"
+        run: scripts/workflows/deploy-llms/build-diff-report.sh
 
       - name: Deploy llms.txt
         uses: peaceiris/actions-gh-pages@v3

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "cssnano": "^5.0.14",
     "cz-conventional-changelog": "^3.3.0",
     "diff": "^8.0.2",
-    "diff2html": "3.4.56",
+    "diff2html-cli": "5.2.15",
     "eslint": "^9.15.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-airbnb-typescript": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "cssnano": "^5.0.14",
     "cz-conventional-changelog": "^3.3.0",
     "diff": "^8.0.2",
+    "diff2html": "3.4.56",
     "eslint": "^9.15.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-airbnb-typescript": "^17.0.0",

--- a/scripts/build-llms.mjs
+++ b/scripts/build-llms.mjs
@@ -12,12 +12,13 @@ import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 import { loadProps } from "./extract-props.mjs";
-import { loadStories } from "./extract-stories.mjs";
+import { loadStories, resolveLinkBases } from "./extract-stories.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const root = resolve(here, "..");
 
-const PAGES = "https://telicent-oss.github.io/telicent-ds";
+// A branch preview must link to its own Storybook, not main's.
+const { storybookBase } = resolveLinkBases();
 const NPM = "https://www.npmjs.com/package/@telicent-oss/ds";
 const GITHUB = "https://github.com/telicent-oss/telicent-ds";
 
@@ -161,7 +162,7 @@ const llmsFull = `${manifest}${otherExports}
 
 - Install with \`yarn add @telicent-oss/ds\`
 - npm: ${NPM}
-- Live examples (Storybook): ${PAGES}/
+- Live examples (Storybook): ${storybookBase}/
 - Source and issues: ${GITHUB}
 
 This reference documents @telicent-oss/ds v${version}.

--- a/scripts/build-llms.mjs
+++ b/scripts/build-llms.mjs
@@ -17,7 +17,7 @@ import { loadStories, resolveLinkBases } from "./extract-stories.mjs";
 const here = dirname(fileURLToPath(import.meta.url));
 const root = resolve(here, "..");
 
-// A branch preview must link to its own Storybook, not main's.
+// A branch preview links to the Storybook built from that branch.
 const { storybookBase } = resolveLinkBases();
 const NPM = "https://www.npmjs.com/package/@telicent-oss/ds";
 const GITHUB = "https://github.com/telicent-oss/telicent-ds";

--- a/scripts/workflows/deploy-llms/build-diff-report.sh
+++ b/scripts/workflows/deploy-llms/build-diff-report.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Renders llms.diff.html: the manifest just built against the one already published.
+# Must run before the deploy steps, which overwrite that published manifest. Writes the
+# report into ./llms so those steps publish it alongside the manifest.
+#
+# Both sides collapse the branch out of URLs (/<branch>/, blob/<branch>/) to ../, so the
+# diff shows content rather than the prefix. Only these copies are rewritten; a "Branch:"
+# line names each side.
+set -euo pipefail
+
+: "${SITE:?SITE is required}"
+: "${REPO:?REPO is required}"
+: "${BRANCH:?BRANCH is required}"
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+urlpath="${URLPATH-}"
+
+d="$(mktemp -d "${RUNNER_TEMP:-/tmp}/llms-diff.XXXXXX")"
+
+# Read the baseline from gh-pages, not over HTTP: the Pages CDN serves a stale copy for
+# minutes after a deploy, which would diff against the wrong file.
+git fetch --depth=1 --no-tags origin gh-pages || echo "no gh-pages yet"
+git show origin/gh-pages:llms.txt > "$d/a.raw" 2>/dev/null \
+  || { echo "no published manifest, treating it as a new file"; : > "$d/a.raw"; }
+cp llms/llms.txt "$d/b.raw"
+
+{ echo "Branch: /";                sed "s#$SITE/#$SITE/../#g;         s#$REPO/blob/main/#$REPO/blob/../#g"    "$d/a.raw"; } > "$d/a"
+{ echo "Branch: ${urlpath:-/}";    sed "s#$SITE/$urlpath#$SITE/../#g; s#$REPO/blob/$BRANCH/#$REPO/blob/../#g" "$d/b.raw"; } > "$d/b"
+
+if diff -q "$d/a" "$d/b" >/dev/null; then
+  echo "changed=false" >> "$GITHUB_OUTPUT"
+  echo "manifest is identical to the published one, so no report"
+  exit 0
+fi
+
+echo "changed=true" >> "$GITHUB_OUTPUT"
+diff -u --label a/llms.txt --label b/llms.txt "$d/a" "$d/b" > "$d/llms.diff" || true
+node_modules/.bin/diff2html -i file -F llms/llms.diff.html --style side -- "$d/llms.diff"

--- a/scripts/workflows/deploy-llms/resolve-publish-target.sh
+++ b/scripts/workflows/deploy-llms/resolve-publish-target.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Decides where this ref publishes. The only place the ref is read; every later step
+# in deploy-llms.yml reads these outputs.
+#
+# ref     dir         urlpath      major      published at
+# main    './'        ''           <major>    /llms.txt and /v<major>/llms.txt
+# branch  './<name>'  '<name>/'    unset      /<name>/llms.txt
+set -euo pipefail
+
+: "${REF:?REF is required}"
+: "${REF_NAME:?REF_NAME is required}"
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+
+echo "ref=$REF_NAME" >> "$GITHUB_OUTPUT"
+
+if [ "$REF" != "refs/heads/main" ]; then
+  {
+    echo "dir=./$REF_NAME"
+    echo "urlpath=$REF_NAME/"
+  } >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+# An empty major would publish to /v/, so fail here instead.
+major="$(node -p 'require("./package.json").version.split(".")[0]')"
+: "${major:?could not read the major from package.json}"
+
+{
+  echo "dir=./"
+  echo "urlpath="
+  echo "major=$major"
+} >> "$GITHUB_OUTPUT"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3283,6 +3283,13 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
   integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
 
+"@profoundlogic/hogan@^3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@profoundlogic/hogan/-/hogan-3.0.4.tgz#30032a0172a911471965bca77772a95f71989d01"
+  integrity sha512-pmNVGuooS30Mm7YbZd5T7E5zYVO6D5Ct91sn4T39mUvMUc3sCGridcnhAufL1/Bz2QzAtzEn0agNrdk3+5yWzw==
+  dependencies:
+    nopt "1.0.10"
+
 "@react-spring/animated@~9.7.5":
   version "9.7.5"
   resolved "https://registry.yarnpkg.com/@react-spring/animated/-/animated-9.7.5.tgz#eb0373aaf99b879736b380c2829312dae3b05f28"
@@ -4782,6 +4789,11 @@ abab@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
   integrity sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==
+
+abbrev@1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
+  integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
 acorn-globals@^7.0.0:
   version "7.0.1"
@@ -6744,6 +6756,16 @@ diff-sequences@^29.6.3:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.6.3.tgz#4deaf894d11407c51efc8418012f9e70b84ea921"
   integrity sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
 
+diff2html@3.4.56:
+  version "3.4.56"
+  resolved "https://registry.yarnpkg.com/diff2html/-/diff2html-3.4.56.tgz#537aa343e9f1b1ede346909f56eeddb2c780c09f"
+  integrity sha512-u9gfn+BlbHcyO7vItCIC4z49LJDUt31tODzOfAuJ5R1E7IdlRL6KjugcB9zOpejD+XiR+dDZbsnHSQ3g6A/u8A==
+  dependencies:
+    "@profoundlogic/hogan" "^3.0.4"
+    diff "^8.0.3"
+  optionalDependencies:
+    highlight.js "11.11.1"
+
 diff@^4.0.1:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.4.tgz#7a6dbfda325f25f07517e9b518f897c08332e07d"
@@ -6758,6 +6780,11 @@ diff@^8.0.2:
   version "8.0.3"
   resolved "https://registry.yarnpkg.com/diff/-/diff-8.0.3.tgz#c7da3d9e0e8c283bb548681f8d7174653720c2d5"
   integrity sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==
+
+diff@^8.0.3:
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-8.0.4.tgz#4f5baf3188b9b2431117b962eb20ba330fadf696"
+  integrity sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -8316,6 +8343,11 @@ he@1.2.0, he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+highlight.js@11.11.1:
+  version "11.11.1"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.11.1.tgz#fca06fa0e5aeecf6c4d437239135fabc15213585"
+  integrity sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==
 
 hoist-non-react-statics@^3.3.1:
   version "3.3.2"
@@ -10621,6 +10653,13 @@ node-releases@^2.0.27:
   version "2.0.27"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.27.tgz#eedca519205cf20f650f61d56b070db111231e4e"
   integrity sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==
+
+nopt@1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
+  integrity sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==
+  dependencies:
+    abbrev "1"
 
 normalize-package-data@^2.5.0:
   version "2.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5711,6 +5711,15 @@ cli-width@^3.0.0:
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
   integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
 
+clipboardy@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/clipboardy/-/clipboardy-4.0.0.tgz#e73ced93a76d19dd379ebf1f297565426dffdca1"
+  integrity sha512-5mOlNS0mhX0707P2I0aZ2V/cmHUEO/fL7VFLqszkhUsxt7RwnmrInf/eEQKlf5GzvYeHIjT+Ov1HRfNmymlG0w==
+  dependencies:
+    execa "^8.0.1"
+    is-wsl "^3.1.0"
+    is64bit "^2.0.0"
+
 cliui@^7.0.2:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
@@ -6490,6 +6499,11 @@ dargs@^7.0.0:
   resolved "https://registry.yarnpkg.com/dargs/-/dargs-7.0.0.tgz#04015c41de0bcb69ec84050f3d9be0caf8d6d5cc"
   integrity sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==
 
+data-uri-to-buffer@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
+  integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
+
 data-urls@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-3.0.2.tgz#9cf24a477ae22bcef5cd5f6f0bfbc1d2d3be9143"
@@ -6756,7 +6770,18 @@ diff-sequences@^29.6.3:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.6.3.tgz#4deaf894d11407c51efc8418012f9e70b84ea921"
   integrity sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
 
-diff2html@3.4.56:
+diff2html-cli@5.2.15:
+  version "5.2.15"
+  resolved "https://registry.yarnpkg.com/diff2html-cli/-/diff2html-cli-5.2.15.tgz#5e09e7da36cca0816960927ebe3b656597c92c07"
+  integrity sha512-w1WJSzyiXDSVsz6cYPE7eu0f3KptN1fT2s/i0ENavaB9aT1Fj/3zjH00mYB14JiPdj3X0hl4PsrtBNjgGKdpkA==
+  dependencies:
+    clipboardy "^4.0.0"
+    diff2html "^3.4.47"
+    node-fetch "^3.3.2"
+    open "^10.0.3"
+    yargs "^17.6.0"
+
+diff2html@^3.4.47:
   version "3.4.56"
   resolved "https://registry.yarnpkg.com/diff2html/-/diff2html-3.4.56.tgz#537aa343e9f1b1ede346909f56eeddb2c780c09f"
   integrity sha512-u9gfn+BlbHcyO7vItCIC4z49LJDUt31tODzOfAuJ5R1E7IdlRL6KjugcB9zOpejD+XiR+dDZbsnHSQ3g6A/u8A==
@@ -7653,6 +7678,21 @@ execa@^5.0.0:
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
 
+execa@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-8.0.1.tgz#51f6a5943b580f963c3ca9c6321796db8cc39b8c"
+  integrity sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==
+  dependencies:
+    cross-spawn "^7.0.3"
+    get-stream "^8.0.1"
+    human-signals "^5.0.0"
+    is-stream "^3.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^5.1.0"
+    onetime "^6.0.0"
+    signal-exit "^4.1.0"
+    strip-final-newline "^3.0.0"
+
 exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
@@ -7759,6 +7799,14 @@ fdir@^6.5.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
   integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
+
+fetch-blob@^3.1.2, fetch-blob@^3.1.4:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
+  integrity sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==
+  dependencies:
+    node-domexception "^1.0.0"
+    web-streams-polyfill "^3.0.3"
 
 fflate@^0.8.0:
   version "0.8.2"
@@ -7881,6 +7929,13 @@ form-data@^4.0.0, form-data@^4.0.5:
     es-set-tostringtag "^2.1.0"
     hasown "^2.0.2"
     mime-types "^2.1.12"
+
+formdata-polyfill@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
+  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
+  dependencies:
+    fetch-blob "^3.1.2"
 
 fraction.js@^5.3.4:
   version "5.3.4"
@@ -8042,6 +8097,11 @@ get-stream@^6.0.0, get-stream@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
+
+get-stream@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-8.0.1.tgz#def9dfd71742cd7754a7761ed43749a27d02eca2"
+  integrity sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==
 
 get-symbol-description@^1.1.0:
   version "1.1.0"
@@ -8428,6 +8488,11 @@ human-signals@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
+
+human-signals@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-5.0.0.tgz#42665a284f9ae0dade3ba41ebc37eb4b852f3a28"
+  integrity sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==
 
 husky@^8.0.3:
   version "8.0.3"
@@ -8875,6 +8940,11 @@ is-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
   integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
 
+is-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-3.0.0.tgz#e6bfd7aa6bef69f4f472ce9bb681e3e57b4319ac"
+  integrity sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==
+
 is-string@^1.0.7, is-string@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.1.1.tgz#92ea3f3d5c5b6e039ca8677e5ac8d07ea773cbb9"
@@ -8962,6 +9032,13 @@ is-yarn-global@^0.4.0:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/is-yarn-global/-/is-yarn-global-0.4.1.tgz#b312d902b313f81e4eaf98b6361ba2b45cd694bb"
   integrity sha512-/kppl+R+LO5VmhYSEWARUFjodS25D68gvj8W7z0I7OWhUla5xWu8KL6CtB2V0R6yqhnRgbcaREMr4EEM6htLPQ==
+
+is64bit@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is64bit/-/is64bit-2.0.0.tgz#198c627cbcb198bbec402251f88e5e1a51236c07"
+  integrity sha512-jv+8jaWCl0g2lSBkNSVXdzfBA0npK1HGC2KtWM9FumFRoGS94g3NbCCLVnCYHLjp4GrW2KZeeSTMo5ddtznmGw==
+  dependencies:
+    system-architecture "^0.1.0"
 
 isarray@^2.0.5:
   version "2.0.5"
@@ -10454,6 +10531,11 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
+mimic-fn@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-4.0.0.tgz#60a90550d5cb0b239cca65d893b1a53b29871ecc"
+  integrity sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==
+
 mimic-response@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
@@ -10619,6 +10701,11 @@ node-addon-api@^7.0.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-7.1.1.tgz#1aba6693b0f255258a049d621329329322aad558"
   integrity sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==
 
+node-domexception@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
+  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
+
 node-exports-info@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/node-exports-info/-/node-exports-info-1.6.0.tgz#1aedafb01a966059c9a5e791a94a94d93f5c2a13"
@@ -10635,6 +10722,15 @@ node-fetch@^2.6.7:
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
+
+node-fetch@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.3.2.tgz#d1e889bacdf733b4ff3b2b243eb7a12866a0b78b"
+  integrity sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==
+  dependencies:
+    data-uri-to-buffer "^4.0.0"
+    fetch-blob "^3.1.4"
+    formdata-polyfill "^4.0.10"
 
 node-html-parser@^6.0.0:
   version "6.1.13"
@@ -10711,6 +10807,13 @@ npm-run-path@^4.0.1:
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
+
+npm-run-path@^5.1.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-5.3.0.tgz#e23353d0ebb9317f174e93417e4a4d82d0249e9f"
+  integrity sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==
+  dependencies:
+    path-key "^4.0.0"
 
 npmlog@^6.0.2:
   version "6.0.2"
@@ -10859,7 +10962,14 @@ onetime@^5.1.0, onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
-open@^10.2.0:
+onetime@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-6.0.0.tgz#7c24c18ed1fd2e9bca4bd26806a33613c77d34b4"
+  integrity sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==
+  dependencies:
+    mimic-fn "^4.0.0"
+
+open@^10.0.3, open@^10.2.0:
   version "10.2.0"
   resolved "https://registry.yarnpkg.com/open/-/open-10.2.0.tgz#b9d855be007620e80b6fb05fac98141fe62db73c"
   integrity sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==
@@ -11128,6 +11238,11 @@ path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+
+path-key@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-4.0.0.tgz#295588dc3aee64154f877adb9d780b81c554bf18"
+  integrity sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==
 
 path-parse@^1.0.6, path-parse@^1.0.7:
   version "1.0.7"
@@ -12483,6 +12598,11 @@ signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
+signal-exit@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
+
 sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
@@ -12840,6 +12960,11 @@ strip-final-newline@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
+strip-final-newline@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-3.0.0.tgz#52894c313fbff318835280aed60ff71ebf12b8fd"
+  integrity sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==
+
 strip-indent@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
@@ -12969,6 +13094,11 @@ synckit@^0.11.12:
   integrity sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==
   dependencies:
     "@pkgr/core" "^0.2.9"
+
+system-architecture@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/system-architecture/-/system-architecture-0.1.0.tgz#71012b3ac141427d97c67c56bc7921af6bff122d"
+  integrity sha512-ulAk51I9UVUyJgxlv9M6lFot2WP3e7t8Kz9+IS6D4rVba1tR9kON+Ey69f+1R4Q8cd45Lod6a4IcJIxnzGc/zA==
 
 tailwindcss@^3.4.1:
   version "3.4.19"
@@ -13771,6 +13901,11 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
+web-streams-polyfill@^3.0.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz#2073b91a2fdb1fbfbd401e7de0ac9f8214cecb4b"
+  integrity sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==
+
 web-worker@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/web-worker/-/web-worker-1.5.0.tgz#71b2b0fbcc4293e8f0aa4f6b8a3ffebff733dcc5"
@@ -14080,6 +14215,19 @@ yargs@^17.0.0, yargs@^17.3.1:
   version "17.7.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
+
+yargs@^17.6.0:
+  version "17.7.3"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.3.tgz#779dffe6bcafec596a7172e983289a588647faaa"
+  integrity sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==
   dependencies:
     cliui "^8.0.1"
     escalade "^3.1.1"


### PR DESCRIPTION
📣 **AI-generated: Requires line-by-line review**

Ticket: https://telicent.atlassian.net/browse/LAB-70

<img width="1445" height="719" alt="Screenshot 2026-07-07 at 11 53 18" src="https://github.com/user-attachments/assets/2e426000-5b15-4ad0-89d3-74a648cb9713" />

### Goal

When the component manifest changes, publish a rendered diff of it

WHY: Help reviewer sees what a branch changed

### Work Completed

- Diffs the freshly-built `llms.txt` against the live one and [publishes the result](https://telicent-oss.github.io/telicent-ds/ci/llms-diff-report/llms.diff.html) in the Github Status below
<img width="209" height="32" alt="Screenshot 2026-07-06 at 16 01 51" src="https://github.com/user-attachments/assets/ee1b8fca-009c-4850-b762-480ff2f9be63" />

### Engineering Notes

- Base: #507 (the workflow this extends)
- diff2html-cli (5.2.15) is a pinned devDependency, run via the local bin

