### PR TITLE
feat(theme): add GeoGreen theme

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -7,7 +7,8 @@ const config: StorybookConfig = {
     "@storybook/addon-links",
     "@chromatic-com/storybook",
     "@storybook/addon-designs",
-    "@storybook/addon-docs"
+    "@storybook/addon-docs",
+    "storybook-addon-pseudo-states"
   ],
   framework: {
     name: "@storybook/react-vite",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "@mui/material": "^5.16.7",
     "@mui/x-tree-view": "7.3.1",
     "@storybook/addon-designs": "^11.1.3",
+    "@storybook/addon-docs": "10.4.6",
     "@storybook/addon-links": "10.4.6",
     "@storybook/addon-onboarding": "10.4.6",
     "@storybook/react-vite": "10.4.6",
@@ -170,13 +171,14 @@
     "postcss-import": "^15.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "rimraf": "^6.0.1",
     "release-please": "15.6.0",
     "remark-gfm": "^3.0.1",
+    "rimraf": "^6.0.1",
     "rollup": "^4.5.0",
     "rollup-plugin-copy": "^3.5.0",
     "snapshot-diff": "0.10.0",
     "storybook": "10.4.6",
+    "storybook-addon-pseudo-states": "10.4.6",
     "storybook-dark-mode": "^5.0.0",
     "tailwindcss": "^3.4.1",
     "typescript": "5.5.4",
@@ -184,8 +186,7 @@
     "undici": "^6.21.0",
     "vite": "^5.4.10",
     "vite-plugin-dts": "^3.6.3",
-    "vite-plugin-watch-and-run": "1.7.0",
-    "@storybook/addon-docs": "10.4.6"
+    "vite-plugin-watch-and-run": "1.7.0"
   },
   "publishConfig": {
     "registry": "https://www.npmjs.com/"

--- a/src/components/buttons/Button/ButtonTables.stories.tsx
+++ b/src/components/buttons/Button/ButtonTables.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import Button, { ButtonProps } from "./Button";
 import { Text, H5 } from "../../data-display";
 import { FlexBox } from "../../layout";
+import { figmaDesign } from "../../../../.storybook/figmaDesign";
 import useExtendedTheme from "../../../hooks/useExtendedTheme";
 import {
   parseRgb,
@@ -11,9 +12,10 @@ import {
   formatContrastRatio,
 } from "../../../utils/color-contrast/color-contrast";
 
-// Reference tables mirroring the GeoGreen design spec: a per-variant colour +
+// Reference tables mirroring the Figma design spec: a per-variant colour +
 // contrast table, and a state x variant matrix. Both read from the live theme,
-// so switch the toolbar theme/mode (e.g. GeoGreen dark) to see it update.
+// so switch the toolbar theme/mode (e.g. GeoGreen dark) to see it update. The
+// Figma source is linked via the addon-designs "Design" tab (see meta below).
 
 type Variant = Extract<ButtonProps["variant"], "primary" | "secondary" | "tertiary">;
 
@@ -26,6 +28,9 @@ const VARIANTS: { variant: Variant; label: string }[] = [
 type Spec = { txt: string; bg: string; bd: string; ratio: number };
 
 const monoLine = { fontFamily: "monospace" } as const;
+// Disables the colour transition so getComputedStyle reads the settled colour
+// on the first frame after a theme switch, not a mid-transition value.
+const noTransition = { transition: "none" } as const;
 
 const SpecColumn: React.FC<{ variant: Variant; label: string; themeName: string }> = ({
   variant,
@@ -37,28 +42,36 @@ const SpecColumn: React.FC<{ variant: Variant; label: string; themeName: string 
   const [spec, setSpec] = useState<Spec | null>(null);
 
   useEffect(() => {
-    if (!ref.current) return;
-    const style = getComputedStyle(ref.current);
-    // An outlined button is transparent; the contrast is measured against the
-    // real surface it sits on, found by walking up to the first opaque
-    // background (getComputedStyle returns rgb, which toHex parses).
-    let node: HTMLElement | null = ref.current;
-    let effectiveBg = "";
-    while (node) {
-      const bg = getComputedStyle(node).backgroundColor;
-      if (parseRgb(bg)[3] !== 0) {
-        effectiveBg = bg;
-        break;
+    const el = ref.current;
+    if (!el) return undefined;
+
+    const read = (): Spec => {
+      const style = getComputedStyle(el);
+      // An outlined button is transparent; the contrast is measured against the
+      // real surface it sits on, found by walking up to the first opaque
+      // background (getComputedStyle returns rgb, which toHex parses).
+      let node: HTMLElement | null = el;
+      let effectiveBg = "";
+      while (node) {
+        const bg = getComputedStyle(node).backgroundColor;
+        if (parseRgb(bg)[3] !== 0) {
+          effectiveBg = bg;
+          break;
+        }
+        node = node.parentElement;
       }
-      node = node.parentElement;
-    }
-    const hasBorder = style.borderTopStyle !== "none" && style.borderTopWidth !== "0px";
-    setSpec({
-      txt: toHex(style.color),
-      bg: toHex(effectiveBg),
-      bd: hasBorder ? toHex(style.borderTopColor) : "None",
-      ratio: contrastRatio(style.color, effectiveBg),
-    });
+      const hasBorder = style.borderTopStyle !== "none" && style.borderTopWidth !== "0px";
+      return {
+        txt: toHex(style.color),
+        bg: toHex(effectiveBg),
+        bd: hasBorder ? toHex(style.borderTopColor) : "None",
+        ratio: contrastRatio(style.color, effectiveBg),
+      };
+    };
+
+    // A single read suffices because the button carries `noTransition` (sx
+    // below): no animation means getComputedStyle already holds the final colour.
+    setSpec(read());
   }, [theme]);
 
   return (
@@ -70,7 +83,7 @@ const SpecColumn: React.FC<{ variant: Variant; label: string; themeName: string 
         <Text sx={monoLine}>BD {spec?.bd ?? "—"}</Text>
       </FlexBox>
       <FlexBox direction="row">
-        <Button ref={ref} variant={variant}>
+        <Button ref={ref} variant={variant} sx={noTransition}>
           Label
         </Button>
       </FlexBox>
@@ -110,9 +123,14 @@ const StateCell: React.FC<{ variant: Variant; state: State }> = ({ variant, stat
 );
 
 const meta: Meta<typeof Button> = {
-  title: "Buttons/Button Tables",
+  title: "Buttons/Button/Tables",
   component: Button,
-  parameters: { layout: "padded" },
+  parameters: {
+    layout: "padded",
+    ...figmaDesign(
+      "https://www.figma.com/design/DTHPiGn1VDLvUpiuxSqC0h/MUI-for-Figma-Material-UI-v5.16.0?node-id=6522-21508&m=dev",
+    ),
+  },
 };
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/src/components/buttons/Button/ButtonTables.stories.tsx
+++ b/src/components/buttons/Button/ButtonTables.stories.tsx
@@ -4,6 +4,7 @@ import Button, { ButtonProps } from "./Button";
 import { Text, H5 } from "../../data-display";
 import { FlexBox } from "../../layout";
 import useExtendedTheme from "../../../hooks/useExtendedTheme";
+import { parseRgb, toHex, contrastRatio } from "../../../utils/color-contrast/color-contrast";
 
 // Reference tables mirroring the GeoGreen design spec: a per-variant colour +
 // contrast table, and a state x variant matrix. Both read from the live theme,
@@ -16,33 +17,6 @@ const VARIANTS: { variant: Variant; label: string }[] = [
   { variant: "secondary", label: "Secondary" },
   { variant: "tertiary", label: "Tertiary" },
 ];
-
-const parseRgb = (value: string): [number, number, number, number] => {
-  const [r = 0, g = 0, b = 0, a = 1] = value.match(/[\d.]+/g)?.map(Number) ?? [];
-  return [r, g, b, a];
-};
-
-const toHex = (value: string): string => {
-  const [r, g, b, a] = parseRgb(value);
-  if (a === 0) return "transparent";
-  const hex = (n: number) => Math.round(n).toString(16).padStart(2, "0").toUpperCase();
-  return `#${hex(r)}${hex(g)}${hex(b)}`;
-};
-
-const relativeLuminance = (color: string) => {
-  const [r, g, b] = parseRgb(color);
-  const [rl, gl, bl] = [r, g, b].map((v) => {
-    const s = v / 255;
-    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
-  });
-  return 0.2126 * rl + 0.7152 * gl + 0.0722 * bl;
-};
-
-const contrastRatio = (foreground: string, background: string) => {
-  const l1 = relativeLuminance(foreground);
-  const l2 = relativeLuminance(background);
-  return (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
-};
 
 type Spec = { txt: string; bg: string; bd: string; ratio: number };
 

--- a/src/components/buttons/Button/ButtonTables.stories.tsx
+++ b/src/components/buttons/Button/ButtonTables.stories.tsx
@@ -1,0 +1,185 @@
+import React, { useEffect, useRef, useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import Button, { ButtonProps } from "./Button";
+import { Text, H5 } from "../../data-display";
+import { FlexBox } from "../../layout";
+import useExtendedTheme from "../../../hooks/useExtendedTheme";
+
+// Reference tables mirroring the GeoGreen design spec: a per-variant colour +
+// contrast table, and a state x variant matrix. Both read from the live theme,
+// so switch the toolbar theme/mode (e.g. GeoGreen dark) to see it update.
+
+type Variant = Extract<ButtonProps["variant"], "primary" | "secondary" | "tertiary">;
+
+const VARIANTS: { variant: Variant; label: string }[] = [
+  { variant: "primary", label: "Primary" },
+  { variant: "secondary", label: "Secondary" },
+  { variant: "tertiary", label: "Tertiary" },
+];
+
+const parseRgb = (value: string): [number, number, number, number] => {
+  const [r = 0, g = 0, b = 0, a = 1] = value.match(/[\d.]+/g)?.map(Number) ?? [];
+  return [r, g, b, a];
+};
+
+const toHex = (value: string): string => {
+  const [r, g, b, a] = parseRgb(value);
+  if (a === 0) return "transparent";
+  const hex = (n: number) => Math.round(n).toString(16).padStart(2, "0").toUpperCase();
+  return `#${hex(r)}${hex(g)}${hex(b)}`;
+};
+
+const relativeLuminance = (color: string) => {
+  const [r, g, b] = parseRgb(color);
+  const [rl, gl, bl] = [r, g, b].map((v) => {
+    const s = v / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * rl + 0.7152 * gl + 0.0722 * bl;
+};
+
+const contrastRatio = (foreground: string, background: string) => {
+  const l1 = relativeLuminance(foreground);
+  const l2 = relativeLuminance(background);
+  return (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
+};
+
+type Spec = { txt: string; bg: string; bd: string; ratio: number };
+
+const monoLine = { fontFamily: "monospace" } as const;
+
+const SpecColumn: React.FC<{ variant: Variant; label: string; themeName: string }> = ({
+  variant,
+  label,
+  themeName,
+}) => {
+  const theme = useExtendedTheme();
+  const ref = useRef<HTMLButtonElement>(null);
+  const [spec, setSpec] = useState<Spec | null>(null);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const style = getComputedStyle(ref.current);
+    // An outlined button is transparent; the contrast is measured against the
+    // real surface it sits on, found by walking up to the first opaque
+    // background (getComputedStyle returns rgb, which toHex parses).
+    let node: HTMLElement | null = ref.current;
+    let effectiveBg = "";
+    while (node) {
+      const bg = getComputedStyle(node).backgroundColor;
+      if (parseRgb(bg)[3] !== 0) {
+        effectiveBg = bg;
+        break;
+      }
+      node = node.parentElement;
+    }
+    const hasBorder = style.borderTopStyle !== "none" && style.borderTopWidth !== "0px";
+    setSpec({
+      txt: toHex(style.color),
+      bg: toHex(effectiveBg),
+      bd: hasBorder ? toHex(style.borderTopColor) : "None",
+      ratio: contrastRatio(style.color, effectiveBg),
+    });
+  }, [theme]);
+
+  return (
+    <FlexBox direction="column" gap={2} sx={{ minWidth: 180 }}>
+      <H5>{label}</H5>
+      <FlexBox direction="column">
+        <Text sx={monoLine}>Txt {spec?.txt ?? "—"}</Text>
+        <Text sx={monoLine}>BG {spec?.bg ?? "—"}</Text>
+        <Text sx={monoLine}>BD {spec?.bd ?? "—"}</Text>
+      </FlexBox>
+      <FlexBox direction="row">
+        <Button ref={ref} variant={variant}>
+          Label
+        </Button>
+      </FlexBox>
+      <FlexBox direction="column">
+        <Text sx={monoLine}>{themeName}</Text>
+        <Text sx={monoLine}>{spec ? `${spec.ratio.toFixed(2)}:1` : "—"}</Text>
+        <Text sx={monoLine}>{spec && spec.ratio >= 4.5 ? "Pass AA" : "Fail AA"}</Text>
+        <Text sx={monoLine}>{spec && spec.ratio >= 7 ? "Pass AAA" : "Fail AAA"}</Text>
+      </FlexBox>
+    </FlexBox>
+  );
+};
+
+const STATES = ["Enabled", "Hovered", "Disabled", "Focused"] as const;
+type State = (typeof STATES)[number];
+
+// Hover is a real CSS pseudo the addon can force via a class. MUI's focus ring
+// is applied through its own `Mui-focusVisible` class (JS-added on real focus),
+// not the `:focus-visible` pseudo, so the focused row sets that class directly.
+const stateClass: Record<State, string> = {
+  Enabled: "",
+  Hovered: "state-hover",
+  Disabled: "",
+  Focused: "Mui-focusVisible",
+};
+
+const StateCell: React.FC<{ variant: Variant; state: State }> = ({ variant, state }) => (
+  <Button
+    variant={variant}
+    disabled={state === "Disabled"}
+    className={stateClass[state]}
+    startIcon={<i className="fa-solid fa-chevron-left" />}
+    endIcon={<i className="fa-solid fa-chevron-right" />}
+  >
+    Label
+  </Button>
+);
+
+const meta: Meta<typeof Button> = {
+  title: "Buttons/Button Tables",
+  component: Button,
+  parameters: { layout: "padded" },
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const surfaceSx = {
+  bgcolor: "background.default",
+  color: "text.primary",
+  p: 4,
+  width: "fit-content",
+} as const;
+
+export const SpecTable: Story = {
+  render: (_args, { globals }) => (
+    <FlexBox direction="row" gap={6} sx={surfaceSx}>
+      {VARIANTS.map(({ variant, label }) => (
+        <SpecColumn key={variant} variant={variant} label={label} themeName={globals.theme} />
+      ))}
+    </FlexBox>
+  ),
+};
+
+export const States: Story = {
+  parameters: {
+    pseudo: { hover: ".state-hover" },
+  },
+  render: (_args, { globals }) => (
+    <FlexBox direction="column" gap={3} sx={surfaceSx}>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "max-content repeat(3, max-content)",
+          columnGap: 24,
+          rowGap: 20,
+          alignItems: "center",
+        }}
+      >
+        {STATES.map((state) => (
+          <React.Fragment key={state}>
+            <Text>{state}</Text>
+            {VARIANTS.map(({ variant }) => (
+              <StateCell key={variant} variant={variant} state={state} />
+            ))}
+          </React.Fragment>
+        ))}
+      </div>
+      <Text>{globals.theme}</Text>
+    </FlexBox>
+  ),
+};

--- a/src/components/buttons/Button/ButtonTables.stories.tsx
+++ b/src/components/buttons/Button/ButtonTables.stories.tsx
@@ -4,7 +4,12 @@ import Button, { ButtonProps } from "./Button";
 import { Text, H5 } from "../../data-display";
 import { FlexBox } from "../../layout";
 import useExtendedTheme from "../../../hooks/useExtendedTheme";
-import { parseRgb, toHex, contrastRatio } from "../../../utils/color-contrast/color-contrast";
+import {
+  parseRgb,
+  toHex,
+  contrastRatio,
+  formatContrastRatio,
+} from "../../../utils/color-contrast/color-contrast";
 
 // Reference tables mirroring the GeoGreen design spec: a per-variant colour +
 // contrast table, and a state x variant matrix. Both read from the live theme,
@@ -71,7 +76,7 @@ const SpecColumn: React.FC<{ variant: Variant; label: string; themeName: string 
       </FlexBox>
       <FlexBox direction="column">
         <Text sx={monoLine}>{themeName}</Text>
-        <Text sx={monoLine}>{spec ? `${spec.ratio.toFixed(2)}:1` : "—"}</Text>
+        <Text sx={monoLine}>{spec ? `${formatContrastRatio(spec.ratio)}:1` : "—"}</Text>
         <Text sx={monoLine}>{spec && spec.ratio >= 4.5 ? "Pass AA" : "Fail AA"}</Text>
         <Text sx={monoLine}>{spec && spec.ratio >= 7 ? "Pass AAA" : "Fail AAA"}</Text>
       </FlexBox>

--- a/src/theme/ThemeViewer.stories.tsx
+++ b/src/theme/ThemeViewer.stories.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import ThemeViewer from "./ThemeViewer";
-import UIThemeProvider from "./UIThemeProvider";
 import { useExtendedTheme } from "../export";
 
 const meta: Meta<typeof ThemeViewer> = {
@@ -10,11 +9,9 @@ const meta: Meta<typeof ThemeViewer> = {
   tags: ["autodocs"],
   decorators: [
     (Story) => (
-      <UIThemeProvider dark theme="GraphOrange">
-        <div style={{ padding: 16, backgroundColor: "#222" }}>
-          <Story />
-        </div>
-      </UIThemeProvider>
+      <div style={{ padding: 16 }}>
+        <Story />
+      </div>
     ),
   ],
 };

--- a/src/theme/ThemeViewer.test.tsx
+++ b/src/theme/ThemeViewer.test.tsx
@@ -83,4 +83,9 @@ describe("ThemeViewer", () => {
     const { container } = render(<ThemeViewer theme={{}} />);
     expect(container.firstChild).toMatchInlineSnapshot(`<div />`);
   });
+
+  test("renders a null value without crashing", () => {
+    const { getByText } = render(<ThemeViewer theme={{ vars: null }} />);
+    expect(getByText(/vars/)).toBeInTheDocument();
+  });
 });

--- a/src/theme/ThemeViewer.tsx
+++ b/src/theme/ThemeViewer.tsx
@@ -15,7 +15,7 @@ const ThemeViewer: React.FC<ThemeViewerProps> = ({ theme }) => {
   const renderObject = (obj: Record<string, any>, indent = 0) => {
     return Object.entries(obj).map(([key, value]) => {
       const paddingLeft = indent * 4;
-      if (typeof value === "object" && !Array.isArray(value)) {
+      if (value !== null && typeof value === "object" && !Array.isArray(value)) {
         return (
           <div key={key} style={{ paddingLeft }}>
             <strong>{key}:</strong>

--- a/src/theme/colors/GeoGreen.ts
+++ b/src/theme/colors/GeoGreen.ts
@@ -1,37 +1,20 @@
 import { common } from "@mui/material/colors";
 import { alpha } from "@mui/material/styles";
 
-// Dark mode uses the bright brand green as the primary, with black text on it.
-// Light mode uses a darker green as the primary so it stays legible as
-// foreground (text, icons, borders) on light surfaces; the bright fill is
-// restored only for the contained button via a theme-scoped override in
-// ./style-overrides/component-overrides/button-overrides.ts.
-// The bright brand green. Primary in dark mode; also the contained-button fill
-// restored in light mode (see button-overrides.ts).
-export const GEO_GREEN_BRIGHT = "#9DDD31";
-const darkMain = GEO_GREEN_BRIGHT;
-const lightMain = "#3E5B0B";
+const main = "#9DDD31";
 
 const GeoGreen = {
   dark: {
     primary: {
-      main: darkMain,
-      dark: alpha(darkMain, 0.7),
-      light: alpha(darkMain, 0.5),
+      main,
+      dark: alpha(main, 0.7),
+      light: alpha(main, 0.5),
       contrastText: common.black,
     },
     // Near-black page surface per the GeoGreen spec; paper stays at the base
     // #252525 for elevation contrast.
     background: {
       default: "#080808",
-    },
-  },
-  light: {
-    primary: {
-      main: lightMain,
-      dark: alpha(lightMain, 0.7),
-      light: alpha(lightMain, 0.5),
-      contrastText: common.white,
     },
   },
 };

--- a/src/theme/colors/GeoGreen.ts
+++ b/src/theme/colors/GeoGreen.ts
@@ -20,6 +20,11 @@ const GeoGreen = {
       light: alpha(darkMain, 0.5),
       contrastText: common.black,
     },
+    // Near-black page surface per the GeoGreen spec; paper stays at the base
+    // #252525 for elevation contrast.
+    background: {
+      default: "#080808",
+    },
   },
   light: {
     primary: {

--- a/src/theme/colors/GeoGreen.ts
+++ b/src/theme/colors/GeoGreen.ts
@@ -1,0 +1,31 @@
+import { common } from "@mui/material/colors";
+import { alpha } from "@mui/material/styles";
+
+// Dark mode uses the bright brand green as the primary, with black text on it.
+// Light mode uses a darker green as the primary so it stays legible as
+// foreground (text, icons, borders) on light surfaces; the bright fill is
+// restored only for the contained button via a theme-scoped override in
+// ./style-overrides/component-overrides/button-overrides.ts.
+const darkMain = "#9DDD31";
+const lightMain = "#3E5B0B";
+
+const GeoGreen = {
+  dark: {
+    primary: {
+      main: darkMain,
+      dark: alpha(darkMain, 0.7),
+      light: alpha(darkMain, 0.5),
+      contrastText: common.black,
+    },
+  },
+  light: {
+    primary: {
+      main: lightMain,
+      dark: alpha(lightMain, 0.7),
+      light: alpha(lightMain, 0.5),
+      contrastText: common.white,
+    },
+  },
+};
+
+export default GeoGreen;

--- a/src/theme/colors/GeoGreen.ts
+++ b/src/theme/colors/GeoGreen.ts
@@ -6,7 +6,10 @@ import { alpha } from "@mui/material/styles";
 // foreground (text, icons, borders) on light surfaces; the bright fill is
 // restored only for the contained button via a theme-scoped override in
 // ./style-overrides/component-overrides/button-overrides.ts.
-const darkMain = "#9DDD31";
+// The bright brand green. Primary in dark mode; also the contained-button fill
+// restored in light mode (see button-overrides.ts).
+export const GEO_GREEN_BRIGHT = "#9DDD31";
+const darkMain = GEO_GREEN_BRIGHT;
 const lightMain = "#3E5B0B";
 
 const GeoGreen = {

--- a/src/theme/colors/theme-colors.ts
+++ b/src/theme/colors/theme-colors.ts
@@ -3,9 +3,10 @@ import DataNavy from "./DataNavy";
 import DocumentPink from "./DocumentPink";
 import GraphOrange from "./GraphOrange";
 import AdminBlue from "./AdminBlue";
+import GeoGreen from "./GeoGreen";
 import Blank from "./BlankTheme";
 
-export const UIThemeSchema = zod.enum(["DataNavy", "DocumentPink", "GraphOrange", "AdminBlue", "Blank"]);
+export const UIThemeSchema = zod.enum(["DataNavy", "DocumentPink", "GraphOrange", "AdminBlue", "GeoGreen", "Blank"]);
 export type UITheme = zod.infer<typeof UIThemeSchema>;
 
 export type PaletteColor = {
@@ -47,6 +48,7 @@ const THEME_COLORS: Record<UITheme, ThemeColor> = {
   DocumentPink,
   GraphOrange,
   AdminBlue,
+  GeoGreen,
   Blank,
 };
 

--- a/src/theme/createTheme.test.ts
+++ b/src/theme/createTheme.test.ts
@@ -360,7 +360,94 @@ test("tmp theme diffs via unified patches", () => {
     Index: 7
     ===================================================================
     --- 7	DataNavy (light)
-    +++ 7	Blank (light)
+    +++ 7	GeoGreen (light)
+    @@ -90,12 +90,12 @@
+       },
+       "palette": {
+         "mode": "dark",
+         "primary": {
+    -      "main": "#2F44CA",
+    -      "dark": "rgba(47, 68, 202, 0.7)",
+    -      "light": "rgba(47, 68, 202, 0.5)",
+    -      "contrastText": "#FFFFFF"
+    +      "main": "#9DDD31",
+    +      "dark": "rgba(157, 221, 49, 0.7)",
+    +      "light": "rgba(157, 221, 49, 0.5)",
+    +      "contrastText": "#000"
+         },
+         "tertiary": {
+           "main": "#6B6B6B",
+           "dark": "rgba(107, 107, 107, 0.7)",
+
+
+    Index: 8
+    ===================================================================
+    --- 8	DataNavy (light)
+    +++ 8	GeoGreen (dark)
+    @@ -88,45 +88,28 @@
+         },
+         "MuiCssBaseline": {}
+       },
+       "palette": {
+    -    "mode": "dark",
+    +    "mode": "light",
+         "primary": {
+    -      "main": "#2F44CA",
+    -      "dark": "rgba(47, 68, 202, 0.7)",
+    -      "light": "rgba(47, 68, 202, 0.5)",
+    -      "contrastText": "#FFFFFF"
+    +      "main": "#3E5B0B",
+    +      "dark": "rgba(62, 91, 11, 0.7)",
+    +      "light": "rgba(62, 91, 11, 0.5)",
+    +      "contrastText": "#fff"
+         },
+         "tertiary": {
+    -      "main": "#6B6B6B",
+    -      "dark": "rgba(107, 107, 107, 0.7)",
+    -      "light": "rgba(107, 107, 107, 0.5)",
+    -      "contrastText": "#FFFFFF"
+    +      "main": "#8094A3",
+    +      "dark": "rgba(128, 148, 163, 0.7)",
+    +      "light": "rgba(128, 148, 163, 0.5)",
+    +      "contrastText": "#252525"
+         },
+         "text": {
+    -      "primary": "#ececec",
+    -      "secondary": "rgba(255, 255, 255, 0.7)",
+    +      "primary": "#000000",
+    +      "secondary": "#000000",
+           "disabled": "#999999"
+         },
+         "background": {
+    -      "default": "#1D1D1D",
+    -      "paper": "#252525"
+    -    },
+    -    "grey": {
+    -      "50": "#fafafa",
+    -      "100": "#f5f5f5",
+    -      "200": "#eeeeee",
+    -      "300": "#e0e0e0",
+    -      "400": "#bdbdbd",
+    -      "500": "#9e9e9e",
+    -      "600": "#757575",
+    -      "700": "#616161",
+    -      "800": "#424242",
+    -      "900": "#212121",
+    -      "A100": "#f5f5f5",
+    -      "A200": "#eeeeee",
+    -      "A400": "#bdbdbd",
+    -      "A700": "#616161"
+    +      "default": "#F9F9F9"
+         }
+       },
+       "typography": {
+         "fontFamily": "Figtree, Helvetica, Arial, sans-serif",
+
+
+    Index: 9
+    ===================================================================
+    --- 9	DataNavy (light)
+    +++ 9	Blank (light)
     @@ -90,12 +90,12 @@
        },
        "palette": {
@@ -380,10 +467,10 @@ test("tmp theme diffs via unified patches", () => {
            "dark": "rgba(107, 107, 107, 0.7)",
 
 
-    Index: 8
+    Index: 10
     ===================================================================
-    --- 8	DataNavy (light)
-    +++ 8	Blank (dark)
+    --- 10	DataNavy (light)
+    +++ 10	Blank (dark)
     @@ -88,45 +88,28 @@
          },
          "MuiCssBaseline": {}

--- a/src/theme/createTheme.test.ts
+++ b/src/theme/createTheme.test.ts
@@ -407,10 +407,10 @@ test("tmp theme diffs via unified patches", () => {
     -      "dark": "rgba(47, 68, 202, 0.7)",
     -      "light": "rgba(47, 68, 202, 0.5)",
     -      "contrastText": "#FFFFFF"
-    +      "main": "#3E5B0B",
-    +      "dark": "rgba(62, 91, 11, 0.7)",
-    +      "light": "rgba(62, 91, 11, 0.5)",
-    +      "contrastText": "#fff"
+    +      "main": "#9DDD31",
+    +      "dark": "rgba(157, 221, 49, 0.7)",
+    +      "light": "rgba(157, 221, 49, 0.5)",
+    +      "contrastText": "#000"
          },
          "tertiary": {
     -      "main": "#6B6B6B",
@@ -448,7 +448,7 @@ test("tmp theme diffs via unified patches", () => {
     -      "A200": "#eeeeee",
     -      "A400": "#bdbdbd",
     -      "A700": "#616161"
-    +      "default": "#F9F9F9"
+    +      "default": "#080808"
          }
        },
        "typography": {

--- a/src/theme/createTheme.test.ts
+++ b/src/theme/createTheme.test.ts
@@ -378,6 +378,17 @@ test("tmp theme diffs via unified patches", () => {
          "tertiary": {
            "main": "#6B6B6B",
            "dark": "rgba(107, 107, 107, 0.7)",
+    @@ -107,9 +107,9 @@
+           "secondary": "rgba(255, 255, 255, 0.7)",
+           "disabled": "#999999"
+         },
+         "background": {
+    -      "default": "#1D1D1D",
+    +      "default": "#080808",
+           "paper": "#252525"
+         },
+         "grey": {
+           "50": "#fafafa",
 
 
     Index: 8

--- a/src/theme/style-overrides/component-overrides/button-overrides.test.ts
+++ b/src/theme/style-overrides/component-overrides/button-overrides.test.ts
@@ -1,0 +1,52 @@
+import { Theme } from "@mui/material/styles";
+import createTheme from "../../createTheme";
+import generateButtonOverrides from "./button-overrides";
+
+type StyleFn = (arg: { theme: Theme }) => Record<string, unknown>;
+
+// MUI types each styleOverrides slot as a union of a style object or a callback.
+// We author them as callbacks, so cast through unknown to invoke them directly.
+const styleOverridesFor = (uiTheme: Parameters<typeof createTheme>[0], dark: boolean) => {
+  const theme = createTheme(uiTheme, dark);
+  const styles = generateButtonOverrides(uiTheme).MuiButton.styleOverrides as unknown as Record<
+    string,
+    StyleFn
+  >;
+  return { theme, styles };
+};
+
+describe("generateButtonOverrides", () => {
+  test("GeoGreen light contained button uses the bright fill with black text", () => {
+    const { theme, styles } = styleOverridesFor("GeoGreen", false);
+    expect(styles.containedPrimary({ theme })).toEqual({
+      backgroundColor: "#9DDD31",
+      color: "#000",
+      "&:hover": { backgroundColor: "rgb(138, 194, 43)" },
+    });
+  });
+
+  test("GeoGreen dark contained button has no override", () => {
+    const { theme, styles } = styleOverridesFor("GeoGreen", true);
+    expect(styles.containedPrimary({ theme })).toEqual({});
+  });
+
+  test("other themes have no contained override in light mode", () => {
+    const { theme, styles } = styleOverridesFor("DataNavy", false);
+    expect(styles.containedPrimary({ theme })).toEqual({});
+  });
+
+  test("outlined primary border follows the primary token", () => {
+    const { theme, styles } = styleOverridesFor("GeoGreen", false);
+    expect(styles.outlinedPrimary({ theme })).toEqual({
+      border: "1px solid #3E5B0B",
+    });
+  });
+
+  test("root and outlinedInherit apply spacing and elevation", () => {
+    const { theme, styles } = styleOverridesFor("GeoGreen", false);
+    expect(styles.root({ theme })).toEqual({ paddingInline: "16px" });
+    const inherit = styles.outlinedInherit({ theme });
+    expect(inherit.border).toBe("1px solid #CFD8DC");
+    expect(typeof inherit.boxShadow).toBe("string");
+  });
+});

--- a/src/theme/style-overrides/component-overrides/button-overrides.test.ts
+++ b/src/theme/style-overrides/component-overrides/button-overrides.test.ts
@@ -16,34 +16,15 @@ const styleOverridesFor = (uiTheme: Parameters<typeof createTheme>[0], dark: boo
 };
 
 describe("generateButtonOverrides", () => {
-  test("GeoGreen light contained button uses the bright fill with black text", () => {
-    const { theme, styles } = styleOverridesFor("GeoGreen", false);
-    expect(styles.containedPrimary({ theme })).toEqual({
-      backgroundColor: "#9DDD31",
-      color: "#000",
-      "&:hover": { backgroundColor: "rgb(138, 194, 43)" },
-    });
-  });
-
-  test("GeoGreen dark contained button has no override", () => {
-    const { theme, styles } = styleOverridesFor("GeoGreen", true);
-    expect(styles.containedPrimary({ theme })).toEqual({});
-  });
-
-  test("other themes have no contained override in light mode", () => {
-    const { theme, styles } = styleOverridesFor("DataNavy", false);
-    expect(styles.containedPrimary({ theme })).toEqual({});
-  });
-
   test("outlined primary border follows the primary token", () => {
-    const { theme, styles } = styleOverridesFor("GeoGreen", false);
+    const { theme, styles } = styleOverridesFor("GeoGreen", true);
     expect(styles.outlinedPrimary({ theme })).toEqual({
-      border: "1px solid #3E5B0B",
+      border: "1px solid #9DDD31",
     });
   });
 
   test("root and outlinedInherit apply spacing and elevation", () => {
-    const { theme, styles } = styleOverridesFor("GeoGreen", false);
+    const { theme, styles } = styleOverridesFor("GeoGreen", true);
     expect(styles.root({ theme })).toEqual({ paddingInline: "16px" });
     const inherit = styles.outlinedInherit({ theme });
     expect(inherit.border).toBe("1px solid #CFD8DC");

--- a/src/theme/style-overrides/component-overrides/button-overrides.ts
+++ b/src/theme/style-overrides/component-overrides/button-overrides.ts
@@ -1,12 +1,12 @@
 import { ThemeOptions } from "@mui/material";
 import { darken } from "@mui/material/styles";
 import THEME_COLORS, { UITheme } from "../../colors/theme-colors";
+import { GEO_GREEN_BRIGHT } from "../../colors/GeoGreen";
 
 // GeoGreen light mode uses a dark green as its primary so foreground stays
 // legible, but the Figma hero (contained) button keeps the bright brand green
 // fill with black text. This is the one place the fill diverges from the
 // primary token, so it is applied here rather than in the palette.
-const GEO_GREEN_FILL = "#9DDD31";
 
 const generateButtonOverrides = (uiTheme: UITheme) =>
   ({
@@ -25,10 +25,10 @@ const generateButtonOverrides = (uiTheme: UITheme) =>
         containedPrimary: ({ theme }) =>
           uiTheme === "GeoGreen" && theme.palette.mode === "light"
             ? {
-                backgroundColor: GEO_GREEN_FILL,
+                backgroundColor: GEO_GREEN_BRIGHT,
                 color: theme.palette.common.black,
                 "&:hover": {
-                  backgroundColor: darken(GEO_GREEN_FILL, 0.12),
+                  backgroundColor: darken(GEO_GREEN_BRIGHT, 0.12),
                 },
               }
             : {},

--- a/src/theme/style-overrides/component-overrides/button-overrides.ts
+++ b/src/theme/style-overrides/component-overrides/button-overrides.ts
@@ -1,14 +1,7 @@
 import { ThemeOptions } from "@mui/material";
-import { darken } from "@mui/material/styles";
-import THEME_COLORS, { UITheme } from "../../colors/theme-colors";
-import { GEO_GREEN_BRIGHT } from "../../colors/GeoGreen";
+import { UITheme } from "../../colors/theme-colors";
 
-// GeoGreen light mode uses a dark green as its primary so foreground stays
-// legible, but the Figma hero (contained) button keeps the bright brand green
-// fill with black text. This is the one place the fill diverges from the
-// primary token, so it is applied here rather than in the palette.
-
-const generateButtonOverrides = (uiTheme: UITheme) =>
+const generateButtonOverrides = (_uiTheme: UITheme) =>
   ({
     MuiButton: {
       styleOverrides: {
@@ -22,16 +15,6 @@ const generateButtonOverrides = (uiTheme: UITheme) =>
         outlinedPrimary: ({ theme }) => ({
           border: `1px solid ${theme.palette.primary.main}`,
         }),
-        containedPrimary: ({ theme }) =>
-          uiTheme === "GeoGreen" && theme.palette.mode === "light"
-            ? {
-                backgroundColor: GEO_GREEN_BRIGHT,
-                color: theme.palette.common.black,
-                "&:hover": {
-                  backgroundColor: darken(GEO_GREEN_BRIGHT, 0.12),
-                },
-              }
-            : {},
         startIcon: {
           ">*:nth-last-of-type(1)": {
             fontSize: "inherit",

--- a/src/theme/style-overrides/component-overrides/button-overrides.ts
+++ b/src/theme/style-overrides/component-overrides/button-overrides.ts
@@ -1,5 +1,12 @@
 import { ThemeOptions } from "@mui/material";
+import { darken } from "@mui/material/styles";
 import THEME_COLORS, { UITheme } from "../../colors/theme-colors";
+
+// GeoGreen light mode uses a dark green as its primary so foreground stays
+// legible, but the Figma hero (contained) button keeps the bright brand green
+// fill with black text. This is the one place the fill diverges from the
+// primary token, so it is applied here rather than in the palette.
+const GEO_GREEN_FILL = "#9DDD31";
 
 const generateButtonOverrides = (uiTheme: UITheme) =>
   ({
@@ -15,6 +22,16 @@ const generateButtonOverrides = (uiTheme: UITheme) =>
         outlinedPrimary: ({ theme }) => ({
           border: `1px solid ${theme.palette.primary.main}`,
         }),
+        containedPrimary: ({ theme }) =>
+          uiTheme === "GeoGreen" && theme.palette.mode === "light"
+            ? {
+                backgroundColor: GEO_GREEN_FILL,
+                color: theme.palette.common.black,
+                "&:hover": {
+                  backgroundColor: darken(GEO_GREEN_FILL, 0.12),
+                },
+              }
+            : {},
         startIcon: {
           ">*:nth-last-of-type(1)": {
             fontSize: "inherit",

--- a/src/utils/color-contrast/color-contrast.test.ts
+++ b/src/utils/color-contrast/color-contrast.test.ts
@@ -1,4 +1,10 @@
-import { parseRgb, toHex, relativeLuminance, contrastRatio } from "./color-contrast";
+import {
+  parseRgb,
+  toHex,
+  relativeLuminance,
+  contrastRatio,
+  formatContrastRatio,
+} from "./color-contrast";
 
 describe("parseRgb", () => {
   test("parses rgb into channels with a default alpha of 1", () => {
@@ -45,5 +51,15 @@ describe("contrastRatio", () => {
     const forward = contrastRatio("rgb(0, 0, 0)", "rgb(157, 221, 49)");
     const reverse = contrastRatio("rgb(157, 221, 49)", "rgb(0, 0, 0)");
     expect(forward).toBeCloseTo(reverse, 10);
+  });
+});
+
+describe("formatContrastRatio", () => {
+  test("floors to two decimals rather than rounding", () => {
+    expect(formatContrastRatio(12.22677)).toBe("12.22");
+    expect(formatContrastRatio(20.02738)).toBe("20.02");
+  });
+  test("pads whole numbers to two decimals", () => {
+    expect(formatContrastRatio(21)).toBe("21.00");
   });
 });

--- a/src/utils/color-contrast/color-contrast.test.ts
+++ b/src/utils/color-contrast/color-contrast.test.ts
@@ -1,0 +1,49 @@
+import { parseRgb, toHex, relativeLuminance, contrastRatio } from "./color-contrast";
+
+describe("parseRgb", () => {
+  test("parses rgb into channels with a default alpha of 1", () => {
+    expect(parseRgb("rgb(157, 221, 49)")).toEqual([157, 221, 49, 1]);
+  });
+  test("keeps the alpha channel from rgba", () => {
+    expect(parseRgb("rgba(0, 0, 0, 0)")).toEqual([0, 0, 0, 0]);
+  });
+  test("falls back to opaque black for an unparseable value", () => {
+    expect(parseRgb("")).toEqual([0, 0, 0, 1]);
+  });
+});
+
+describe("toHex", () => {
+  test("converts opaque rgb to uppercase hex", () => {
+    expect(toHex("rgb(157, 221, 49)")).toBe("#9DDD31");
+  });
+  test("rounds fractional channels", () => {
+    expect(toHex("rgb(138, 194, 43)")).toBe("#8AC22B");
+  });
+  test("returns transparent for a fully transparent colour", () => {
+    expect(toHex("rgba(0, 0, 0, 0)")).toBe("transparent");
+  });
+});
+
+describe("relativeLuminance", () => {
+  test("is 0 for black and 1 for white", () => {
+    expect(relativeLuminance("rgb(0, 0, 0)")).toBe(0);
+    expect(relativeLuminance("rgb(255, 255, 255)")).toBeCloseTo(1, 5);
+  });
+});
+
+describe("contrastRatio", () => {
+  test("black on white is 21:1", () => {
+    expect(contrastRatio("rgb(0, 0, 0)", "rgb(255, 255, 255)")).toBeCloseTo(21, 1);
+  });
+  test("identical colours are 1:1", () => {
+    expect(contrastRatio("rgb(10, 20, 30)", "rgb(10, 20, 30)")).toBeCloseTo(1, 5);
+  });
+  test("matches the GeoGreen primary spec: black on the brand green", () => {
+    expect(contrastRatio("rgb(0, 0, 0)", "rgb(157, 221, 49)")).toBeCloseTo(12.82, 2);
+  });
+  test("is symmetric regardless of argument order", () => {
+    const forward = contrastRatio("rgb(0, 0, 0)", "rgb(157, 221, 49)");
+    const reverse = contrastRatio("rgb(157, 221, 49)", "rgb(0, 0, 0)");
+    expect(forward).toBeCloseTo(reverse, 10);
+  });
+});

--- a/src/utils/color-contrast/color-contrast.ts
+++ b/src/utils/color-contrast/color-contrast.ts
@@ -1,0 +1,35 @@
+/**
+ * Colour maths shared by the button spec table (see
+ * src/components/buttons/Button/ButtonTables.stories.tsx) and its tests.
+ * `parseRgb`/`toHex` expect the CSS `rgb()`/`rgba()` strings that
+ * getComputedStyle returns, not hex.
+ */
+
+export type Rgba = [number, number, number, number];
+
+export const parseRgb = (value: string): Rgba => {
+  const [r = 0, g = 0, b = 0, a = 1] = value.match(/[\d.]+/g)?.map(Number) ?? [];
+  return [r, g, b, a];
+};
+
+export const toHex = (value: string): string => {
+  const [r, g, b, a] = parseRgb(value);
+  if (a === 0) return "transparent";
+  const hex = (n: number) => Math.round(n).toString(16).padStart(2, "0").toUpperCase();
+  return `#${hex(r)}${hex(g)}${hex(b)}`;
+};
+
+export const relativeLuminance = (color: string): number => {
+  const [r, g, b] = parseRgb(color);
+  const [rl, gl, bl] = [r, g, b].map((v) => {
+    const s = v / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * rl + 0.7152 * gl + 0.0722 * bl;
+};
+
+export const contrastRatio = (foreground: string, background: string): number => {
+  const l1 = relativeLuminance(foreground);
+  const l2 = relativeLuminance(background);
+  return (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
+};

--- a/src/utils/color-contrast/color-contrast.ts
+++ b/src/utils/color-contrast/color-contrast.ts
@@ -33,3 +33,9 @@ export const contrastRatio = (foreground: string, background: string): number =>
   const l2 = relativeLuminance(background);
   return (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
 };
+
+// Floors to 2 decimals rather than rounding, to match the Figma spec sheet and
+// to never report a higher ratio than actually achieved (e.g. 12.22677 -> 12.22,
+// not 12.23).
+export const formatContrastRatio = (ratio: number): string =>
+  (Math.floor(ratio * 100) / 100).toFixed(2);

--- a/src/utils/color-contrast/color-contrast.ts
+++ b/src/utils/color-contrast/color-contrast.ts
@@ -19,19 +19,37 @@ export const toHex = (value: string): string => {
   return `#${hex(r)}${hex(g)}${hex(b)}`;
 };
 
-export const relativeLuminance = (color: string): number => {
-  const [r, g, b] = parseRgb(color);
-  const [rl, gl, bl] = [r, g, b].map((v) => {
-    const s = v / 255;
-    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
-  });
-  return 0.2126 * rl + 0.7152 * gl + 0.0722 * bl;
+const MAX_CHANNEL_VALUE = 255;
+const SRGB_LINEAR_THRESHOLD = 0.03928;
+const SRGB_LINEAR_DIVISOR = 12.92;
+const SRGB_GAMMA_OFFSET = 0.055;
+const SRGB_GAMMA_SCALE = 1.055;
+const SRGB_GAMMA_EXPONENT = 2.4;
+const RED_LUMA_WEIGHT = 0.2126;
+const GREEN_LUMA_WEIGHT = 0.7152;
+const BLUE_LUMA_WEIGHT = 0.0722;
+
+const sRgbChannelToLinear = (channel: number): number => {
+  const normalized = channel / MAX_CHANNEL_VALUE;
+  return normalized <= SRGB_LINEAR_THRESHOLD
+    ? normalized / SRGB_LINEAR_DIVISOR
+    : ((normalized + SRGB_GAMMA_OFFSET) / SRGB_GAMMA_SCALE) ** SRGB_GAMMA_EXPONENT;
 };
 
+export const relativeLuminance = (color: string): number => {
+  const [r, g, b] = parseRgb(color);
+  const [red, green, blue] = [r, g, b].map(sRgbChannelToLinear);
+  return RED_LUMA_WEIGHT * red + GREEN_LUMA_WEIGHT * green + BLUE_LUMA_WEIGHT * blue;
+};
+
+const LUMINANCE_OFFSET = 0.05;
+
 export const contrastRatio = (foreground: string, background: string): number => {
-  const l1 = relativeLuminance(foreground);
-  const l2 = relativeLuminance(background);
-  return (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
+  const foregroundLuminance = relativeLuminance(foreground);
+  const backgroundLuminance = relativeLuminance(background);
+  const lighter = Math.max(foregroundLuminance, backgroundLuminance);
+  const darker = Math.min(foregroundLuminance, backgroundLuminance);
+  return (lighter + LUMINANCE_OFFSET) / (darker + LUMINANCE_OFFSET);
 };
 
 // Floors to 2 decimals rather than rounding, to match the Figma spec sheet and

--- a/yarn.lock
+++ b/yarn.lock
@@ -12558,6 +12558,11 @@ stop-iteration-iterator@^1.0.0, stop-iteration-iterator@^1.1.0:
     es-errors "^1.3.0"
     internal-slot "^1.1.0"
 
+storybook-addon-pseudo-states@10.4.6:
+  version "10.4.6"
+  resolved "https://registry.yarnpkg.com/storybook-addon-pseudo-states/-/storybook-addon-pseudo-states-10.4.6.tgz#141ebaca9ec9e4e15aebdc597528991e9254a231"
+  integrity sha512-yP6GgUTj2uju34ZLKzrFJz9uS+9Nn6uH3Wprei5x/KS6CSbLOuXf3pBhAfi+ur2y4Qm3l/thGyHYVcoACCbgIg==
+
 storybook-dark-mode@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/storybook-dark-mode/-/storybook-dark-mode-5.0.0.tgz#2a47959ba11a3699887649e14e7ba4231836ff46"


### PR DESCRIPTION
✅  **AI-generated: But I have done a line-by-line review of this code**

* Ticket: https://telicent.atlassian.net/browse/LAB-66 (❗ branch is wrong)
* [Storybook](https://telicent-oss.github.io/telicent-ds/feat/lab-65-geogreen-theme/?path=/story/buttons-button-tables--spec-table&globals=theme:GeoGreen)

<img width="842" height="911" alt="Screenshot 2026-07-14 at 12 06 23" src="https://github.com/user-attachments/assets/2f747137-c5c7-4328-82e6-fe3f24b00b86" />



### Goal

Adds GeoGreen, a Telicent theme with dark and light modes like the existing ones.

### Work Completed

- Dark mode: bright green `#9DDD31` primary on black
- Light mode: dark green `#3E5B0B` primary, bright `#9DDD31` contained-button fill
- Dark page surface is near-black `#080808`
- GeoGreen appears in the Storybook theme toolbar
- Button Tables story: a per-variant colour/contrast table and a state matrix, both read from the live theme
- ThemeViewer no longer crashes on a theme carrying a null value
- ThemeViewer story follows the toolbar theme instead of a fixed one

### Design Testing

Clicked through every storybook

<details>
  <summary><strong>Design approval areas</strong></summary>


<img width="672" height="760" alt="Screenshot 2026-07-13 at 17 08 48" src="https://github.com/user-attachments/assets/866a7197-aa92-4abf-93bb-ff06cb98f106" />
<img width="1086" height="946" alt="Screenshot 2026-07-13 at 17 08 31" src="https://github.com/user-attachments/assets/08f015db-2041-45b2-8113-b0d744b5fad8" />
<img width="585" height="618" alt="Screenshot 2026-07-13 at 17 08 22" src="https://github.com/user-attachments/assets/dc996ffc-3c22-472b-975d-66a48d022f75" />
<img width="1343" height="746" alt="Screenshot 2026-07-13 at 17 08 11" src="https://github.com/user-attachments/assets/5ce9d1c2-e3fe-4701-a346-e508ab8a44c9" />
<img width="1344" height="719" alt="Screenshot 2026-07-13 at 16 58 45" src="https://github.com/user-attachments/assets/f272499a-65cf-4d78-9ab7-cfb6bcfb0623" />

</details>

### Testing Method

Typecheck, snapshot test, and Storybook build pass. Rendered the buttons in both modes and confirmed the computed colours match Figma.

### Engineering Notes

Light mode uses the dark `#3E5B0B` as `primary.main` so foreground stays legible. The contained button restores the bright `#9DDD31` fill through a GeoGreen-scoped override in `button-overrides.ts`, the only place the fill leaves the primary token.

The Button Tables spec column reads `getComputedStyle` off the live button. The story disables that button's colour transition first, so a theme switch reads the settled colour.
