### PR TITLE
feat: select changes & mui reexports

### DIFF
--- a/src/components/feedback/Alert/Alert.stories.tsx
+++ b/src/components/feedback/Alert/Alert.stories.tsx
@@ -1,0 +1,89 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useTheme } from "@mui/material/styles";
+import { Alert } from "./Alert";
+import UIThemeProvider from "../../../theme/UIThemeProvider";
+
+const meta = {
+  title: "Feedback/Alert",
+  component: Alert,
+} satisfies Meta<typeof Alert>;
+
+export default meta;
+
+export type AlertStory = StoryObj<typeof meta>;
+
+export const Basic: AlertStory = {
+  args: {
+    severity: "info",
+    children: "This is an alert imported from @telicent-oss/ds.",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Thin re-export of MUI Alert. Imported via `import { Alert } from '@telicent-oss/ds'` so it runs against DS's bundled MUI copy and picks up the DS theme.",
+      },
+    },
+  },
+  render: (args) => <Alert {...args} />,
+};
+
+const Diag = () => {
+  const t = useTheme();
+  return (
+    <pre style={{ margin: 0, fontSize: 12 }}>
+      {JSON.stringify(
+        {
+          mode: t.palette.mode,
+          "background.paper": t.palette.background.paper,
+          "text.primary": t.palette.text.primary,
+        },
+        null,
+        2,
+      )}
+    </pre>
+  );
+};
+
+export const DarkModeThemingCheck: AlertStory = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Renders Alert inside `<UIThemeProvider dark theme='AdminBlue'>`. If `mode` prints `dark`, `background.paper` is dark, and the alert itself renders on the dark surface, the DS-imported Alert is reading DS's theme correctly — confirming the wrapper-import path fixes the consumer-app dual-MUI issue.",
+      },
+    },
+  },
+  render: () => (
+    <UIThemeProvider dark theme="AdminBlue">
+      <div style={{ padding: 16, display: "flex", flexDirection: "column", gap: 12 }}>
+        <Diag />
+        <Alert severity="info">Info alert (dark mode)</Alert>
+        <Alert severity="success">Success alert (dark mode)</Alert>
+        <Alert severity="warning">Warning alert (dark mode)</Alert>
+        <Alert severity="error">Error alert (dark mode)</Alert>
+      </div>
+    </UIThemeProvider>
+  ),
+};
+
+export const LightModeThemingCheck: AlertStory = {
+  parameters: {
+    docs: {
+      description: {
+        story: "Same diagnostic under light mode for comparison.",
+      },
+    },
+  },
+  render: () => (
+    <UIThemeProvider theme="AdminBlue">
+      <div style={{ padding: 16, display: "flex", flexDirection: "column", gap: 12 }}>
+        <Diag />
+        <Alert severity="info">Info alert (light mode)</Alert>
+        <Alert severity="success">Success alert (light mode)</Alert>
+        <Alert severity="warning">Warning alert (light mode)</Alert>
+        <Alert severity="error">Error alert (light mode)</Alert>
+      </div>
+    </UIThemeProvider>
+  ),
+};

--- a/src/components/feedback/Alert/Alert.tsx
+++ b/src/components/feedback/Alert/Alert.tsx
@@ -1,0 +1,1 @@
+export { default as Alert, type AlertColor } from "@mui/material/Alert";

--- a/src/components/feedback/index.ts
+++ b/src/components/feedback/index.ts
@@ -3,3 +3,4 @@ export { default as Spinner } from "./Spinner/Spinner";
 export { default as Dialog } from "./Dialog/Dialog";
 export * from "./Dialog/Dialog";
 export { Skeleton } from "./Skeleton/Skeleton";
+export { Alert, type AlertColor } from "./Alert/Alert";

--- a/src/components/inputs/DateAndTimePicker/DayTimePicker.stories.tsx
+++ b/src/components/inputs/DateAndTimePicker/DayTimePicker.stories.tsx
@@ -4,7 +4,7 @@ import { Box } from "@mui/material";
 import { useState } from "react";
 import dayjs, { Dayjs } from "dayjs";
 
-const meta = {
+const meta: Meta<typeof DateTimePicker> = {
   title: "Inputs/DateTimePicker",
   component: DateTimePicker,
   tags: ["autodocs"],
@@ -43,7 +43,7 @@ const [value, setValue] = useState(dayjs());
     },
   },
   decorators: [(Story) => <Box sx={{ width: "100%", mx: "auto" }}>{Story()}</Box>],
-} satisfies Meta<typeof DateTimePicker>;
+};
 
 export default meta;
 type Story = StoryObj<typeof DateTimePicker>;

--- a/src/components/inputs/DatePicker/DatePicker.stories.tsx
+++ b/src/components/inputs/DatePicker/DatePicker.stories.tsx
@@ -4,7 +4,7 @@ import { Box } from "@mui/material";
 import { useState } from "react";
 import dayjs, { Dayjs } from "dayjs";
 
-const meta = {
+const meta: Meta<typeof DatePicker> = {
   title: "Inputs/DatePicker",
   component: DatePicker,
   tags: ["autodocs"],
@@ -41,7 +41,7 @@ const [date, setDate] = useState(dayjs());
     },
   },
   decorators: [(Story) => <Box sx={{ width: "100%", mx: "auto" }}>{Story()}</Box>],
-} satisfies Meta<typeof DatePicker>;
+};
 
 export default meta;
 type Story = StoryObj<typeof DatePicker>;

--- a/src/components/inputs/Select/Select.stories.tsx
+++ b/src/components/inputs/Select/Select.stories.tsx
@@ -159,6 +159,88 @@ const OWNER_OPTIONS: Options[] = [
  * - **Plain node** — `footer={<MyAction />}` when you don't need to close the
  *   menu yourself (the menu stays open until the user clicks away).
  */
+const RESOURCE_TYPE_OPTIONS: Options[] = [
+  { value: "dataset", label: "Dataset" },
+  { value: "model", label: "Model" },
+  { value: "pipeline", label: "Pipeline" },
+  { value: "notebook", label: "Notebook" },
+];
+
+const RESOURCE_TYPE_META: Record<
+  string,
+  { description: string; available: boolean }
+> = {
+  dataset: { description: "A curated collection of records.", available: true },
+  model: { description: "A trained ML model or checkpoint.", available: true },
+  pipeline: { description: "A scheduled data-processing job.", available: false },
+  notebook: { description: "An interactive analysis document.", available: false },
+};
+
+/**
+ * The `renderOption` prop lets you render rich content inside each menu
+ * item — e.g. a title + description block, with an inline chip on
+ * unavailable options. `option.label` stays the source of truth for
+ * filtering, ARIA, and the closed-trigger value; only the visual
+ * option-item is customised.
+ *
+ * Pair with MUI's `renderValue` if you also want to customise the
+ * closed trigger (not shown here).
+ */
+export const WithRenderOption: Story = {
+  args: {
+    label: "Resource type",
+    value: "dataset",
+    width: 320,
+    onChange: () => {},
+    options: RESOURCE_TYPE_OPTIONS,
+    renderOption: (option) => {
+      const meta = RESOURCE_TYPE_META[option.value as string];
+      return (
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 0.25,
+            py: 0.5,
+            width: "100%",
+          }}
+        >
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+            <Box component="span" sx={{ fontWeight: 500 }}>
+              {option.label}
+            </Box>
+            {meta && !meta.available && (
+              <Box
+                component="span"
+                sx={{
+                  fontSize: 10,
+                  lineHeight: 1,
+                  px: 0.75,
+                  py: 0.25,
+                  borderRadius: 0.5,
+                  bgcolor: "action.selected",
+                  color: "text.secondary",
+                  letterSpacing: 0.5,
+                }}
+              >
+                SOON
+              </Box>
+            )}
+          </Box>
+          {meta && (
+            <Box
+              component="span"
+              sx={{ fontSize: 12, color: "text.secondary" }}
+            >
+              {meta.description}
+            </Box>
+          )}
+        </Box>
+      );
+    },
+  },
+};
+
 export const WithFooter: Story = {
   args: {
     label: "Owner",

--- a/src/components/inputs/Select/Select.tsx
+++ b/src/components/inputs/Select/Select.tsx
@@ -39,6 +39,18 @@ export type SelectProps = MuiSelectProps & {
    * `onChange`.
    */
   footer?: React.ReactNode | ((args: SelectFooterArgs) => React.ReactNode);
+
+  /**
+   * Optional custom renderer for each menu item's contents. When provided,
+   * the return value is rendered inside the `<MenuItem>` in place of
+   * `option.label`.
+   *
+   * `option.label` remains the source of truth for the string used by
+   * filtering, ARIA, and the closed-trigger value — it is not replaced.
+   * Pair with `renderValue` if you also need to customise the closed
+   * trigger.
+   */
+  renderOption?: (option: Options) => React.ReactNode;
 };
 
 const Select = React.forwardRef<HTMLInputElement, SelectProps>(
@@ -57,6 +69,7 @@ const Select = React.forwardRef<HTMLInputElement, SelectProps>(
       required = false,
       fullWidth = false,
       footer,
+      renderOption,
       ...rest
     },
     ref,
@@ -114,17 +127,17 @@ const Select = React.forwardRef<HTMLInputElement, SelectProps>(
           aria-describedby={helperText ? helperTextId : undefined}
         >
           {options.map((option) => (
-            <MenuItem key={option.value} value={option.value} disableRipple>
-              {option.label}
+            <MenuItem
+              key={option.value}
+              value={option.value}
+              aria-label={renderOption ? option.label : undefined}
+              disableRipple
+            >
+              {renderOption ? renderOption(option) : option.label}
             </MenuItem>
           ))}
           {footer && options.length > 0 && (
-            <Divider
-              key="__ds-select-footer-divider"
-              component="li"
-              role="separator"
-              sx={{ my: 0.5 }}
-            />
+            <Divider key="__ds-select-footer-divider" component="li" role="separator" sx={{ my: 0.5 }} />
           )}
           {footer && (
             <Box

--- a/src/components/inputs/Select/Select.tsx
+++ b/src/components/inputs/Select/Select.tsx
@@ -96,9 +96,15 @@ const Select = React.forwardRef<HTMLInputElement, SelectProps>(
     };
     const closeMenu = React.useCallback(() => setOpenInternal(false), []);
 
+    const consumerSx = Array.isArray(sx) ? sx : sx ? [sx] : [];
+    const composedSx = [
+      { minWidth: 88, ...(width && { width }), ...(fullWidth && { width: "100%" }) },
+      ...consumerSx,
+    ];
+
     return (
       <FormControl
-        sx={{ minWidth: 88, ...(width && { width }), ...(fullWidth && { width: "100%" }), ...sx }}
+        sx={composedSx}
         size="small"
         error={error}
         required={required}

--- a/src/components/layout/Box/Box.stories.tsx
+++ b/src/components/layout/Box/Box.stories.tsx
@@ -1,0 +1,113 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Box } from "./Box";
+
+const meta = {
+  title: "Layout/Box",
+  component: Box,
+  tags: ["autodocs"],
+} satisfies Meta<typeof Box>;
+
+export default meta;
+
+export type BoxStory = StoryObj<typeof meta>;
+
+export const Basic: BoxStory = {
+  argTypes: {
+    component: {
+      control: "text",
+      table: { defaultValue: { summary: "div" } },
+    },
+  },
+  args: {
+    children: "Box content",
+    sx: { p: 2, bgcolor: "background.paper", border: 1, borderColor: "divider", borderRadius: 1 },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: `The Box component is the most basic layout primitive. It renders a \`<div>\` by default and accepts the \`sx\` prop for one-off theme-aware styling. Use it as a wrapper for spacing, backgrounds, borders, or as the root of a flex/grid container.`,
+      },
+    },
+  },
+  render: (args) => <Box {...args} />,
+};
+
+export const WithSxOverride: BoxStory = {
+  parameters: {
+    docs: {
+      description: {
+        story: `The \`sx\` prop accepts a callback that receives the DS theme, so you can read palette, spacing, and radius tokens directly.`,
+      },
+    },
+  },
+  render: () => (
+    <Box
+      sx={(theme) => ({
+        p: 2,
+        borderRadius: 1,
+        bgcolor: theme.palette.background.paper,
+        color: theme.palette.text.primary,
+        border: `1px solid ${theme.palette.divider}`,
+      })}
+    >
+      Themed via sx callback
+    </Box>
+  ),
+};
+
+export const Outlined: BoxStory = {
+  args: {
+    variant: "outlined",
+    sx: { p: 2, borderRadius: 1 },
+    children: "Outlined Box",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: `Pass \`variant="outlined"\` to render a Box with a border in the theme's primary colour. Mirrors MUI's \`variant="outlined"\` convention on Button and Chip.`,
+      },
+    },
+  },
+  render: (args) => <Box {...args} />,
+};
+
+export const AsSemanticElement: BoxStory = {
+  parameters: {
+    docs: {
+      description: {
+        story: `Box is polymorphic — pass \`component\` to render as any HTML element or React component while keeping the \`sx\` API. Element-specific HTML attributes (e.g. \`href\` on \`"a"\`, \`htmlFor\` on \`"label"\`) type-check correctly.`,
+      },
+    },
+  },
+  render: () => (
+    <Box component="section" sx={{ p: 2, bgcolor: "background.paper", display: "flex", flexDirection: "column", gap: 1 }}>
+      <Box component="h3" sx={{ m: 0 }}>
+        Section heading
+      </Box>
+      <Box component="label" htmlFor="box-poly-input" sx={{ fontSize: 12 }}>
+        Label rendered via component="label" with htmlFor
+      </Box>
+      <input id="box-poly-input" placeholder="associated input" />
+      <Box component="a" href="https://example.com" sx={{ color: "primary.main" }}>
+        Link rendered via component="a" with href
+      </Box>
+    </Box>
+  ),
+};
+
+export const FlexRow: BoxStory = {
+  parameters: {
+    docs: {
+      description: {
+        story: `A common use — Box as a flex container with themed children.`,
+      },
+    },
+  },
+  render: () => (
+    <Box sx={{ display: "flex", gap: 2, alignItems: "center" }}>
+      <Box sx={{ p: 1, bgcolor: "#f77", borderRadius: 1 }}>One</Box>
+      <Box sx={{ p: 1, bgcolor: "#7f7", borderRadius: 1 }}>Two</Box>
+      <Box sx={{ p: 1, bgcolor: "#77f", borderRadius: 1 }}>Three</Box>
+    </Box>
+  ),
+};

--- a/src/components/layout/Box/Box.tsx
+++ b/src/components/layout/Box/Box.tsx
@@ -1,0 +1,28 @@
+import BoxRaw, { type BoxProps } from "@mui/material/Box";
+import type { OverridableComponent } from "@mui/material/OverridableComponent";
+import type { SxProps, Theme } from "@mui/material/styles";
+import type { BoxTypeMap } from "@mui/system";
+
+type BoxVariant = "outlined";
+type BoxAdditionalProps = { variant?: BoxVariant };
+
+const variantSx: Record<BoxVariant, SxProps<Theme>> = {
+  outlined: (theme) => ({
+    border: `1px solid ${theme.palette.primary.main}`,
+  }),
+};
+
+const BoxImpl = ({ variant, sx, ...rest }: BoxProps & BoxAdditionalProps) => {
+  if (!variant) {
+    return <BoxRaw sx={sx} {...rest} />;
+  }
+
+  const consumerSx = Array.isArray(sx) ? sx : [sx];
+  const composedSx = [variantSx[variant], ...consumerSx];
+
+  return <BoxRaw sx={composedSx} {...rest} />;
+};
+
+export const Box = BoxImpl as OverridableComponent<
+  BoxTypeMap<BoxAdditionalProps, "div", Theme>
+>;

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -1,4 +1,5 @@
 export { default as AppChrome } from "./AppChrome";
+export { Box } from "./Box/Box";
 export { default as Container } from "./Container/Container";
 export { default as FlexBox } from "./FlexBox";
 export { FlexGrid, FlexGridItem } from "./FlexGrid";

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -3,3 +3,5 @@ export type { UITheme };
 export { UIThemeSchema };
 
 export { default as UIThemeProvider } from "./UIThemeProvider";
+
+export { alpha } from "@mui/material/styles";


### PR DESCRIPTION
ticket: https://telicent.atlassian.net/browse/TELFE-1643

## Summary

Expose a set of MUI primitives via the DS public API so consuming a
can drop direct `@mui/material` imports and pick up DS-bundled MUI
theme context (correct `palette.mode`, working `sx` callbacks).

### New public exports

| Export | Source | Notes |
|---|---|---|
| `Box` | `@mui/material/Box` | With additive `variant="outlined"` (primary-colour border). Polymorphic typing preserved via `OverridableComponent<BoxTypeMap>` — `component="a" href=…`, `component="label" htmlFor=…` still type-check. |
| `Alert`, `AlertColor` | `@mui/material/Alert` | Thin value + type re-export. |
| `alpha` | `@mui/material/styles` | Pure colour utility. |                                                                                                          
### Select                                                                                                                                                           
- `renderOption?: (option: Options) => ReactNode` — additive. Renders inside each `MenuItem` in place of `option.label`. `option.label` stays the source of truth for filtering / ARIA / closed-trigger value.
- Fix: consumer `sx` was merged via `...sx` spread, which silently no-oped for callback and array forms. Switched to MUI's array-sx pattern. Object-form `sx` unaffected.

### Housekeeping

- Explicit `Meta<typeof …>` annotation on `DatePicker` / `DateTimeP742.

## Test plan

- [ ] Storybook `Layout/Box` `AsSemanticElement` renders `<a href>`, `<label htmlFor>` without type or console errors.
- [ ] Storybook `Layout/Box` `Outlined` shows a primary-colour border in both themes.
- [ ] Storybook `Inputs/Select` `WithRenderOption` renders rich two
- [ ] Consumer canary: catalogue rebuilds `ResourceTypePicker` on `renderOption`, reports back before promotion.