### PR TITLE
chore(deps): add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      actions:
+        patterns: ["*"]


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` covering two ecosystems on a daily schedule, grouped to keep PR noise low:
- **npm** — minor + patch grouped into one PR; majors still open individually
- **github-actions** — grouped

No `docker` block — this repo doesn't ship a Dockerfile.

## Why daily
Fast patching + grouping keeps CVE exposure short without adding review churn. If we enable Dependabot auto-merge for passing CI later (part of the follow-up strategic work), daily is the right cadence.

## Notes
- Dependabot **alerts** (org/repo toggle) still need to be confirmed on by an org admin — separate follow-up

## Test plan
- [ ] CI passes on this branch
- [ ] After merge, verify a Dependabot PR opens within 24h — or trigger manually via Insights → Dependency graph → Dependabot

🤖 Generated with [Claude Code](https://claude.com/claude-code)