### PR TITLE
fix(select): support per-option disabled flag

### DIFF
--- a/src/components/inputs/Select/Select.stories.tsx
+++ b/src/components/inputs/Select/Select.stories.tsx
@@ -159,13 +159,6 @@ const OWNER_OPTIONS: Options[] = [
  * - **Plain node** — `footer={<MyAction />}` when you don't need to close the
  *   menu yourself (the menu stays open until the user clicks away).
  */
-const RESOURCE_TYPE_OPTIONS: Options[] = [
-  { value: "dataset", label: "Dataset" },
-  { value: "model", label: "Model" },
-  { value: "pipeline", label: "Pipeline" },
-  { value: "notebook", label: "Notebook" },
-];
-
 const RESOURCE_TYPE_META: Record<
   string,
   { description: string; available: boolean }
@@ -176,11 +169,26 @@ const RESOURCE_TYPE_META: Record<
   notebook: { description: "An interactive analysis document.", available: false },
 };
 
+// Unavailable resource types get both the "SOON" pill (visual) and
+// `disabled: true` (interaction), so the visual state and the ability
+// to select stay in lockstep.
+const RESOURCE_TYPE_OPTIONS: Options[] = [
+  { value: "dataset", label: "Dataset" },
+  { value: "model", label: "Model" },
+  { value: "pipeline", label: "Pipeline" },
+  { value: "notebook", label: "Notebook" },
+].map((option) => ({
+  ...option,
+  disabled: !RESOURCE_TYPE_META[option.value].available,
+}));
+
 /**
  * The `renderOption` prop lets you render rich content inside each menu
- * item — e.g. a title + description block, with an inline chip on
- * unavailable options. `option.label` stays the source of truth for
- * filtering, ARIA, and the closed-trigger value; only the visual
+ * item — e.g. a title + description block, with an inline "SOON" chip on
+ * unavailable options. Those same options are marked `disabled: true` so
+ * MUI dims them, blocks selection, sets `aria-disabled`, and skips them
+ * during keyboard navigation. `option.label` stays the source of truth
+ * for filtering, ARIA, and the closed-trigger value; only the visual
  * option-item is customised.
  *
  * Pair with MUI's `renderValue` if you also want to customise the

--- a/src/components/inputs/Select/Select.test.tsx
+++ b/src/components/inputs/Select/Select.test.tsx
@@ -158,3 +158,78 @@ describe("Select footer slot", () => {
     expect(combobox).not.toHaveTextContent("Create new owner");
   });
 });
+
+describe("Select per-option disabled", () => {
+  afterEach(cleanup);
+
+  const DISABLED_OPTIONS: Options[] = [
+    { value: "option1", label: "Option 1" },
+    { value: "option2", label: "Option 2", disabled: true },
+    { value: "option3", label: "Option 3" },
+  ];
+
+  it("applies .Mui-disabled and aria-disabled=true to an option with disabled: true", async () => {
+    const { user } = setup(
+      <Select label="Owner" value="" onChange={() => {}} options={DISABLED_OPTIONS} />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+
+    const disabledOption = await screen.findByRole("option", { name: "Option 2" });
+    expect(disabledOption).toHaveClass("Mui-disabled");
+    expect(disabledOption).toHaveAttribute("aria-disabled", "true");
+
+    // Sibling options remain enabled.
+    const enabledOption = screen.getByRole("option", { name: "Option 1" });
+    expect(enabledOption).not.toHaveClass("Mui-disabled");
+    expect(enabledOption).not.toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("clicking a disabled option does not fire onChange", async () => {
+    const onChange = jest.fn();
+    const { user } = setup(
+      <Select label="Owner" value="" onChange={onChange} options={DISABLED_OPTIONS} />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+
+    const disabledOption = await screen.findByRole("option", { name: "Option 2" });
+
+    // MUI gates the click at the CSS layer via pointer-events: none on
+    // .Mui-disabled. user-event honours that and refuses the interaction,
+    // which matches real browser behaviour.
+    await expect(user.click(disabledOption)).rejects.toThrow(/pointer-events/);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("keyboard arrow navigation skips a disabled option", async () => {
+    const onChange = jest.fn();
+    const { user } = setup(
+      <Select label="Owner" value="" onChange={onChange} options={DISABLED_OPTIONS} />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await screen.findByRole("listbox");
+
+    // On open, MUI highlights the first enabled option (Option 1). A single
+    // ArrowDown must skip disabled Option 2 and land on Option 3; Enter then
+    // commits that selection.
+    await user.keyboard("{ArrowDown}{Enter}");
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0].target.value).toBe("option3");
+  });
+
+  it("omitting disabled leaves the option enabled (backwards compatible)", async () => {
+    const onChange = jest.fn();
+    const { user } = setup(
+      <Select label="Owner" value="" onChange={onChange} options={OPTIONS} />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByRole("option", { name: "Option 2" }));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0].target.value).toBe("option2");
+  });
+});

--- a/src/components/inputs/Select/Select.tsx
+++ b/src/components/inputs/Select/Select.tsx
@@ -13,6 +13,7 @@ import React, { useId } from "react";
 export interface Options {
   value: string | number;
   label: string;
+  disabled?: boolean;
 }
 
 /**
@@ -138,6 +139,7 @@ const Select = React.forwardRef<HTMLInputElement, SelectProps>(
               value={option.value}
               aria-label={renderOption ? option.label : undefined}
               disableRipple
+              disabled={option.disabled}
             >
               {renderOption ? renderOption(option) : option.label}
             </MenuItem>


### PR DESCRIPTION
## Summary

- `Options` gains an optional `disabled?: boolean` field, forwarded to the underlying MUI `MenuItem`. Consumers can now render individual options as disabled without fighting emotion/portal scoping to override `MenuItemRoot` hover, focus, click gating and `aria-disabled` — MUI handles all of that natively.
- `WithRenderOption` story now derives `disabled` from the same availability metadata that drives the "SOON" pill, so the visual and interaction states stay in lockstep (Pipeline and Notebook become dimmed + unclickable).
- Fully backwards-compatible: `disabled` is optional, existing `{value, label}` options continue to type-check and behave unchanged. `Options` is a public export from `components/inputs`.

## Why this is a fix, not a feat

`renderOption` only styles the inner content — hover, focus, keyboard nav, click gating and `aria-disabled` all live on the `MenuItem` DS renders, so consumers couldn't disable individual options at all. `Autocomplete` already supports `getOptionDisabled`; this brings `Select` to parity.

## Test plan

- [x] `Select.test.tsx` — new `describe("Select per-option disabled")` block covering:
  - `.Mui-disabled` + `aria-disabled="true"` applied when `disabled: true`
  - clicking a disabled option refuses (pointer-events: none) and `onChange` is not called
  - `ArrowDown` skips the disabled option and lands on the next enabled one
  - omitting `disabled` keeps options enabled (backwards-compat guard)
- [x] All 7 pre-existing footer tests still pass — no regressions
- [x] Full project `tsc --noEmit` clean
- [x] Full `jest` suite green (311 passed) via pre-push hook
- [ ] Manual: open `Inputs/Select > WithRenderOption` in Storybook and confirm Pipeline/Notebook are dimmed, refuse click, and are skipped by keyboard nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)