### PR TITLE
fix(theme): fix ExtendedTheme type

### DIFF
--- a/src/hooks/useExtendedTheme.ts
+++ b/src/hooks/useExtendedTheme.ts
@@ -1,7 +1,7 @@
 import React from "react";
 import { useTheme } from "@mui/material/styles";
 
-import { type ExtendedTheme } from "../theme/theme-type";
+import { type ExtendedTheme } from "../theme/extended-theme";
 
 // useExtendedTheme should now generally be used everywhere in place of useTheme.
 const useExtendedTheme = () => useTheme<ExtendedTheme>();

--- a/src/theme/extended-theme.ts
+++ b/src/theme/extended-theme.ts
@@ -1,0 +1,31 @@
+// `ExtendedTheme` is the theme shape consumers see from `useExtendedTheme()`.
+//
+// It lives in this compiled module rather than in the ambient `theme-type.d.ts`
+// beside it, for one reason: `vite-plugin-dts` with `rollupTypes` can only inline
+// declarations the TypeScript program EMITS. A hand-written `.d.ts` is an input,
+// not an output, so the rollup had nothing to inline and instead emitted
+// `import { ExtendedTheme } from '../theme/theme-type'` into `dist/export.d.ts`.
+// That path resolves outside `dist`, and `src/theme/theme-type.d.ts` is not in
+// the package's `files` array, so the type was unresolvable for every consumer
+// and `useExtendedTheme()` silently degraded to `any`.
+//
+// `theme-type.d.ts` keeps the `declare module "@mui/material/styles"`
+// augmentation, which is what makes `Theme["components"]` required below.
+import type { Palette, Theme } from "@mui/material/styles";
+import type { ComponentOverrides } from "./createTheme";
+
+export interface ExtendedPalette extends Palette {
+  components: ComponentOverrides;
+}
+
+// `components` and `palette` are omitted and re-declared rather than narrowed in
+// place. MUI types each `styleOverrides` entry against `Omit<Theme, "components">`,
+// so a plain `extends Theme` re-declaration of `components` trips TS2430 on
+// variance. The previous ambient version avoided this only by being circular
+// (`ExtraTheme extends Theme` while the augmentation made `Theme extends
+// ExtraTheme`), which TypeScript resolved to an error type — the reason it went
+// unnoticed is that `skipLibCheck` never checked the file.
+export interface ExtendedTheme extends Omit<Theme, "components" | "palette"> {
+  components: ComponentOverrides;
+  palette: ExtendedPalette;
+}

--- a/src/theme/extended-theme.ts
+++ b/src/theme/extended-theme.ts
@@ -1,16 +1,8 @@
-// `ExtendedTheme` is the theme shape consumers see from `useExtendedTheme()`.
+// The theme shape `useExtendedTheme()` returns.
 //
-// It lives in this compiled module rather than in the ambient `theme-type.d.ts`
-// beside it, for one reason: `vite-plugin-dts` with `rollupTypes` can only inline
-// declarations the TypeScript program EMITS. A hand-written `.d.ts` is an input,
-// not an output, so the rollup had nothing to inline and instead emitted
-// `import { ExtendedTheme } from '../theme/theme-type'` into `dist/export.d.ts`.
-// That path resolves outside `dist`, and `src/theme/theme-type.d.ts` is not in
-// the package's `files` array, so the type was unresolvable for every consumer
-// and `useExtendedTheme()` silently degraded to `any`.
-//
-// `theme-type.d.ts` keeps the `declare module "@mui/material/styles"`
-// augmentation, which is what makes `Theme["components"]` required below.
+// A compiled module, not a `.d.ts`: `vite-plugin-dts` only inlines declarations
+// the TypeScript program emits. Move these into `theme-type.d.ts` and
+// `dist/export.d.ts` gets an import resolving outside `dist`.
 import type { Palette, Theme } from "@mui/material/styles";
 import type { ComponentOverrides } from "./createTheme";
 
@@ -18,13 +10,8 @@ export interface ExtendedPalette extends Palette {
   components: ComponentOverrides;
 }
 
-// `components` and `palette` are omitted and re-declared rather than narrowed in
-// place. MUI types each `styleOverrides` entry against `Omit<Theme, "components">`,
-// so a plain `extends Theme` re-declaration of `components` trips TS2430 on
-// variance. The previous ambient version avoided this only by being circular
-// (`ExtraTheme extends Theme` while the augmentation made `Theme extends
-// ExtraTheme`), which TypeScript resolved to an error type — the reason it went
-// unnoticed is that `skipLibCheck` never checked the file.
+// `Omit` rather than `extends Theme`: MUI types `styleOverrides` against
+// `Omit<Theme, "components">`, so re-declaring `components` trips TS2430.
 export interface ExtendedTheme extends Omit<Theme, "components" | "palette"> {
   components: ComponentOverrides;
   palette: ExtendedPalette;

--- a/src/theme/theme-type.d.ts
+++ b/src/theme/theme-type.d.ts
@@ -12,11 +12,7 @@ interface ExtraTheme extends Theme {
   components: ComponentOverrides;
 }
 
-// `ExtendedTheme` and `ExtendedPalette` used to be declared here too. They moved
-// to the compiled module `./extended-theme` so the dts rollup can inline them
-// into `dist/export.d.ts`; see the comment at the top of that file. This file
-// stays a `.d.ts` and keeps only the augmentation below, which is what makes
-// `Theme["components"]` required across the package.
+// `ExtendedTheme` and `ExtendedPalette` are in `./extended-theme`.
 
 /**
  * Adding extra theme properties

--- a/src/theme/theme-type.d.ts
+++ b/src/theme/theme-type.d.ts
@@ -12,18 +12,11 @@ interface ExtraTheme extends Theme {
   components: ComponentOverrides;
 }
 
-export interface ExtendedTheme extends ExtraTheme {
-  components: ComponentOverrides;
-  palette: ExtendedPalette;
-}
-
-interface ExtraPalette extends Palette {
-  // Add palette fields here.
-}
-
-interface ExtendedPalette extends ExtraPalette {
-  components: ComponentOverrides;
-}
+// `ExtendedTheme` and `ExtendedPalette` used to be declared here too. They moved
+// to the compiled module `./extended-theme` so the dts rollup can inline them
+// into `dist/export.d.ts`; see the comment at the top of that file. This file
+// stays a `.d.ts` and keeps only the augmentation below, which is what makes
+// `Theme["components"]` required across the package.
 
 /**
  * Adding extra theme properties


### PR DESCRIPTION
✅  **AI-generated: Reviewed line-by-line up to [b3ba21b](https://github.com/telicent-oss/telicent-ds/pull/524/commits/b3ba21b65b738b3daa300085c8cfa4064be84f3f)**

Ticket: in service of https://telicent.atlassian.net/browse/LAB-88

### Goal

`useExtendedTheme()` returns a real type instead of `any` for consumers of the published package.

### Work Completed

- `ExtendedTheme` and `ExtendedPalette` move to a compiled module, so the dts rollup inlines them
- `dist/export.d.ts` no longer imports `../theme/theme-type`, a path outside `dist` for a file not in `files`
- the `@mui/material/styles` augmentation now ships inside `dist`

### Testing Method

`tsc --noEmit`, `yarn build` and `yarn test` green. Typecheck matches `main`.

`dist/export.d.ts`, built from each side:

```diff
-38:  import { ExtendedTheme } from '../theme/theme-type';
+857: declare interface ExtendedTheme extends Omit<Theme_2, "components" | "palette"> {
+858:     components: ComponentOverrides;
+859:     palette: ExtendedPalette;
+860: }
```

On `main` the name is only imported, never declared. A consumer typechecking
against the built `dist` now resolves `ExtendedTheme` and its `palette.components`.

### Code Review Tips

`ExtendedTheme` extends `Omit<Theme, "components" | "palette">`, not `Theme`. MUI types `styleOverrides` against `Omit<Theme, "components">`, so re-declaring `components` trips _TS2430 - Interface Incorrectly Extends Interface_. The ambient version escaped that by being circular, which `skipLibCheck` hid.

### Out-of-scope

`yarn lint` fails on `main`: no `eslint.config.js` and no `.eslintrc.*` against ESLint v9.

