### PR TITLE
feat: add AppInfo and ConfirmDialog components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ build-storybook.log
 .env
 upload.env
 .vscode
+.claude
 
 main.tsx
 App.tsx

--- a/src/components/data-display/AppInfo/AppInfo.stories.tsx
+++ b/src/components/data-display/AppInfo/AppInfo.stories.tsx
@@ -1,0 +1,153 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import Box from "@mui/material/Box";
+
+import AppInfo from "./AppInfo";
+import AppInfoRow from "./AppInfoRow";
+
+const meta = {
+  title: "Data display/App info",
+  component: AppInfo,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: `
+An icon-button + popover shell that surfaces app metadata from the AppBar end slot. Every Telicent app uses this next to \`UserProfile\`, so the visual language and behaviour of the trigger and popover are enforced here rather than reimplemented per app.
+
+The component is composition-first: it owns the trigger, the popover, and the layout, but nothing about what's inside. Consumers compose rows using \`AppInfoRow\` (or arbitrary JSX for exotic content).
+
+---
+
+### Supported use cases
+
+- **Version-only** — the most common case. Pass a single \`AppInfoRow\` child with the version string.
+- **Extra metadata rows** — compose additional \`AppInfoRow\` children for build hash, environment, licence, or anything else app-specific. All rows share the same styling.
+- **Exotic content** — pass any JSX as children when a label:value row isn't the right shape (e.g. a copyright notice, a support link block). Match the visual style yourself, or lean on \`AppInfoRow\`.
+- **Custom trigger id / label** — override \`id\` for stable E2E selectors (\`\${id}-trigger\`, \`\${id}-popover\`) and \`ariaLabel\` for the icon-button.
+
+---
+
+### When & how to use it
+
+- **In the AppBar end slot** — place next to \`UserProfile\`. The anchor positioning is tuned for the top-right of the AppBar; do not use elsewhere.
+- **App metadata comes from the app**, not the DS — read \`version\` from your app's \`package.json\` (via Vite \`define\`, direct import, or however your app configures it) and pass it as an \`AppInfoRow\` value.
+- **Prefer \`AppInfoRow\` for every row** so per-app extensions share styling with the standard version row.
+
+---
+
+### Example
+
+\`\`\`tsx
+import { AppInfo, AppInfoRow } from "@telicent-oss/ds";
+import { version } from "../../../package.json";
+
+<AppInfo>
+  <AppInfoRow label="Version" value={version} />
+  <AppInfoRow label="Build" value={buildHash} />
+  <AppInfoRow label="Environment" value={env} />
+</AppInfo>
+\`\`\`
+        `,
+      },
+    },
+  },
+  argTypes: {
+    id: {
+      control: "text",
+      description:
+        'Optional id prefix used for stable selectors (E2E, telemetry). Defaults to `"app-info"`, producing `${id}-trigger` and `${id}-popover`.',
+    },
+    ariaLabel: {
+      control: "text",
+      description:
+        'Accessible label for the icon-button trigger and the popover dialog. Defaults to `"App information"`.',
+    },
+    children: {
+      control: false,
+      description:
+        "Rows rendered inside the popover. Compose from `AppInfoRow` for standard label:value pairs.",
+      table: { type: { summary: "ReactNode" } },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <Box sx={{ display: "flex", justifyContent: "flex-end", p: 2 }}>
+        {Story()}
+      </Box>
+    ),
+  ],
+} satisfies Meta<typeof AppInfo>;
+
+export default meta;
+export type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: <AppInfoRow label="Version" value="1.16.0" />,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The minimum viable usage — a single Version row. Click the info icon to open the popover.",
+      },
+    },
+  },
+};
+
+export const WithExtraRows: Story = {
+  args: {
+    children: (
+      <>
+        <AppInfoRow label="Version" value="1.16.0" />
+        <AppInfoRow label="Build" value="a1b2c3d" />
+        <AppInfoRow label="Environment" value="production" />
+      </>
+    ),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Additional metadata rows. Every row uses `AppInfoRow`, so styling is uniform — no special-cased first row.",
+      },
+    },
+  },
+};
+
+export const LongVersion: Story = {
+  args: {
+    children: (
+      <AppInfoRow label="Version" value="1.16.0-rc.3+build.2026-08-07.abc1234" />
+    ),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Verifies that long values wrap gracefully within the 240px popover — useful for pre-release builds that include build metadata.",
+      },
+    },
+  },
+};
+
+export const CustomId: Story = {
+  args: {
+    id: "graph-app-info",
+    children: (
+      <AppInfoRow
+        label="Version"
+        value="1.16.0"
+        id="graph-app-info-version"
+      />
+    ),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Override the id prefix on `AppInfo` to produce stable selectors for the trigger and popover. Put ids on individual `AppInfoRow` values as needed for E2E/telemetry.",
+      },
+    },
+  },
+};

--- a/src/components/data-display/AppInfo/AppInfo.tsx
+++ b/src/components/data-display/AppInfo/AppInfo.tsx
@@ -1,0 +1,56 @@
+import React, { PropsWithChildren, useState } from "react";
+
+import IconButton from "../../buttons/Button/IconButton";
+import { Box } from "../../layout/Box/Box";
+import PopOver from "../../surfaces/PopOver/Popover";
+import InfoIcon from "../Icons/InfoIcon";
+
+export type AppInfoProps = PropsWithChildren<{
+  id?: string;
+  ariaLabel?: string;
+}>;
+
+const AppInfo: React.FC<AppInfoProps> = ({
+  id = "app-info",
+  ariaLabel = "App information",
+  children,
+}) => {
+  const [anchor, setAnchor] = useState<HTMLElement | null>(null);
+  const open = Boolean(anchor);
+
+  return (
+    <>
+      <IconButton
+        id={`${id}-trigger`}
+        aria-label={ariaLabel}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        onClick={(e) => setAnchor(e.currentTarget)}
+        color="inherit"
+        size="large"
+      >
+        <InfoIcon fontSize="medium" sx={{ fontSize: 24 }} />
+      </IconButton>
+
+      <PopOver
+        id={`${id}-popover`}
+        open={open}
+        anchorEl={anchor}
+        onClose={() => setAnchor(null)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+        transformOrigin={{ vertical: "top", horizontal: "right" }}
+        width={240}
+      >
+        <Box
+          role="dialog"
+          aria-label={ariaLabel}
+          sx={{ display: "flex", flexDirection: "column", gap: 1 }}
+        >
+          {children}
+        </Box>
+      </PopOver>
+    </>
+  );
+};
+
+export default AppInfo;

--- a/src/components/data-display/AppInfo/AppInfoRow.tsx
+++ b/src/components/data-display/AppInfo/AppInfoRow.tsx
@@ -1,0 +1,36 @@
+import React, { ReactNode } from "react";
+
+import FlexBox from "../../layout/FlexBox";
+import { Text } from "../Text/Text";
+
+export interface AppInfoRowProps {
+  label: string;
+  value: ReactNode;
+  id?: string;
+}
+
+const AppInfoRow: React.FC<AppInfoRowProps> = ({ label, value, id }) => (
+  <FlexBox
+    direction="row"
+    alignItems="center"
+    justifyContent="space-between"
+    spacing={2}
+  >
+    <Text
+      variant="caption"
+      sx={{
+        fontWeight: 600,
+        letterSpacing: "0.08em",
+        textTransform: "uppercase",
+        color: "text.secondary",
+      }}
+    >
+      {label}
+    </Text>
+    <Text id={id} variant="body2">
+      {value}
+    </Text>
+  </FlexBox>
+);
+
+export default AppInfoRow;

--- a/src/components/data-display/AppInfo/__tests__/AppInfo.test.tsx
+++ b/src/components/data-display/AppInfo/__tests__/AppInfo.test.tsx
@@ -1,0 +1,76 @@
+import { screen } from "@testing-library/react";
+import AppInfo from "../AppInfo";
+import AppInfoRow from "../AppInfoRow";
+import { setup } from "../../../../test-utils";
+
+describe("AppInfo", () => {
+  test("renders the trigger with the default accessible name", () => {
+    setup(<AppInfo />);
+
+    expect(
+      screen.getByRole("button", { name: "App information" })
+    ).toBeInTheDocument();
+  });
+
+  test("popover is closed by default", () => {
+    setup(<AppInfo />);
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  test("opens on click and renders composed children", async () => {
+    const { user } = setup(
+      <AppInfo>
+        <AppInfoRow label="Version" value="1.16.0" />
+      </AppInfo>
+    );
+
+    await user.click(screen.getByRole("button", { name: "App information" }));
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+    expect(await screen.findByText("1.16.0")).toBeInTheDocument();
+  });
+
+  test("closes on Escape", async () => {
+    const { user } = setup(<AppInfo />);
+
+    await user.click(screen.getByRole("button", { name: "App information" }));
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  test("renders arbitrary children inside the open dialog", async () => {
+    const { user } = setup(
+      <AppInfo>
+        <div id="extra">extra</div>
+      </AppInfo>
+    );
+
+    await user.click(screen.getByRole("button", { name: "App information" }));
+
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog).toContainElement(screen.getByTestId("extra"));
+  });
+
+  test("custom id prop is applied to the trigger", () => {
+    setup(<AppInfo id="foo" />);
+
+    expect(
+      screen.getByRole("button", { name: "App information" })
+    ).toHaveAttribute("id", "foo-trigger");
+  });
+
+  test("aria-expanded reflects the open state", async () => {
+    const { user } = setup(<AppInfo />);
+
+    const trigger = screen.getByRole("button", { name: "App information" });
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+
+    await user.click(trigger);
+
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+  });
+});

--- a/src/components/data-display/AppInfo/__tests__/AppInfoRow.test.tsx
+++ b/src/components/data-display/AppInfo/__tests__/AppInfoRow.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import AppInfoRow from "../AppInfoRow";
+
+describe("AppInfoRow", () => {
+  test("renders label and string value", () => {
+    render(<AppInfoRow label="Build" value="a1b2c3d" />);
+
+    expect(screen.getByText("Build")).toBeInTheDocument();
+    expect(screen.getByText("a1b2c3d")).toBeInTheDocument();
+  });
+
+  test("renders ReactNode value", () => {
+    render(
+      <AppInfoRow
+        label="Support"
+        value={<a href="mailto:support@example.com">Contact</a>}
+      />
+    );
+
+    expect(screen.getByRole("link", { name: "Contact" })).toBeInTheDocument();
+  });
+
+  test("applies id to the value element", () => {
+    render(<AppInfoRow label="Build" value="a1b2c3d" id="build-value" />);
+
+    expect(screen.getByText("a1b2c3d")).toHaveAttribute("id", "build-value");
+  });
+});

--- a/src/components/data-display/Icons/WarningIcon.tsx
+++ b/src/components/data-display/Icons/WarningIcon.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import MUISvgIcon, {
+  SvgIconProps as MUISvgIconProps,
+} from "@mui/material/SvgIcon";
+
+const WarningIcon: React.FC<MUISvgIconProps> = (iconProps) => (
+  <MUISvgIcon {...iconProps}>
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M10.2679 3.5C11.0378 2.16667 12.9622 2.16667 13.7321 3.5L21.5311 17C22.301 18.3333 21.3388 20 19.799 20H4.20096C2.66116 20 1.69891 18.3333 2.46881 17L10.2679 3.5ZM12 4.5L4.20096 18H19.799L12 4.5ZM11 10H13V14H11V10ZM11 15H13V17H11V15Z"
+      fill="currentColor"
+    />
+  </MUISvgIcon>
+);
+
+export default WarningIcon;

--- a/src/components/data-display/Icons/index.ts
+++ b/src/components/data-display/Icons/index.ts
@@ -12,6 +12,7 @@ export { default as MapIcon } from "./MapIcon";
 export { default as MinusCircleIcon } from "./MinusCircleIcon";
 export { default as PlayIcon } from "./PlayIcon";
 export { default as PlusCircleIcon } from "./PlusCircleIcon";
+export { default as WarningIcon } from "./WarningIcon";
 export { default as TelicentMark } from "./TelicentMark";
 export { default as TelicentHorizontalSVG } from "./TelicentHorizontalSVG";
 export { default as UserIcon } from "./UserIcon";

--- a/src/components/data-display/index.ts
+++ b/src/components/data-display/index.ts
@@ -21,6 +21,12 @@ export type { TreeViewProps, TreeViewBaseItem } from "./TreeView/TreeView";
 export { default as UserProfile } from "./UserProfile/UserProfile";
 export type { UserProfileProps } from "./UserProfile/UserProfile";
 
+export { default as AppInfo } from "./AppInfo/AppInfo";
+export type { AppInfoProps } from "./AppInfo/AppInfo";
+
+export { default as AppInfoRow } from "./AppInfo/AppInfoRow";
+export type { AppInfoRowProps } from "./AppInfo/AppInfoRow";
+
 export { default as UserProfileContent } from "./UserProfile/UserProfileContent/UserProfileContent";
 export { default as TitleAndContent } from "./Text/TitleAndContent/TitleAndContent";
 

--- a/src/components/feedback/ConfirmDialog/ConfirmDialog.stories.tsx
+++ b/src/components/feedback/ConfirmDialog/ConfirmDialog.stories.tsx
@@ -1,0 +1,288 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import Button from "../../buttons/Button/Button";
+import MinusCircleIcon from "../../data-display/Icons/MinusCircleIcon";
+import ConfirmDialog from "./ConfirmDialog";
+
+const meta = {
+  title: "Feedback/Confirm dialog",
+  component: ConfirmDialog,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: `
+A modal dialog that asks the user to confirm an action — submits, publishes, restarts, deletes, or anything else that needs explicit consent before proceeding. Encodes the DS-blessed layout, colour language, focus behaviour, and pending-state handling so consuming apps don't reimplement (or diverge on) any of it.
+
+Owns nothing but its own rendering — the caller controls \`open\` and \`isPending\` so the dialog integrates with any mutation library (React Query, RTK, custom).
+
+---
+
+### Variants
+
+The visual tone is chosen by the \`variant\` prop:
+
+- **Neutral** (default, no \`variant\`) — primary confirm button, no header icon by default. For routine confirmations where the consequence is minor or purely acknowledgement (submit, save, send invitation, one-time key display).
+- **Warning** (\`variant="warning"\`) — amber-tinted header pill with \`WarningIcon\`, amber confirm button. For high-consequence but non-destructive actions where the user should be warned before proceeding (dirty-form leave-page, restart service, apply migration).
+- **Destructive** (\`variant="destructive"\`) — red-tinted header pill with \`BinIcon\`, red confirm button. For irreversible operations that remove something (delete, revoke, archive, remove-from-team).
+
+The safe default is neutral — a forgotten \`variant\` prop under-sells the action rather than over-selling it.
+
+---
+
+### Other supported features
+
+- **Pending state** — while \`isPending\` is true both buttons disable, the confirm label swaps to \`pendingLabel\`, and dismissal (backdrop click / Escape) is blocked to prevent race conditions between "cancel" and "in-flight mutation".
+- **Alert callout** — pass \`alert={{ severity, message }}\` to surface an important consequence of the action as a visually distinct Alert above the buttons. Developer-authored, static — not for showing async mutation errors.
+- **Custom icon** — override \`icon\` for any variant. The same icon renders in the header pill and on the confirm button.
+- **Stable selectors** — override \`id\` to produce stable ids for E2E and telemetry: \`\${id}-title\`, \`\${id}-body\`, \`\${id}-cancel\`, \`\${id}-confirm\`, \`\${id}-alert\`.
+
+---
+
+### When & how to use it
+
+- **Anywhere the user needs to make a yes/no decision with a consequence** — deletes, publishes, revokes, form submits with side effects, dirty-form leave-page prompts.
+- **Do not use for informational modals with a single "OK" button** — that's a different shape (an alert/acknowledgement dialog), not covered here.
+- **Do not use for form validation errors** — inline field errors or an Alert on the form itself are the right tool.
+- **Wire \`isPending\` to your mutation** — the component won't manage the async lifecycle for you, but it handles the UX of it correctly if you supply the state. If a server error needs to be shown after the action, handle that in the calling flow (e.g. a toast) rather than trying to render it inside the dialog.
+
+---
+
+### Example
+
+\`\`\`tsx
+import { ConfirmDialog } from "@telicent-oss/ds";
+import { useMutation } from "@tanstack/react-query";
+
+const deleteMutation = useMutation({ mutationFn: deleteDataset });
+
+<ConfirmDialog
+  open={confirmOpen}
+  variant="destructive"
+  onClose={() => setConfirmOpen(false)}
+  onConfirm={() => deleteMutation.mutate(datasetId)}
+  title="Delete dataset?"
+  body="The dataset and its metadata will be removed from the catalogue."
+  confirmLabel="Delete"
+  pendingLabel="Deleting…"
+  isPending={deleteMutation.isPending}
+  alert={{
+    severity: "warning",
+    message: "This permanently removes the dataset and orphans its distributions. This action cannot be undone.",
+  }}
+/>
+\`\`\`
+        `,
+      },
+    },
+  },
+  args: {
+    onConfirm: fn(),
+    onClose: fn(),
+  },
+  argTypes: {
+    open: {
+      control: "boolean",
+      description: "Whether the dialog is shown. Controlled by the consumer.",
+    },
+    title: {
+      control: "text",
+      description: 'Short, action-focused heading (e.g. "Delete project?").',
+    },
+    body: {
+      control: false,
+      description: "Body content. A string is wrapped in body2 Text; a ReactNode is rendered as-is.",
+      table: { type: { summary: "ReactNode" } },
+    },
+    confirmLabel: {
+      control: "text",
+      description:
+        'Label for the confirm button. Defaults to `"Confirm"` — set explicitly (e.g. `"Delete"`, `"Publish"`, `"Leave"`) for clarity.',
+    },
+    cancelLabel: {
+      control: "text",
+      description: 'Label for the cancel button. Defaults to `"Cancel"`.',
+    },
+    pendingLabel: {
+      control: "text",
+      description: 'Confirm-button label while `isPending` is true. Defaults to `"Working…"`.',
+    },
+    icon: {
+      control: false,
+      description:
+        "Icon shown in the header pill and on the confirm button. Defaults to `BinIcon` for destructive, `WarningIcon` for warning, none for neutral.",
+      table: { type: { summary: "ReactNode" } },
+    },
+    isPending: {
+      control: "boolean",
+      description: "When true: buttons disable, confirm label swaps to `pendingLabel`, and close is blocked.",
+    },
+    alert: {
+      control: false,
+      description:
+        "Optional callout rendered as an Alert below the body. Use it to emphasise domain consequences the user must read before confirming (e.g. \"This permanently removes the dataset and orphans its distributions.\"). Not for surfacing async mutation errors — those belong in the calling flow, not inside the confirmation.",
+      table: { type: { summary: "{ severity: AlertColor; message: string }" } },
+    },
+    variant: {
+      control: "radio",
+      options: [undefined, "warning", "destructive"],
+      description:
+        'Visual tone. Undefined = neutral (default). `"warning"` = amber for consequential-but-not-destructive actions. `"destructive"` = red for irreversible removals.',
+    },
+    id: {
+      control: "text",
+      description:
+        'Optional id prefix used for stable selectors. Defaults to `"confirm-dialog"`, producing `${id}-title`, `${id}-body`, `${id}-cancel`, `${id}-confirm`, `${id}-error`.',
+    },
+    ariaLabel: {
+      control: "text",
+      description: "Overrides the dialog's accessible name. When omitted, the title is used via `aria-labelledby`.",
+    },
+  },
+} satisfies Meta<typeof ConfirmDialog>;
+
+export default meta;
+export type Story = StoryObj<typeof meta>;
+
+const InteractiveTemplate: Story["render"] = (args) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>Open dialog</Button>
+      <ConfirmDialog
+        {...args}
+        open={open}
+        onClose={() => {
+          setOpen(false);
+          args.onClose();
+        }}
+        onConfirm={() => {
+          setOpen(false);
+          args.onConfirm();
+        }}
+      />
+    </>
+  );
+};
+
+export const Neutral: Story = {
+  args: {
+    open: false,
+    title: "Publish this dataset?",
+    body: "Consumers with access will see the new version immediately.",
+    confirmLabel: "Publish",
+  },
+  render: InteractiveTemplate,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The default. No `variant` set — primary confirm button, no header icon. Use for actions that need explicit consent but aren't dangerous (publish, submit, save, send).",
+      },
+    },
+  },
+};
+
+export const Warning: Story = {
+  args: {
+    open: false,
+    variant: "warning",
+    title: "Leave without saving?",
+    body: "Your edits will be lost if you leave now.",
+    confirmLabel: "Leave",
+    cancelLabel: "Stay",
+  },
+  render: InteractiveTemplate,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "For consequential actions that aren't destructive per se, but where the user should think twice — dirty-form leave-page, restart service, apply migration. Amber pill with `WarningIcon`, amber confirm button.",
+      },
+    },
+  },
+};
+
+export const Destructive: Story = {
+  args: {
+    open: false,
+    variant: "destructive",
+    title: "Delete project?",
+    body: "This can't be undone. All related assets will also be removed.",
+    confirmLabel: "Delete",
+  },
+  render: InteractiveTemplate,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "For irreversible operations that remove something — delete, revoke, archive, remove-from-team. Red pill with `BinIcon`, red confirm button. Explicit opt-in — the default is neutral, so this styling never appears by accident.",
+      },
+    },
+  },
+};
+
+export const WithAlert: Story = {
+  args: {
+    open: false,
+    variant: "destructive",
+    title: "Delete dataset?",
+    body: "The dataset and its metadata will be removed from the catalogue.",
+    confirmLabel: "Delete",
+    alert: {
+      severity: "warning",
+      message:
+        "This permanently removes the dataset and orphans its distributions. This action cannot be undone.",
+    },
+  },
+  render: InteractiveTemplate,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Use `alert` to surface an important consequence of the action as a visually distinct callout above the buttons. This is developer-authored context — pick the severity that matches the tone (`warning` for consequences, `info` for heads-up, `success` rarely). Not for showing async mutation errors.",
+      },
+    },
+  },
+};
+
+export const CustomIcon: Story = {
+  args: {
+    open: false,
+    variant: "destructive",
+    title: "Revoke API key?",
+    body: "The key will stop working immediately. Existing clients using it will fail.",
+    confirmLabel: "Revoke",
+    icon: <MinusCircleIcon />,
+  },
+  render: InteractiveTemplate,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Override `icon` for any variant. Use for destructive actions that aren't deletes (revoke, archive, remove-from-team) or to reinforce a warning with a domain-specific glyph. The same icon renders in the header pill and on the confirm button.",
+      },
+    },
+  },
+};
+
+export const LongBody: Story = {
+  args: {
+    open: false,
+    variant: "destructive",
+    title: "Delete workspace?",
+    body: "Deleting this workspace will permanently remove all projects, datasets, dashboards, saved queries, sharing rules, and audit logs contained within it. This action affects 12 collaborators and cannot be undone once confirmed.",
+    confirmLabel: "Delete",
+  },
+  render: InteractiveTemplate,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The body wraps as needed within the 420px dialog. Use longer body copy when the user needs to understand exactly what the action affects before confirming.",
+      },
+    },
+  },
+};

--- a/src/components/feedback/ConfirmDialog/ConfirmDialog.tsx
+++ b/src/components/feedback/ConfirmDialog/ConfirmDialog.tsx
@@ -1,0 +1,165 @@
+import React, { ReactNode } from "react";
+import { alpha, Theme } from "@mui/material/styles";
+
+import Button from "../../buttons/Button/Button";
+import BinIcon from "../../data-display/Icons/BinIcon";
+import WarningIcon from "../../data-display/Icons/WarningIcon";
+import { Text } from "../../data-display/Text/Text";
+import { Box } from "../../layout/Box/Box";
+import { Alert, AlertColor } from "../Alert/Alert";
+import Dialog, { DialogActions, DialogContent } from "../Dialog/Dialog";
+
+export type ConfirmDialogVariant = "destructive" | "warning";
+
+export type ConfirmDialogAlert = {
+  severity: AlertColor;
+  message: string;
+};
+
+export interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  body: ReactNode;
+  onConfirm: () => void;
+  onClose: () => void;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  pendingLabel?: string;
+  icon?: ReactNode;
+  isPending?: boolean;
+  alert?: ConfirmDialogAlert;
+  variant?: ConfirmDialogVariant;
+  id?: string;
+  ariaLabel?: string;
+}
+
+const noop = () => {};
+
+const defaultIconFor = (variant: ConfirmDialogVariant | undefined): ReactNode => {
+  if (variant === "destructive") return <BinIcon fontSize="small" />;
+  if (variant === "warning") return <WarningIcon fontSize="small" />;
+  return null;
+};
+
+const paletteFor = (
+  variant: ConfirmDialogVariant | undefined,
+  theme: Theme
+): { bg: string; color: string } => {
+  if (variant === "destructive") {
+    return {
+      bg: alpha(theme.palette.error.main, 0.15),
+      color: theme.palette.error.main,
+    };
+  }
+  if (variant === "warning") {
+    return {
+      bg: alpha(theme.palette.warning.main, 0.15),
+      color: theme.palette.warning.main,
+    };
+  }
+  return {
+    bg: alpha(theme.palette.primary.main, 0.15),
+    color: theme.palette.primary.main,
+  };
+};
+
+const buttonColorFor = (
+  variant: ConfirmDialogVariant | undefined
+): "primary" | "warning" | "error" => {
+  if (variant === "destructive") return "error";
+  if (variant === "warning") return "warning";
+  return "primary";
+};
+
+const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
+  open,
+  title,
+  body,
+  onConfirm,
+  onClose,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  pendingLabel = "Working…",
+  icon,
+  isPending = false,
+  alert,
+  variant,
+  id = "confirm-dialog",
+  ariaLabel,
+}) => {
+  const resolvedIcon = icon ?? defaultIconFor(variant);
+  const titleId = `${id}-title`;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={isPending ? noop : onClose}
+      aria-labelledby={ariaLabel ? undefined : titleId}
+      PaperProps={{ id, "aria-label": ariaLabel }}
+      sx={{ "& .MuiDialog-paper": { width: 420, maxWidth: "100%" } }}
+    >
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, px: 3, pt: 3 }}>
+        {resolvedIcon && (
+          <Box
+            sx={(theme) => {
+              const { bg, color } = paletteFor(variant, theme);
+              return {
+                width: 36,
+                height: 36,
+                borderRadius: 1,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                bgcolor: bg,
+                color,
+                flexShrink: 0,
+              };
+            }}
+          >
+            {resolvedIcon}
+          </Box>
+        )}
+        <Text
+          component="h2"
+          id={titleId}
+          sx={{ fontSize: "16px", fontWeight: 600, lineHeight: 1.3, m: 0 }}
+        >
+          {title}
+        </Text>
+      </Box>
+      <DialogContent sx={{ pt: 2 }}>
+        <Box id={`${id}-body`}>
+          {typeof body === "string" ? <Text variant="body2">{body}</Text> : body}
+        </Box>
+        {alert && (
+          <Alert id={`${id}-alert`} severity={alert.severity} sx={{ mt: 2 }}>
+            {alert.message}
+          </Alert>
+        )}
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 3, pt: 1, gap: 1 }}>
+        <Button
+          id={`${id}-cancel`}
+          variant="tertiary"
+          onClick={onClose}
+          disabled={isPending}
+        >
+          {cancelLabel}
+        </Button>
+        <Button
+          id={`${id}-confirm`}
+          color={buttonColorFor(variant)}
+          variant="primary"
+          onClick={onConfirm}
+          disabled={isPending}
+          startIcon={resolvedIcon}
+          sx={{ "& .MuiButton-startIcon > *": { fontSize: 16 } }}
+        >
+          {isPending ? pendingLabel : confirmLabel}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ConfirmDialog;

--- a/src/components/feedback/ConfirmDialog/__tests__/ConfirmDialog.test.tsx
+++ b/src/components/feedback/ConfirmDialog/__tests__/ConfirmDialog.test.tsx
@@ -1,0 +1,180 @@
+import { screen } from "@testing-library/react";
+import ConfirmDialog from "../ConfirmDialog";
+import { setup } from "../../../../test-utils";
+
+const baseProps = {
+  open: true,
+  title: "Delete project?",
+  body: "This can't be undone.",
+  onConfirm: jest.fn(),
+  onClose: jest.fn(),
+};
+
+describe("ConfirmDialog", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("renders nothing when closed", () => {
+    setup(<ConfirmDialog {...baseProps} open={false} />);
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  test("renders title and body when open", () => {
+    setup(<ConfirmDialog {...baseProps} />);
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Delete project?")).toBeInTheDocument();
+    expect(screen.getByText("This can't be undone.")).toBeInTheDocument();
+  });
+
+  test("calls onConfirm when the confirm button is clicked", async () => {
+    const onConfirm = jest.fn();
+    const { user } = setup(<ConfirmDialog {...baseProps} onConfirm={onConfirm} />);
+
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  test("calls onClose when the cancel button is clicked", async () => {
+    const onClose = jest.fn();
+    const { user } = setup(<ConfirmDialog {...baseProps} onClose={onClose} />);
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("calls onClose when Escape is pressed", async () => {
+    const onClose = jest.fn();
+    const { user } = setup(<ConfirmDialog {...baseProps} onClose={onClose} />);
+
+    await user.keyboard("{Escape}");
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("blocks close and disables buttons while pending", async () => {
+    const onClose = jest.fn();
+    const onConfirm = jest.fn();
+    const { user } = setup(
+      <ConfirmDialog
+        {...baseProps}
+        onClose={onClose}
+        onConfirm={onConfirm}
+        isPending
+      />
+    );
+
+    await user.keyboard("{Escape}");
+    expect(onClose).not.toHaveBeenCalled();
+
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Working…" })).toBeDisabled();
+  });
+
+  test("shows pendingLabel on the confirm button while pending", () => {
+    setup(
+      <ConfirmDialog {...baseProps} isPending pendingLabel="Deleting…" />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Deleting…" })
+    ).toBeInTheDocument();
+  });
+
+  test("does not render an alert when the alert prop is undefined", () => {
+    setup(<ConfirmDialog {...baseProps} />);
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  test("renders the alert message when provided", () => {
+    setup(
+      <ConfirmDialog
+        {...baseProps}
+        alert={{
+          severity: "warning",
+          message: "This permanently removes the dataset.",
+        }}
+      />
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "This permanently removes the dataset."
+    );
+  });
+
+  test("applies the alert severity to the Alert", () => {
+    setup(
+      <ConfirmDialog
+        {...baseProps}
+        alert={{ severity: "info", message: "Heads up." }}
+      />
+    );
+
+    expect(screen.getByRole("alert")).toHaveClass("MuiAlert-standardInfo");
+  });
+
+  test("uses neutral styling by default (primary confirm button)", () => {
+    setup(<ConfirmDialog {...baseProps} />);
+
+    const confirmButton = screen.getByRole("button", { name: "Confirm" });
+    expect(confirmButton).not.toHaveClass("MuiButton-colorError");
+    expect(confirmButton).not.toHaveClass("MuiButton-colorWarning");
+  });
+
+  test('variant="destructive" applies error color on the confirm button', () => {
+    setup(<ConfirmDialog {...baseProps} variant="destructive" />);
+
+    expect(
+      screen.getByRole("button", { name: "Confirm" })
+    ).toHaveClass("MuiButton-colorError");
+  });
+
+  test('variant="warning" applies warning color on the confirm button', () => {
+    setup(<ConfirmDialog {...baseProps} variant="warning" />);
+
+    expect(
+      screen.getByRole("button", { name: "Confirm" })
+    ).toHaveClass("MuiButton-colorWarning");
+  });
+
+  test("applies custom id prefix to internal elements", () => {
+    setup(<ConfirmDialog {...baseProps} id="delete-project" />);
+
+    expect(screen.getByRole("dialog")).toHaveAttribute("id", "delete-project");
+    expect(
+      screen.getByRole("button", { name: "Cancel" })
+    ).toHaveAttribute("id", "delete-project-cancel");
+    expect(
+      screen.getByRole("button", { name: "Confirm" })
+    ).toHaveAttribute("id", "delete-project-confirm");
+  });
+
+  test("wires aria-labelledby to the title id by default", () => {
+    setup(<ConfirmDialog {...baseProps} id="delete-project" />);
+
+    expect(screen.getByRole("dialog")).toHaveAttribute(
+      "aria-labelledby",
+      "delete-project-title"
+    );
+  });
+
+  test("applies ariaLabel to the dialog when provided", () => {
+    setup(
+      <ConfirmDialog
+        {...baseProps}
+        id="delete-project"
+        ariaLabel="Delete project confirmation"
+      />
+    );
+
+    expect(screen.getByRole("dialog")).toHaveAttribute(
+      "aria-label",
+      "Delete project confirmation"
+    );
+  });
+});

--- a/src/components/feedback/index.ts
+++ b/src/components/feedback/index.ts
@@ -2,5 +2,7 @@ export { default as LinearProgress } from "./LinearProgress/LinearProgress";
 export { default as Spinner } from "./Spinner/Spinner";
 export { default as Dialog } from "./Dialog/Dialog";
 export * from "./Dialog/Dialog";
+export { default as ConfirmDialog } from "./ConfirmDialog/ConfirmDialog";
+export type { ConfirmDialogProps } from "./ConfirmDialog/ConfirmDialog";
 export { Skeleton } from "./Skeleton/Skeleton";
 export { Alert, type AlertColor } from "./Alert/Alert";

--- a/src/components/surfaces/AppBar/AppBar.stories.tsx
+++ b/src/components/surfaces/AppBar/AppBar.stories.tsx
@@ -2,8 +2,9 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Box } from "@mui/material";
 
 import AppBar from "./AppBar";
-import { AppSwitch, Divider, TitleAndContent, UserProfile } from "../../data-display";
+import { AppInfo, AppInfoRow, AppSwitch, Divider, TitleAndContent, UserProfile } from "../../data-display";
 import { Button } from "../../buttons";
+import FlexBox from "../../layout/FlexBox";
 import { appList } from "../../data-display/AppSwitch/AppSwitch.stories";
 import { figmaDesign } from "../../../../.storybook/figmaDesign";
 
@@ -108,13 +109,13 @@ export default meta;
 type Story = StoryObj<typeof AppBar>;
 
 const UserProfileExample = (
-  <UserProfile fullName="JohnDoe@company.co.uk">
+  <UserProfile>
     <TitleAndContent title="Username" content="John Doe" />
     <TitleAndContent title="Email" content="JohnDoe@company.co.uk" />
     <TitleAndContent title="Deployed Organisation" content="Company UK" />
-    <TitleAndContent title="Version number" content="1.2.3" />
-    <Divider />
-    <Box sx={{ pt: 1 }}>
+
+    <Divider sx={{ py: 1 }} />
+    <Box sx={{ pt: 2 }}>
       <Button
         onClick={() => console.log("Sign Out clicked")}
         variant="primary"
@@ -158,18 +159,27 @@ export const ClickableBrand: Story = {
   },
 };
 
-export const UsageExample: Story = {
+export const StandardHeader: Story = {
   args: {
     appName: "Catalogue",
     isElevated: true,
     startChild: <AppSwitch apps={appList} />,
-    endChild: UserProfileExample,
+    endChild: (
+      <FlexBox direction="row" alignItems="center" spacing={0.5}>
+        <AppInfo>
+          <AppInfoRow label="Version" value="1.16.0" />
+          <AppInfoRow label="Build" value="a1b2c3d" />
+          <AppInfoRow label="Environment" value="production" />
+        </AppInfo>
+        {UserProfileExample}
+      </FlexBox>
+    ),
   },
   parameters: {
     docs: {
       description: {
         story:
-          "Recommended application-header setup with branding, app navigation on the left, and a primary action on the right.",
+          "The full Telicent app-header composition: `AppSwitch` on the left, `AppInfo` and `UserProfile` on the right. This is the shape every Telicent app should assemble — the DS provides the pieces, apps compose them in the AppBar slots. `AppInfo` sits next to `UserProfile` so version/build/environment metadata is one click away without cluttering the profile dropdown.",
       },
     },
   },

--- a/src/story-coverage.test.ts
+++ b/src/story-coverage.test.ts
@@ -87,6 +87,7 @@ it("looks for components that appear to be missing a story - snapshots these com
       "./src/components/data-display/Icons/TelicentHorizontalSVG.tsx",
       "./src/components/data-display/Icons/TelicentMark.tsx",
       "./src/components/data-display/Icons/UserIcon.tsx",
+      "./src/components/data-display/Icons/WarningIcon.tsx",
       "./src/components/data-display/Icons/XIcon.tsx",
       "./src/components/data-display/IESType/IESType.tsx",
       "./src/components/data-display/List/List.tsx",


### PR DESCRIPTION
## Summary
- New `AppInfo` component (data-display) with `AppInfoRow` row primitive — icon-button + popover for AppBar end-slot metadata.
- New `ConfirmDialog` component (feedback) with `variant?: "destructive" | "warning"` (default neutral) — replaces app-side `ConfirmDeleteModal` copies.
- New `WarningIcon` used as the warning-variant default.
- New `StandardHeader` story on `AppBar` showing the full composition.

## Test plan
- [ ] Storybook `Data display / App info` renders all four stories
- [ ] Storybook `Feedback / Confirm dialog` renders all six stories
- [ ] `Surfaces / AppBar` has the new `StandardHeader` story
- [ ] `yarn test` passes
- [ ] `yarn tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)