### PR TITLE
telicent-ds / MUI coverage SPIKE - size theming work for unexported components

### DIFF
--- a/specs/mui-coverage-spike/spec.md
+++ b/specs/mui-coverage-spike/spec.md
@@ -1,0 +1,137 @@
+# Spike: Storybook for unexported MUI components
+
+Show every MUI component the DS does not export, rendered stock and under the Telicent theme, so the FE team can size the work to bless each one for our theme, palette, and UX requirements.
+
+Output is an estimate, not a shipped feature. Nothing is exported and nothing is released.
+
+## Not in this spike
+
+No change to `src/export.ts`. The `mui` namespace stays at three keys.
+
+Stories import `@mui/material` directly. The eslint ban on `@mui/*` lives in consuming apps, not in this repo, so the spike needs no export to render anything. Deciding how these components eventually reach app authors is a separate decision that this spike exists to inform.
+
+## Counts
+
+Measured against `dist/export.d.ts` (228 names) and `node_modules/@mui/material` (133 component modules).
+
+| Bucket | Count | In the spike |
+| --- | --- | --- |
+| Name or capability the DS already owns | 33 | no |
+| Cannot be assessed visually | 26 | no |
+| Child of a parent | 39 | yes, inside the parent's page |
+| Standalone | 35 | yes, own page |
+
+74 components across 35 pages.
+
+## Pages
+
+- file: `src/mui/<Name>.stories.tsx`, title `MUI Coverage/<Name>`
+- stock story: `parameters: { stock: true }`, no DS provider
+- themed story `WithTelicentTheme`: identical markup inside `UIThemeProvider`
+- both follow the mode toolbar
+- a page shows the parent with its children in place, not each child alone
+- add a variant story only where it changes the assessment (`Slider` marks, `Table` dense)
+
+The difference between the two panels is what the theme already does. The gap between the themed panel and our UX requirements is the work being sized.
+
+### Stock
+
+`.storybook/preview.tsx` wraps every story in `UIThemeProvider`, which renders `<CssBaseline />` (`src/theme/UIThemeProvider.tsx:20`). The `MuiCssBaseline` override injects `FONT_FACES_CSS` and scrollbar rules into the document, and a nested `ThemeProvider` cannot retract CSS already in the page.
+
+So the decorator must not run for stock stories. `preview.tsx` reads `context.parameters.stock` and renders `<Story />` under `<ThemeProvider theme={createTheme({ palette: { mode } })}>` from `@mui/material/styles`, with no DS provider. Passing the toolbar mode keeps both panels in the same mode; mode is MUI's own knob, so the panel stays stock.
+
+Two limits:
+
+- **autodocs**: a page rendering both stories in one document lets the themed story's `CssBaseline` inject globals that reach the stock story. Disable autodocs for `src/mui/`; comparison happens by toggling stories
+- **`src/main.css`**: imported globally by `src/export.ts`, so its resets and fonts reach the stock panel
+
+### Portals
+
+`Backdrop`, `Menu`, `Popover`, `Popper`, `Snackbar`, `SpeedDial`, and `Tooltip` render into `document.body`, outside the story wrapper. Each needs `disablePortal` or an explicit `container`.
+
+`disablePortal` changes positioning and stacking against production, so those seven pages show theming, not layout.
+
+## What the theme already gives them
+
+`createThemePure` sets `palette`, `typography`, `breakpoints`, and `components`, so anything under `UIThemeProvider` gets Telicent colours and type without any work. That part is free and should not be estimated.
+
+What they lack is DS `styleOverrides`. `generateComponentOverrides` covers eleven keys: MuiAppBar, MuiAutocomplete, MuiAvatar, MuiButton, MuiCard, MuiCardActions, MuiCardContent, MuiCssBaseline, MuiIconButton, MuiMenuItem, MuiPaper.
+
+Two of those land in the 74:
+
+- **already overridden**: `Avatar` and `Menu`, via `MuiAvatar` and `MuiMenuItem`. If their panels look identical, the override is not reaching the component, which is a bug to raise
+- **themed only**: the other 72, carrying Telicent colour and type on MUI's radii, padding, elevation, and density. Widest gap on Badge, Breadcrumbs, Fab, Accordion, Stepper, Rating, SpeedDial
+- **nothing to override**: Grid, Collapse, Fade, Grow, Slide, Zoom, Popper, Backdrop. Layout and motion only, so zero design work
+
+## Assessment
+
+Each page carries a `docs.description.component` line naming what a reviewer should judge: palette fit, density, radii, focus and hover states, dark mode.
+
+The spike ends with one table, `specs/mui-coverage-spike/assessment.md`, one row per component:
+
+| Column | Values |
+| --- | --- |
+| Component | name |
+| Effort | none / small / medium / large |
+| Blocked on | palette token, UX decision, nothing |
+| Notes | what specifically is wrong under our theme |
+
+The FE team fills it from the Storybook. That table is the deliverable that answers "how much work".
+
+## Excluded
+
+**Owned by a DS component**:
+
+- `Stack`: `src/components/layout/FlexBox.tsx` wraps it
+- `Typography`: `H1`-`H6` own it
+
+**Renders nothing to judge**:
+`ClickAwayListener`, `Portal`, `NoSsr`, `Unstable_TrapFocus`
+
+**Global side-effects, would fight `UIThemeProvider`**:
+`CssBaseline`, `ScopedCssBaseline`, `GlobalStyles`, `StyledEngineProvider`, `DefaultPropsProvider`, `InitColorSchemeScript`
+
+**Superseded**:
+
+- `Hidden`: use `useMediaQuery`
+- `Unstable_Grid2`: use `Grid`
+- `Icon`, `SvgIcon`: use `@telicent-oss/mui-icons-material`
+- `TextareaAutosize`: use `TextField multiline`
+
+**Needs a parent to render**, so covered by the parent's page:
+`BottomNavigationAction`, `ImageListItemBar`, `ListItemSecondaryAction`, `PaginationItem`, `SnackbarContent`, `SpeedDialIcon`, `StepConnector`, `StepIcon`, `TabScrollButton`
+
+`Menu` stays in. `DropdownButton` is a composed control, not the raw menu primitive.
+
+## Standalone pages
+
+Accordion, Avatar, Backdrop, Badge, BottomNavigation, Breadcrumbs, ButtonBase, ButtonGroup, CircularProgress, Collapse, Fab, Fade, FormControl, Grid, Grow, ImageList, Input, Menu, Pagination, Popover, Popper, Radio, RadioGroup, Rating, Slide, Slider, Snackbar, SpeedDial, Stepper, SwipeableDrawer, Table, Tabs, ToggleButtonGroup, Tooltip, Zoom
+
+## Children shown inside a parent page
+
+| Parent | Children |
+| --- | --- |
+| Accordion | AccordionActions, AccordionDetails, AccordionSummary |
+| Alert | AlertTitle |
+| Avatar | AvatarGroup |
+| Card | CardActionArea, CardMedia |
+| Dialog | DialogContentText |
+| FormControl | FormControlLabel, FormGroup, FormHelperText, FormLabel |
+| ImageList | ImageListItem |
+| Input | FilledInput, InputAdornment, InputBase, InputLabel, NativeSelect, OutlinedInput |
+| List | ListItemAvatar, ListSubheader |
+| Menu | MenuItem, MenuList |
+| SpeedDial | SpeedDialAction |
+| Stepper | MobileStepper, Step, StepButton, StepContent, StepLabel |
+| Table | TableBody, TableCell, TableContainer, TableFooter, TableHead, TablePagination, TableRow, TableSortLabel |
+| Tabs | Tab |
+| ToggleButtonGroup | ToggleButton |
+
+`Alert`, `Card`, `Dialog`, and `List` are DS-owned names, so their children appear on a page named for the child group rather than the DS component.
+
+## Done when
+
+- `yarn build-storybook` passes and `MUI Coverage` lists 35 pages, each with a stock and a themed story
+- every page renders in light and dark with no console error
+- `Avatar` and `Menu` differ between panels, confirming their overrides reach them
+- `assessment.md` has a row per component with an effort value

--- a/src/mui/Accordion.stories.tsx
+++ b/src/mui/Accordion.stories.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  Accordion,
+  AccordionActions,
+  AccordionDetails,
+  AccordionSummary,
+  Button,
+  Stack,
+  Typography,
+} from "@mui/material";
+import { ExpandLess as ExpandLessIcon } from "@telicent-oss/mui-icons-material";
+
+const meta: Meta<typeof Accordion> = {
+  excludeStories: ["Markup"],
+  title: "MUI Coverage/Individual/Accordion",
+  component: Accordion,
+  tags: ["!autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: summary row density and divider weight, panel background against the page, radii on the first and last panel, expand-icon size and colour, action-row button alignment, dark mode. The expand icon is ExpandLess because that is the only expand-ish icon shipped; iconography is not what is being judged here.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Accordion>;
+
+export const Markup: React.FC = () => (
+  <Stack sx={{ width: 420 }}>
+    <Accordion defaultExpanded>
+      <AccordionSummary expandIcon={<ExpandLessIcon />}>
+        <Typography>First panel</Typography>
+      </AccordionSummary>
+      <AccordionDetails>
+        <Typography variant="body2">
+          Details content, rendered expanded so no interaction is needed.
+        </Typography>
+      </AccordionDetails>
+      <AccordionActions>
+        <Button size="small">Cancel</Button>
+        <Button size="small" variant="contained">
+          Save
+        </Button>
+      </AccordionActions>
+    </Accordion>
+    <Accordion defaultExpanded>
+      <AccordionSummary expandIcon={<ExpandLessIcon />}>
+        <Typography>Second panel</Typography>
+      </AccordionSummary>
+      <AccordionDetails>
+        <Typography variant="body2">
+          A second panel shows the divider between stacked accordions.
+        </Typography>
+      </AccordionDetails>
+    </Accordion>
+    <Accordion disabled>
+      <AccordionSummary expandIcon={<ExpandLessIcon />}>
+        <Typography>Disabled panel</Typography>
+      </AccordionSummary>
+      <AccordionDetails>
+        <Typography variant="body2">Never shown.</Typography>
+      </AccordionDetails>
+    </Accordion>
+  </Stack>
+);
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/AlertChildren.stories.tsx
+++ b/src/mui/AlertChildren.stories.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Alert, AlertTitle, Stack } from "@mui/material";
+
+const meta: Meta<typeof AlertTitle> = {
+  title: "MUI Coverage/Individual/Alert children",
+  excludeStories: ["Markup"],
+  component: AlertTitle,
+  tags: ["!autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Assesses AlertTitle inside an Alert. Judge: title weight and size against body text, spacing, severity palette fit, dark mode.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof AlertTitle>;
+
+export const Markup: React.FC = () => (
+  <Stack spacing={2}>
+    <Alert severity="error">
+      <AlertTitle>Error</AlertTitle>
+      The ingest pipeline rejected 12 records.
+    </Alert>
+    <Alert severity="warning">
+      <AlertTitle>Warning</AlertTitle>
+      Some fields could not be mapped to the ontology.
+    </Alert>
+    <Alert severity="info">
+      <AlertTitle>Info</AlertTitle>
+      A new index build starts in ten minutes.
+    </Alert>
+    <Alert severity="success">
+      <AlertTitle>Success</AlertTitle>
+      All 4,120 records were indexed.
+    </Alert>
+  </Stack>
+);
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/Avatar.stories.tsx
+++ b/src/mui/Avatar.stories.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Avatar, AvatarGroup, Stack } from "@mui/material";
+import { LocationOn as LocationOnIcon } from "@telicent-oss/mui-icons-material";
+
+const meta: Meta<typeof Avatar> = {
+  title: "MUI Coverage/Individual/Avatar",
+  excludeStories: ["Markup"],
+  component: Avatar,
+  tags: ["!autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: default background colour and letter contrast, size steps, circular vs rounded shape, AvatarGroup overlap and surplus (+n) chip, dark mode. The design system already ships a MuiAvatar styleOverrides entry, so this one is partly designed already.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Avatar>;
+
+export const Markup: React.FC = () => (
+  <Stack spacing={3}>
+    <Stack direction="row" spacing={2} alignItems="center">
+      <Avatar sx={{ width: 24, height: 24 }}>A</Avatar>
+      <Avatar>B</Avatar>
+      <Avatar sx={{ width: 56, height: 56 }}>C</Avatar>
+    </Stack>
+    <Stack direction="row" spacing={2} alignItems="center">
+      <Avatar />
+      <Avatar variant="rounded">R</Avatar>
+      <Avatar variant="square">S</Avatar>
+      <Avatar>
+        <LocationOnIcon />
+      </Avatar>
+    </Stack>
+    <AvatarGroup max={4}>
+      <Avatar>A</Avatar>
+      <Avatar>B</Avatar>
+      <Avatar>C</Avatar>
+      <Avatar>D</Avatar>
+      <Avatar>E</Avatar>
+      <Avatar>F</Avatar>
+    </AvatarGroup>
+  </Stack>
+);
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/Backdrop.stories.tsx
+++ b/src/mui/Backdrop.stories.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Backdrop, Box, CircularProgress, Typography } from "@mui/material";
+
+const meta: Meta<typeof Backdrop> = {
+  excludeStories: ["Markup"],
+  title: "MUI Coverage/Individual/Backdrop",
+  component: Backdrop,
+  tags: ["!autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: scrim colour and opacity over the surface beneath, contrast of content on top, dark mode. Shows theming, not production positioning or stacking.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Backdrop>;
+
+export const Markup: React.FC = () => (
+  <Box sx={{ position: "relative", height: 200, p: 2, bgcolor: "background.paper" }}>
+    <Typography>Content behind the backdrop</Typography>
+    <Backdrop open sx={{ position: "absolute", color: "common.white", zIndex: 1 }}>
+      <CircularProgress color="inherit" />
+    </Backdrop>
+  </Box>
+);
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/Badge.stories.tsx
+++ b/src/mui/Badge.stories.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Badge, Stack } from "@mui/material";
+import { LocationOn as LocationOnIcon } from "@telicent-oss/mui-icons-material";
+
+const meta: Meta<typeof Badge> = {
+  title: "MUI Coverage/Individual/Badge",
+  excludeStories: ["Markup"],
+  component: Badge,
+  tags: ["!autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: badge fill colour against the palette, contrast of the count text, dot size and offset, dark mode.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Badge>;
+
+export const Markup: React.FC = () => (
+  <Stack direction="row" spacing={4}>
+    <Badge badgeContent={4} color="primary"><LocationOnIcon /></Badge>
+    <Badge badgeContent={100} max={99} color="secondary"><LocationOnIcon /></Badge>
+    <Badge variant="dot" color="error"><LocationOnIcon /></Badge>
+  </Stack>
+);
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/BottomNavigation.stories.tsx
+++ b/src/mui/BottomNavigation.stories.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { BottomNavigation, BottomNavigationAction, Paper, Stack } from "@mui/material";
+import { Check, List, LocationOn } from "@telicent-oss/mui-icons-material";
+
+const meta: Meta<typeof BottomNavigation> = {
+  title: "MUI Coverage/Individual/BottomNavigation",
+  component: BottomNavigation,
+  tags: ["!autodocs", "!dev"],
+  excludeStories: ["Markup"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: selected vs unselected action colour, icon and label sizing, bar height and background, hover and focus states, dark mode.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof BottomNavigation>;
+
+export const Markup: React.FC = () => (
+  <Stack spacing={4} sx={{ width: 480 }}>
+    <Paper elevation={3}>
+      <BottomNavigation value={1} showLabels>
+        <BottomNavigationAction label="Nearby" icon={<LocationOn />} />
+        <BottomNavigationAction label="Records" icon={<List />} />
+        <BottomNavigationAction label="Approved" icon={<Check />} />
+      </BottomNavigation>
+    </Paper>
+    <Paper elevation={3}>
+      <BottomNavigation value={0}>
+        <BottomNavigationAction label="Nearby" icon={<LocationOn />} />
+        <BottomNavigationAction label="Records" icon={<List />} />
+        <BottomNavigationAction label="Approved" icon={<Check />} disabled />
+      </BottomNavigation>
+    </Paper>
+  </Stack>
+);
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/Breadcrumbs.stories.tsx
+++ b/src/mui/Breadcrumbs.stories.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Breadcrumbs, Link, Stack, Typography } from "@mui/material";
+import { ChevronRight } from "@telicent-oss/mui-icons-material";
+
+const meta: Meta<typeof Breadcrumbs> = {
+  title: "MUI Coverage/Individual/Breadcrumbs",
+  component: Breadcrumbs,
+  tags: ["!autodocs"],
+  excludeStories: ["Markup"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: link colour and underline, separator icon size and alignment, current-page emphasis, collapsed-ellipsis treatment, focus and hover states, dark mode.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Breadcrumbs>;
+
+export const Markup: React.FC = () => (
+  <Stack spacing={4}>
+    <Breadcrumbs separator={<ChevronRight fontSize="small" />}>
+      <Link href="#" underline="hover" color="inherit">
+        Home
+      </Link>
+      <Link href="#" underline="hover" color="inherit">
+        Datasets
+      </Link>
+      <Link href="#" underline="hover" color="inherit">
+        Vessels
+      </Link>
+      <Typography color="text.primary">Manifest</Typography>
+    </Breadcrumbs>
+    <Breadcrumbs separator={<ChevronRight fontSize="small" />} maxItems={2}>
+      <Link href="#" underline="hover" color="inherit">
+        Home
+      </Link>
+      <Link href="#" underline="hover" color="inherit">
+        Datasets
+      </Link>
+      <Link href="#" underline="hover" color="inherit">
+        Vessels
+      </Link>
+      <Typography color="text.primary">Manifest</Typography>
+    </Breadcrumbs>
+  </Stack>
+);
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/ButtonBase.stories.tsx
+++ b/src/mui/ButtonBase.stories.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ButtonBase, Stack, Typography } from "@mui/material";
+
+const meta: Meta<typeof ButtonBase> = {
+  title: "MUI Coverage/Individual/ButtonBase",
+  component: ButtonBase,
+  tags: ["!autodocs"],
+  excludeStories: ["Markup"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: focus ring visibility and ripple colour only. ButtonBase carries almost no design of its own — no fill, border, radius or typography — so expect near-zero work beyond focus and ripple treatment.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ButtonBase>;
+
+export const Markup: React.FC = () => (
+  <Stack direction="row" spacing={3} alignItems="center">
+    <ButtonBase sx={{ p: 1.5, borderRadius: 1 }}>
+      <Typography variant="body2">With ripple</Typography>
+    </ButtonBase>
+    <ButtonBase disableRipple sx={{ p: 1.5, borderRadius: 1 }}>
+      <Typography variant="body2">No ripple</Typography>
+    </ButtonBase>
+    <ButtonBase disabled sx={{ p: 1.5, borderRadius: 1 }}>
+      <Typography variant="body2">Disabled</Typography>
+    </ButtonBase>
+  </Stack>
+);
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/ButtonGroup.stories.tsx
+++ b/src/mui/ButtonGroup.stories.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Button, ButtonGroup, Stack } from "@mui/material";
+
+const meta: Meta<typeof ButtonGroup> = {
+  title: "MUI Coverage/Individual/ButtonGroup",
+  component: ButtonGroup,
+  tags: ["!autodocs"],
+  excludeStories: ["Markup"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: the shared divider between grouped buttons, outer radii on the first and last button, whether themed Button overrides survive grouping, size steps, vertical orientation, hover and focus states, dark mode.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ButtonGroup>;
+
+export const Markup: React.FC = () => (
+  <Stack spacing={3} alignItems="flex-start">
+    <ButtonGroup variant="contained">
+      <Button>One</Button>
+      <Button>Two</Button>
+      <Button>Three</Button>
+    </ButtonGroup>
+    <ButtonGroup variant="outlined">
+      <Button>One</Button>
+      <Button>Two</Button>
+      <Button>Three</Button>
+    </ButtonGroup>
+    <ButtonGroup variant="text">
+      <Button>One</Button>
+      <Button>Two</Button>
+      <Button>Three</Button>
+    </ButtonGroup>
+    <Stack direction="row" spacing={2} alignItems="center">
+      <ButtonGroup size="small" variant="contained">
+        <Button>S</Button>
+        <Button>S</Button>
+      </ButtonGroup>
+      <ButtonGroup size="medium" variant="contained">
+        <Button>M</Button>
+        <Button>M</Button>
+      </ButtonGroup>
+      <ButtonGroup size="large" variant="contained">
+        <Button>L</Button>
+        <Button>L</Button>
+      </ButtonGroup>
+    </Stack>
+    <ButtonGroup orientation="vertical" variant="outlined">
+      <Button>Top</Button>
+      <Button>Middle</Button>
+      <Button>Bottom</Button>
+    </ButtonGroup>
+  </Stack>
+);
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/CardChildren.stories.tsx
+++ b/src/mui/CardChildren.stories.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  Card,
+  CardActionArea,
+  CardContent,
+  CardMedia,
+  Stack,
+  Typography,
+} from "@mui/material";
+
+const meta: Meta<typeof CardActionArea> = {
+  excludeStories: ["Markup"],
+  title: "MUI Coverage/Individual/Card children",
+  component: CardActionArea,
+  tags: ["!autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Assesses CardActionArea and CardMedia inside a Card. Judge: hover and focus overlay on the action area, media block radii and cropping, spacing against card padding, dark mode.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof CardActionArea>;
+
+export const Markup: React.FC = () => (
+  <Stack direction="row" spacing={2}>
+    <Card sx={{ width: 260 }}>
+      <CardActionArea>
+        <CardMedia component="div" sx={{ height: 120, bgcolor: "primary.main" }} />
+        <CardContent>
+          <Typography variant="h6">Action area with media</Typography>
+          <Typography variant="body2">The whole card is one target.</Typography>
+        </CardContent>
+      </CardActionArea>
+    </Card>
+    <Card sx={{ width: 260 }}>
+      <CardMedia component="div" sx={{ height: 120, bgcolor: "secondary.main" }} />
+      <CardContent>
+        <Typography variant="h6">Media only</Typography>
+        <Typography variant="body2">No action area, for comparison.</Typography>
+      </CardContent>
+    </Card>
+  </Stack>
+);
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/CircularProgress.stories.tsx
+++ b/src/mui/CircularProgress.stories.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { CircularProgress, Stack } from "@mui/material";
+
+const meta: Meta<typeof CircularProgress> = {
+  title: "MUI Coverage/Individual/CircularProgress",
+  excludeStories: ["Markup"],
+  component: CircularProgress,
+  tags: ["!autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: track colour against the palette, stroke weight at each size, whether the spinner reads on both light and dark surfaces, and whether determinate and indeterminate share one visual language.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof CircularProgress>;
+
+export const Markup: React.FC = () => (
+  <Stack spacing={3}>
+    <Stack direction="row" spacing={3} alignItems="center">
+      <CircularProgress size={20} />
+      <CircularProgress size={40} />
+      <CircularProgress size={64} />
+      <CircularProgress size={40} thickness={6} />
+    </Stack>
+    <Stack direction="row" spacing={3} alignItems="center">
+      <CircularProgress color="primary" />
+      <CircularProgress color="secondary" />
+      <CircularProgress color="error" />
+      <CircularProgress color="success" />
+      <CircularProgress color="inherit" />
+    </Stack>
+    <Stack direction="row" spacing={3} alignItems="center">
+      <CircularProgress variant="determinate" value={25} />
+      <CircularProgress variant="determinate" value={50} color="secondary" />
+      <CircularProgress variant="determinate" value={75} size={64} />
+      <CircularProgress variant="determinate" value={100} color="success" />
+    </Stack>
+  </Stack>
+);
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/Collapse.stories.tsx
+++ b/src/mui/Collapse.stories.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import useCycle from "./useCycle";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Box, Collapse, Paper, Typography } from "@mui/material";
+
+const meta: Meta<typeof Collapse> = {
+  title: "MUI Coverage/Individual/Collapse",
+  excludeStories: ["Markup"],
+  component: Collapse,
+  tags: ["!autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: duration and easing only. Collapse carries no visual design of its own — all visible design belongs to the Paper inside it — but the theme owns transitions.duration and transitions.easing, so the timing is themeable. The story loops so the motion is visible.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Collapse>;
+
+export const Markup: React.FC = () => {
+  const on = useCycle();
+
+  return (
+  <Box sx={{ width: 320, height: 160 }}>
+    <Collapse in={on}>
+      <Paper sx={{ p: 2, height: 160 }}>
+        <Typography variant="h6">Collapse</Typography>
+        <Typography variant="body2">
+          Rendered with `in` set, so the transition is already complete and the
+          Paper is fully visible.
+        </Typography>
+      </Paper>
+    </Collapse>
+  </Box>
+  );
+};
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/DialogChildren.stories.tsx
+++ b/src/mui/DialogChildren.stories.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from "@mui/material";
+
+const meta: Meta<typeof DialogContentText> = {
+  excludeStories: ["Markup"],
+  title: "MUI Coverage/Individual/Dialog children",
+  component: DialogContentText,
+  tags: ["!autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Assesses DialogContentText inside a Dialog. Judge: body text colour and contrast against the dialog surface, line height, spacing to title and actions, dark mode. Shows theming, not production positioning or stacking.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof DialogContentText>;
+
+export const Markup: React.FC = () => (
+  <Box sx={{ position: "relative", height: 360 }}>
+    <Dialog
+      open
+      disablePortal
+      hideBackdrop
+      disableScrollLock
+      disableAutoFocus
+      disableEnforceFocus
+      sx={{ position: "absolute" }}
+      PaperProps={{ sx: { position: "absolute" } }}
+    >
+      <DialogTitle>Delete this dataset?</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          Deleting removes the dataset and every derived index. This cannot be undone.
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button>Cancel</Button>
+        <Button color="error">Delete</Button>
+      </DialogActions>
+    </Dialog>
+  </Box>
+);
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/Fab.stories.tsx
+++ b/src/mui/Fab.stories.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Fab, Stack } from "@mui/material";
+import { Add as AddIcon, Edit as EditIcon } from "@telicent-oss/mui-icons-material";
+
+const meta: Meta<typeof Fab> = {
+  title: "MUI Coverage/Individual/Fab",
+  component: Fab,
+  tags: ["!autodocs"],
+  excludeStories: ["Markup"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: fill colours against the palette, icon contrast, elevation/shadow weight, size steps, the extended variant's label typography and padding, hover and focus states, dark mode.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Fab>;
+
+export const Markup: React.FC = () => (
+  <Stack spacing={3} alignItems="flex-start">
+    <Stack direction="row" spacing={2} alignItems="center">
+      <Fab size="small" color="primary">
+        <AddIcon />
+      </Fab>
+      <Fab size="medium" color="primary">
+        <AddIcon />
+      </Fab>
+      <Fab size="large" color="primary">
+        <AddIcon />
+      </Fab>
+    </Stack>
+    <Stack direction="row" spacing={2} alignItems="center">
+      <Fab color="secondary">
+        <EditIcon />
+      </Fab>
+      <Fab color="default">
+        <EditIcon />
+      </Fab>
+      <Fab disabled>
+        <EditIcon />
+      </Fab>
+    </Stack>
+    <Stack direction="row" spacing={2} alignItems="center">
+      <Fab variant="extended" color="primary">
+        <AddIcon sx={{ mr: 1 }} />
+        Create
+      </Fab>
+      <Fab variant="extended">
+        <EditIcon sx={{ mr: 1 }} />
+        Edit
+      </Fab>
+    </Stack>
+  </Stack>
+);
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/Fade.stories.tsx
+++ b/src/mui/Fade.stories.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import useCycle from "./useCycle";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Box, Fade, Paper, Typography } from "@mui/material";
+
+const meta: Meta<typeof Fade> = {
+  title: "MUI Coverage/Individual/Fade",
+  excludeStories: ["Markup"],
+  component: Fade,
+  tags: ["!autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: duration and easing only. Fade carries no visual design of its own — all visible design belongs to the Paper inside it — but the theme owns transitions.duration and transitions.easing, so the timing is themeable. The story loops so the motion is visible.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Fade>;
+
+export const Markup: React.FC = () => {
+  const on = useCycle();
+
+  return (
+  <Box sx={{ width: 320, height: 160 }}>
+    <Fade in={on}>
+      <Paper sx={{ p: 2, height: 160 }}>
+        <Typography variant="h6">Fade</Typography>
+        <Typography variant="body2">
+          Rendered with `in` set, so the transition is already complete and the
+          Paper is fully visible.
+        </Typography>
+      </Paper>
+    </Fade>
+  </Box>
+  );
+};
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/FormControl.stories.tsx
+++ b/src/mui/FormControl.stories.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  Checkbox,
+  FormControl,
+  FormControlLabel,
+  FormGroup,
+  FormHelperText,
+  FormLabel,
+  MenuItem,
+  Select,
+  Stack,
+  Switch,
+} from "@mui/material";
+
+const meta: Meta<typeof FormControl> = {
+  title: "MUI Coverage/Individual/FormControl",
+  component: FormControl,
+  tags: ["!autodocs"],
+  excludeStories: ["Markup"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: label and helper-text typography, vertical rhythm between grouped controls, error colour and its contrast, disabled dimming, focus ring on the control, dark mode.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof FormControl>;
+
+export const Markup: React.FC = () => (
+  <Stack direction="row" spacing={4} alignItems="flex-start">
+    <FormControl component="fieldset">
+      <FormLabel component="legend">Notifications</FormLabel>
+      <FormGroup>
+        <FormControlLabel control={<Checkbox defaultChecked />} label="Email" />
+        <FormControlLabel control={<Checkbox />} label="SMS" />
+        <FormControlLabel control={<Switch defaultChecked />} label="Digest" />
+      </FormGroup>
+      <FormHelperText>Choose how you are contacted.</FormHelperText>
+    </FormControl>
+
+    <FormControl component="fieldset" disabled>
+      <FormLabel component="legend">Disabled</FormLabel>
+      <FormGroup>
+        <FormControlLabel control={<Checkbox defaultChecked />} label="Email" />
+        <FormControlLabel control={<Checkbox />} label="SMS" />
+      </FormGroup>
+      <FormHelperText>Unavailable on this plan.</FormHelperText>
+    </FormControl>
+
+    <FormControl error sx={{ minWidth: 180 }}>
+      <FormLabel>Region</FormLabel>
+      <Select defaultValue="" displayEmpty>
+        <MenuItem value="">Select a region</MenuItem>
+        <MenuItem value="uk">United Kingdom</MenuItem>
+        <MenuItem value="us">United States</MenuItem>
+      </Select>
+      <FormHelperText>A region is required.</FormHelperText>
+    </FormControl>
+  </Stack>
+);
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/Grid.stories.tsx
+++ b/src/mui/Grid.stories.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Grid, Paper, Typography } from "@mui/material";
+
+const meta: Meta<typeof Grid> = {
+  title: "MUI Coverage/Individual/Grid",
+  component: Grid,
+  tags: ["!autodocs"],
+  excludeStories: ["Markup"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: gutter width against the DS spacing scale, and whether the Paper cells read as a coherent density. Grid itself contributes no colour or typography.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Grid>;
+
+const Cell: React.FC<{ label: string }> = ({ label }) => (
+  <Paper sx={{ p: 2 }}>
+    <Typography variant="body2">{label}</Typography>
+  </Paper>
+);
+
+export const Markup: React.FC = () => (
+  <Grid container spacing={2} sx={{ width: 640 }}>
+    <Grid item xs={12}>
+      <Cell label="xs=12 — full-width header" />
+    </Grid>
+    <Grid item xs={12} md={8}>
+      <Cell label="xs=12 md=8 — main" />
+    </Grid>
+    <Grid item xs={12} md={4}>
+      <Cell label="xs=12 md=4 — sidebar" />
+    </Grid>
+    <Grid item xs={6} md={3}>
+      <Cell label="xs=6 md=3" />
+    </Grid>
+    <Grid item xs={6} md={3}>
+      <Cell label="xs=6 md=3" />
+    </Grid>
+    <Grid item xs={6} md={3}>
+      <Cell label="xs=6 md=3" />
+    </Grid>
+    <Grid item xs={6} md={3}>
+      <Cell label="xs=6 md=3" />
+    </Grid>
+  </Grid>
+);
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/Grow.stories.tsx
+++ b/src/mui/Grow.stories.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import useCycle from "./useCycle";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Box, Grow, Paper, Typography } from "@mui/material";
+
+const meta: Meta<typeof Grow> = {
+  title: "MUI Coverage/Individual/Grow",
+  excludeStories: ["Markup"],
+  component: Grow,
+  tags: ["!autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: duration and easing only. Grow carries no visual design of its own — all visible design belongs to the Paper inside it — but the theme owns transitions.duration and transitions.easing, so the timing is themeable. The story loops so the motion is visible.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Grow>;
+
+export const Markup: React.FC = () => {
+  const on = useCycle();
+
+  return (
+  <Box sx={{ width: 320, height: 160 }}>
+    <Grow in={on}>
+      <Paper sx={{ p: 2, height: 160 }}>
+        <Typography variant="h6">Grow</Typography>
+        <Typography variant="body2">
+          Rendered with `in` set, so the transition is already complete and the
+          Paper is fully visible.
+        </Typography>
+      </Paper>
+    </Grow>
+  </Box>
+  );
+};
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/ImageList.stories.tsx
+++ b/src/mui/ImageList.stories.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  IconButton,
+  ImageList,
+  ImageListItem,
+  ImageListItemBar,
+} from "@mui/material";
+import { Edit } from "@telicent-oss/mui-icons-material";
+
+const meta: Meta<typeof ImageList> = {
+  excludeStories: ["Markup"],
+  title: "MUI Coverage/Individual/ImageList",
+  component: ImageList,
+  tags: ["!autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: the ImageListItemBar scrim and its title/subtitle typography, action-icon contrast over the tile, gap against the DS spacing scale, dark mode. Tiles are flat colour blocks, not photos, so only the chrome is under review.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ImageList>;
+
+const tiles: ReadonlyArray<{ title: string; author: string; colour: string }> = [
+  { title: "Ingest", author: "Platform", colour: "#4a5568" },
+  { title: "Catalogue", author: "Data", colour: "#2c5282" },
+  { title: "Graph", author: "Analytics", colour: "#285e61" },
+  { title: "Search", author: "Discovery", colour: "#553c9a" },
+  { title: "Access", author: "Security", colour: "#742a2a" },
+  { title: "Audit", author: "Compliance", colour: "#744210" },
+];
+
+export const Markup: React.FC = () => (
+  <ImageList sx={{ width: 500, height: 340 }} cols={3} rowHeight={160}>
+    {tiles.map((tile) => (
+      <ImageListItem key={tile.title}>
+        <div
+          style={{ backgroundColor: tile.colour, width: "100%", height: "100%" }}
+        />
+        <ImageListItemBar
+          title={tile.title}
+          subtitle={<span>by {tile.author}</span>}
+          actionIcon={
+            <IconButton
+              sx={{ color: "rgba(255, 255, 255, 0.54)" }}
+              aria-label={`edit ${tile.title}`}
+            >
+              <Edit />
+            </IconButton>
+          }
+        />
+      </ImageListItem>
+    ))}
+  </ImageList>
+);
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/Input.stories.tsx
+++ b/src/mui/Input.stories.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  FilledInput,
+  FormControl,
+  Input,
+  InputAdornment,
+  InputBase,
+  InputLabel,
+  NativeSelect,
+  OutlinedInput,
+  Stack,
+} from "@mui/material";
+import { LocationOn as LocationOnIcon } from "@telicent-oss/mui-icons-material";
+
+const meta: Meta<typeof Input> = {
+  title: "MUI Coverage/Individual/Input",
+  component: Input,
+  tags: ["!autodocs"],
+  excludeStories: ["Markup"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: field height and density across the three variants, border and underline colour, radii, label float position, adornment alignment, error and disabled states, focus ring, dark mode.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Input>;
+
+export const Markup: React.FC = () => (
+  <Stack spacing={4}>
+    <Stack direction="row" spacing={4} alignItems="flex-start">
+      <FormControl variant="standard">
+        <InputLabel htmlFor="std-input">Standard</InputLabel>
+        <Input id="std-input" defaultValue="Underlined" />
+      </FormControl>
+
+      <FormControl variant="filled">
+        <InputLabel htmlFor="filled-input">Filled</InputLabel>
+        <FilledInput id="filled-input" defaultValue="Filled" />
+      </FormControl>
+
+      <FormControl variant="outlined">
+        <InputLabel htmlFor="outlined-input">Outlined</InputLabel>
+        <OutlinedInput id="outlined-input" label="Outlined" defaultValue="Outlined" />
+      </FormControl>
+    </Stack>
+
+    <Stack direction="row" spacing={4} alignItems="flex-start">
+      <FormControl variant="outlined" error>
+        <InputLabel htmlFor="error-input">Error</InputLabel>
+        <OutlinedInput id="error-input" label="Error" defaultValue="Bad value" />
+      </FormControl>
+
+      <FormControl variant="outlined" disabled>
+        <InputLabel htmlFor="disabled-input">Disabled</InputLabel>
+        <OutlinedInput id="disabled-input" label="Disabled" defaultValue="Locked" />
+      </FormControl>
+
+      <FormControl variant="outlined">
+        <InputLabel htmlFor="adornment-input">Adornments</InputLabel>
+        <OutlinedInput
+          id="adornment-input"
+          label="Adornments"
+          defaultValue="London"
+          startAdornment={
+            <InputAdornment position="start">
+              <LocationOnIcon />
+            </InputAdornment>
+          }
+          endAdornment={<InputAdornment position="end">km</InputAdornment>}
+        />
+      </FormControl>
+    </Stack>
+
+    <Stack direction="row" spacing={4} alignItems="center">
+      <InputBase
+        defaultValue="Unstyled InputBase"
+        sx={{ border: "1px solid", borderColor: "divider", px: 1, py: 0.5, borderRadius: 1 }}
+      />
+
+      <FormControl>
+        <InputLabel variant="standard" htmlFor="native-select">
+          Region
+        </InputLabel>
+        <NativeSelect defaultValue="uk" inputProps={{ name: "region", id: "native-select" }}>
+          <option value="uk">United Kingdom</option>
+          <option value="us">United States</option>
+        </NativeSelect>
+      </FormControl>
+    </Stack>
+  </Stack>
+);
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/KitchenSink.stories.tsx
+++ b/src/mui/KitchenSink.stories.tsx
@@ -1,0 +1,180 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Box, Divider, Link, Stack, Typography } from "@mui/material";
+
+import { Markup as AccordionMarkup } from "./Accordion.stories";
+import { Markup as AlertChildrenMarkup } from "./AlertChildren.stories";
+import { Markup as AvatarMarkup } from "./Avatar.stories";
+import { Markup as BackdropMarkup } from "./Backdrop.stories";
+import { Markup as BadgeMarkup } from "./Badge.stories";
+import { Markup as BreadcrumbsMarkup } from "./Breadcrumbs.stories";
+import { Markup as ButtonBaseMarkup } from "./ButtonBase.stories";
+import { Markup as ButtonGroupMarkup } from "./ButtonGroup.stories";
+import { Markup as CardChildrenMarkup } from "./CardChildren.stories";
+import { Markup as CircularProgressMarkup } from "./CircularProgress.stories";
+import { Markup as CollapseMarkup } from "./Collapse.stories";
+import { Markup as DialogChildrenMarkup } from "./DialogChildren.stories";
+import { Markup as FabMarkup } from "./Fab.stories";
+import { Markup as FadeMarkup } from "./Fade.stories";
+import { Markup as FormControlMarkup } from "./FormControl.stories";
+import { Markup as GridMarkup } from "./Grid.stories";
+import { Markup as GrowMarkup } from "./Grow.stories";
+import { Markup as ImageListMarkup } from "./ImageList.stories";
+import { Markup as InputMarkup } from "./Input.stories";
+import { Markup as ListChildrenMarkup } from "./ListChildren.stories";
+import { Markup as MenuMarkup } from "./Menu.stories";
+import { Markup as PaginationMarkup } from "./Pagination.stories";
+import { Markup as PopoverMarkup } from "./Popover.stories";
+import { Markup as PopperMarkup } from "./Popper.stories";
+import { Markup as SlideMarkup } from "./Slide.stories";
+import { Markup as SliderMarkup } from "./Slider.stories";
+import { Markup as SnackbarMarkup } from "./Snackbar.stories";
+import { Markup as SpeedDialMarkup } from "./SpeedDial.stories";
+import { Markup as StepperMarkup } from "./Stepper.stories";
+import { Markup as TableMarkup } from "./Table.stories";
+import { Markup as TabsMarkup } from "./Tabs.stories";
+import { Markup as ToggleButtonGroupMarkup } from "./ToggleButtonGroup.stories";
+import { Markup as TooltipMarkup } from "./Tooltip.stories";
+import { Markup as ZoomMarkup } from "./Zoom.stories";
+
+type Entry = { name: string; Markup: React.FC };
+type Group = { title: string; entries: Entry[] };
+
+const groups: Group[] = [
+  {
+    title: "Inputs & forms",
+    entries: [
+      { name: "ButtonBase", Markup: ButtonBaseMarkup },
+      { name: "ButtonGroup", Markup: ButtonGroupMarkup },
+      { name: "Fab", Markup: FabMarkup },
+      { name: "FormControl", Markup: FormControlMarkup },
+      { name: "Input", Markup: InputMarkup },
+      { name: "Slider", Markup: SliderMarkup },
+      { name: "ToggleButtonGroup", Markup: ToggleButtonGroupMarkup },
+    ],
+  },
+  {
+    title: "Data display",
+    entries: [
+      { name: "Avatar", Markup: AvatarMarkup },
+      { name: "Badge", Markup: BadgeMarkup },
+      { name: "ImageList", Markup: ImageListMarkup },
+      { name: "List children", Markup: ListChildrenMarkup },
+      { name: "Table", Markup: TableMarkup },
+      { name: "Tooltip", Markup: TooltipMarkup },
+    ],
+  },
+  {
+    title: "Surfaces & overlays",
+    entries: [
+      { name: "Accordion", Markup: AccordionMarkup },
+      { name: "Card children", Markup: CardChildrenMarkup },
+      { name: "Dialog children", Markup: DialogChildrenMarkup },
+      { name: "Menu", Markup: MenuMarkup },
+      { name: "Popover", Markup: PopoverMarkup },
+      { name: "Popper", Markup: PopperMarkup },
+      { name: "SpeedDial", Markup: SpeedDialMarkup },
+    ],
+  },
+  {
+    title: "Navigation",
+    entries: [
+      { name: "Breadcrumbs", Markup: BreadcrumbsMarkup },
+      { name: "Pagination", Markup: PaginationMarkup },
+      { name: "Stepper", Markup: StepperMarkup },
+      { name: "Tabs", Markup: TabsMarkup },
+    ],
+  },
+  {
+    title: "Feedback",
+    entries: [
+      { name: "Alert children", Markup: AlertChildrenMarkup },
+      { name: "Backdrop", Markup: BackdropMarkup },
+      { name: "CircularProgress", Markup: CircularProgressMarkup },
+      { name: "Snackbar", Markup: SnackbarMarkup },
+    ],
+  },
+  {
+    title: "Motion",
+    entries: [
+      { name: "Collapse", Markup: CollapseMarkup },
+      { name: "Fade", Markup: FadeMarkup },
+      { name: "Grow", Markup: GrowMarkup },
+      { name: "Slide", Markup: SlideMarkup },
+      { name: "Zoom", Markup: ZoomMarkup },
+    ],
+  },
+  {
+    title: "Layout",
+    entries: [{ name: "Grid", Markup: GridMarkup }],
+  },
+];
+
+const componentCount = groups.reduce((n, group) => n + group.entries.length, 0);
+
+const anchorId = (name: string): string =>
+  `kitchen-sink-${name.toLowerCase().replace(/\s+/g, "-")}`;
+
+const Section: React.FC<Entry> = ({ name, Markup }) => (
+  <Box component="section" id={anchorId(name)} sx={{ py: 3 }}>
+    <Typography variant="h6" component="h3" gutterBottom>
+      {name}
+    </Typography>
+    <Markup />
+    <Divider sx={{ mt: 3 }} />
+  </Box>
+);
+
+const KitchenSink: React.FC = () => (
+  <Box>
+    <Typography variant="h4" component="h1" gutterBottom>
+      MUI kitchen sink — {componentCount} components
+    </Typography>
+    <Typography variant="body2" sx={{ mb: 2 }}>
+      Every unexported MUI component under the Telicent theme, on one page. Use
+      the Mode and Theme toolbars; scroll, or jump via the links below.
+    </Typography>
+    <Stack direction="row" flexWrap="wrap" useFlexGap sx={{ gap: 1.5, mb: 2 }}>
+      {groups
+        .flatMap((group) => group.entries)
+        .map(({ name }) => (
+          <Link key={name} href={`#${anchorId(name)}`} variant="body2">
+            {name}
+          </Link>
+        ))}
+    </Stack>
+    {groups.map((group) => (
+      <Box key={group.title} component="section">
+        <Typography variant="h5" component="h2" sx={{ mt: 5, mb: 1 }}>
+          {group.title} ({group.entries.length})
+        </Typography>
+        <Divider sx={{ mb: 1, borderBottomWidth: 2 }} />
+        {group.entries.map((entry) => (
+          <Section key={entry.name} {...entry} />
+        ))}
+      </Box>
+    ))}
+  </Box>
+);
+
+const meta: Meta<typeof KitchenSink> = {
+  title: "MUI Coverage/Proposed included",
+  component: KitchenSink,
+  tags: ["!autodocs"],
+  parameters: {
+    a11y: {
+      options: {
+        rules: {
+          // Each Markup renders its own headings under this page's h1/h2/h3
+          // scaffold; heading-order is a per-page concern, not a component one.
+          "heading-order": { enabled: false },
+        },
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof KitchenSink>;
+
+export const All: Story = { render: () => <KitchenSink /> };

--- a/src/mui/ListChildren.stories.tsx
+++ b/src/mui/ListChildren.stories.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  Avatar,
+  IconButton,
+  List,
+  ListItem,
+  ListItemAvatar,
+  ListItemSecondaryAction,
+  ListItemText,
+  ListSubheader,
+} from "@mui/material";
+import { Edit, LocationOn } from "@telicent-oss/mui-icons-material";
+
+const meta: Meta<typeof ListItemAvatar> = {
+  excludeStories: ["Markup"],
+  title: "MUI Coverage/Individual/List children",
+  component: ListItemAvatar,
+  tags: ["!autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Assesses ListItemAvatar, ListSubheader and ListItemSecondaryAction inside a List. Judge: subheader weight and background against the list surface, avatar size and alignment, secondary action spacing, row density, dark mode.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ListItemAvatar>;
+
+export const Markup: React.FC = () => (
+  <List sx={{ width: 360, bgcolor: "background.paper" }}>
+    <ListSubheader>Sites</ListSubheader>
+    <ListItem>
+      <ListItemAvatar>
+        <Avatar>
+          <LocationOn />
+        </Avatar>
+      </ListItemAvatar>
+      <ListItemText primary="Bristol depot" secondary="Updated 2 hours ago" />
+      <ListItemSecondaryAction>
+        <IconButton edge="end" aria-label="Edit Bristol depot">
+          <Edit />
+        </IconButton>
+      </ListItemSecondaryAction>
+    </ListItem>
+    <ListSubheader>People</ListSubheader>
+    <ListItem>
+      <ListItemAvatar>
+        <Avatar>AC</Avatar>
+      </ListItemAvatar>
+      <ListItemText primary="A Coolman" secondary="Analyst" />
+      <ListItemSecondaryAction>
+        <IconButton edge="end" aria-label="Edit A Coolman">
+          <Edit />
+        </IconButton>
+      </ListItemSecondaryAction>
+    </ListItem>
+  </List>
+);
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/Menu.stories.tsx
+++ b/src/mui/Menu.stories.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Box, Button, Divider, Menu, MenuItem, MenuList, Paper, Stack } from "@mui/material";
+
+const meta: Meta<typeof Menu> = {
+  excludeStories: ["Markup"],
+  title: "MUI Coverage/Individual/Menu",
+  component: Menu,
+  tags: ["!autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: menu surface colour and elevation, item typography, hover/selected/disabled states, divider colour, dark mode. Shows theming, not production positioning or stacking.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Menu>;
+
+export const Markup: React.FC = () => (
+  <Stack direction="row" spacing={4} alignItems="flex-start">
+    <Box sx={{ position: "relative", width: 260, height: 260 }}>
+      <Button>Anchor</Button>
+      <Menu
+        open
+        anchorReference="anchorPosition"
+        anchorPosition={{ top: 44, left: 0 }}
+        onClose={() => undefined}
+        disablePortal
+        hideBackdrop
+        disableScrollLock
+        disableAutoFocus
+        disableEnforceFocus
+        autoFocus={false}
+        sx={{ position: "absolute" }}
+      >
+        <MenuItem>Profile</MenuItem>
+        <MenuItem selected>My account</MenuItem>
+        <Divider />
+        <MenuItem disabled>Disabled entry</MenuItem>
+      </Menu>
+    </Box>
+    <Paper>
+      <MenuList>
+        <MenuItem>MenuList item</MenuItem>
+        <MenuItem selected>Selected item</MenuItem>
+        <MenuItem disabled>Disabled item</MenuItem>
+      </MenuList>
+    </Paper>
+  </Stack>
+);
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/NotIncluded.stories.tsx
+++ b/src/mui/NotIncluded.stories.tsx
@@ -1,0 +1,154 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  Box,
+  Divider,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
+
+type Row = { name: string; note: string };
+type Section = { title: string; blurb: string; rows: Row[] };
+
+const dsOwned = [
+  "Alert", "AppBar", "Autocomplete", "Box", "Button", "Card", "CardActions",
+  "CardContent", "CardHeader", "Checkbox", "Chip", "Container", "Dialog",
+  "DialogActions", "DialogContent", "DialogTitle", "Divider", "Drawer",
+  "IconButton", "LinearProgress", "Link", "List", "ListItem", "ListItemButton",
+  "ListItemIcon", "ListItemText", "Modal", "Paper", "Select", "Skeleton",
+  "Switch", "TextField", "Toolbar",
+];
+
+const sections: Section[] = [
+  {
+    title: "The design system already exports one",
+    blurb:
+      "Same name, already in @telicent-oss/ds. Use the design-system version; nothing to assess.",
+    rows: dsOwned.map((name) => ({ name, note: "use the DS component" })),
+  },
+  {
+    title: "A design-system component replaces it",
+    blurb: "Different name, same job.",
+    rows: [
+      { name: "Stack", note: "FlexBox wraps it" },
+      { name: "Typography", note: "H1 to H6" },
+      { name: "Icon, SvgIcon", note: "@telicent-oss/mui-icons-material" },
+    ],
+  },
+  {
+    title: "Dropped from the review",
+    blurb: "Deliberately out of this round.",
+    rows: [
+      { name: "Rating", note: "not wanted" },
+      { name: "Radio, RadioGroup", note: "not wanted" },
+      { name: "SwipeableDrawer", note: "not wanted" },
+      { name: "BottomNavigation", note: "not wanted" },
+    ],
+  },
+  {
+    title: "Injects global styles",
+    blurb:
+      "Each one writes styles into the document. A second route to that fights UIThemeProvider.",
+    rows: [
+      { name: "CssBaseline", note: "UIThemeProvider mounts it already" },
+      { name: "ScopedCssBaseline", note: "same, scoped" },
+      { name: "GlobalStyles", note: "global CSS injection" },
+      { name: "StyledEngineProvider", note: "emotion setup" },
+      { name: "DefaultPropsProvider", note: "prop defaults, theme's job" },
+      { name: "InitColorSchemeScript", note: "colour-scheme bootstrap" },
+    ],
+  },
+  {
+    title: "Renders nothing to look at",
+    blurb: "Behaviour wrappers with no visual output.",
+    rows: [
+      { name: "ClickAwayListener", note: "behaviour only" },
+      { name: "Portal", note: "behaviour only" },
+      { name: "NoSsr", note: "behaviour only" },
+      { name: "Unstable_TrapFocus", note: "behaviour only" },
+    ],
+  },
+  {
+    title: "Superseded by MUI",
+    blurb: "Deprecated or replaced in MUI itself.",
+    rows: [
+      { name: "Hidden", note: "use useMediaQuery" },
+      { name: "Unstable_Grid2", note: "use Grid" },
+      { name: "TextareaAutosize", note: "use TextField multiline" },
+    ],
+  },
+  {
+    title: "Needs its parent to render",
+    blurb: "Covered inside the parent's section of the kitchen sink.",
+    rows: [
+      { name: "BottomNavigationAction", note: "BottomNavigation" },
+      { name: "ImageListItemBar", note: "ImageList" },
+      { name: "ListItemSecondaryAction", note: "List children" },
+      { name: "PaginationItem", note: "Pagination" },
+      { name: "SnackbarContent", note: "Snackbar" },
+      { name: "SpeedDialIcon", note: "SpeedDial" },
+      { name: "StepConnector", note: "Stepper" },
+      { name: "StepIcon", note: "Stepper" },
+      { name: "TabScrollButton", note: "Tabs" },
+    ],
+  },
+];
+
+const total = sections.reduce((n, s) => n + s.rows.length, 0);
+
+const NotIncluded: React.FC = () => (
+  <Box>
+    <Typography variant="h4" component="h1" gutterBottom>
+      Not included — {total} components
+    </Typography>
+    <Typography variant="body2" sx={{ mb: 3 }}>
+      Everything MUI ships that the kitchen sink does not show, and why. Nothing
+      here needs assessing.
+    </Typography>
+    {sections.map((section) => (
+      <Box key={section.title} component="section" sx={{ mb: 4 }}>
+        <Typography variant="h6" component="h2">
+          {section.title} ({section.rows.length})
+        </Typography>
+        <Typography variant="body2" sx={{ mb: 1 }}>
+          {section.blurb}
+        </Typography>
+        <Divider sx={{ mb: 1 }} />
+        <TableContainer>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>MUI component</TableCell>
+                <TableCell>Instead</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {section.rows.map((row) => (
+                <TableRow key={row.name}>
+                  <TableCell>{row.name}</TableCell>
+                  <TableCell>{row.note}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Box>
+    ))}
+  </Box>
+);
+
+const meta: Meta<typeof NotIncluded> = {
+  title: "MUI Coverage/Proposed excluded",
+  component: NotIncluded,
+  tags: ["!autodocs"],
+};
+export default meta;
+
+type Story = StoryObj<typeof NotIncluded>;
+
+export const All: Story = { render: () => <NotIncluded /> };

--- a/src/mui/Pagination.stories.tsx
+++ b/src/mui/Pagination.stories.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Pagination, PaginationItem, Stack } from "@mui/material";
+import { ChevronLeft, ChevronRight } from "@telicent-oss/mui-icons-material";
+
+const meta: Meta<typeof Pagination> = {
+  title: "MUI Coverage/Individual/Pagination",
+  excludeStories: ["Markup"],
+  component: Pagination,
+  tags: ["!autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: selected page contrast, item radii across shapes, size scale, outlined vs text variants, disabled and hover states, dark mode.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Pagination>;
+
+export const Markup: React.FC = () => (
+  <Stack spacing={4} alignItems="flex-start">
+    <Pagination count={10} page={4} shape="rounded" />
+    <Pagination count={10} page={4} shape="circular" variant="outlined" color="primary" />
+    <Pagination count={5} page={2} size="small" />
+    <Pagination count={5} page={2} size="large" color="secondary" />
+    <Pagination
+      count={10}
+      page={4}
+      renderItem={(item) => (
+        <PaginationItem slots={{ previous: ChevronLeft, next: ChevronRight }} {...item} />
+      )}
+    />
+    <Pagination count={10} page={4} disabled />
+  </Stack>
+);
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/Popover.stories.tsx
+++ b/src/mui/Popover.stories.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Box, Button, Popover, Typography } from "@mui/material";
+
+const meta: Meta<typeof Popover> = {
+  excludeStories: ["Markup"],
+  title: "MUI Coverage/Individual/Popover",
+  component: Popover,
+  tags: ["!autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: popover surface colour, elevation and radius, content typography, dark mode. Shows theming, not production positioning or stacking.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Popover>;
+
+export const Markup: React.FC = () => (
+  <Box sx={{ position: "relative", width: 320, height: 220 }}>
+    <Button>Anchor</Button>
+    <Popover
+      open
+      anchorReference="anchorPosition"
+      anchorPosition={{ top: 44, left: 0 }}
+      onClose={() => undefined}
+      disablePortal
+      hideBackdrop
+      disableScrollLock
+      disableAutoFocus
+      disableEnforceFocus
+      sx={{ position: "absolute" }}
+    >
+      <Typography sx={{ p: 2 }}>Popover content on a themed surface.</Typography>
+    </Popover>
+  </Box>
+);
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/Popper.stories.tsx
+++ b/src/mui/Popper.stories.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Box, Button, Paper, Popper, Typography } from "@mui/material";
+
+const meta: Meta<typeof Popper> = {
+  excludeStories: ["Markup"],
+  title: "MUI Coverage/Individual/Popper",
+  component: Popper,
+  tags: ["!autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: the surface you place inside the popper — Paper colour, elevation, text contrast, dark mode. Popper itself is unstyled. Shows theming, not production positioning or stacking.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Popper>;
+
+export const Markup: React.FC = () => {
+  const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
+
+  return (
+    <Box sx={{ position: "relative", height: 200 }}>
+      <Button ref={setAnchorEl}>Anchor</Button>
+      <Popper open={anchorEl !== null} anchorEl={anchorEl} disablePortal placement="bottom-start">
+        <Paper sx={{ p: 2, mt: 1 }}>
+          <Typography>Popper content</Typography>
+        </Paper>
+      </Popper>
+    </Box>
+  );
+};
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/Radio.stories.tsx
+++ b/src/mui/Radio.stories.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Radio, Stack, Typography } from "@mui/material";
+
+const meta: Meta<typeof Radio> = {
+  title: "MUI Coverage/Individual/Radio",
+  component: Radio,
+  tags: ["!autodocs", "!dev"],
+  excludeStories: ["Markup"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: selected fill colour against the palette, ring weight and dot size, hit area and hover ripple tint, size steps, disabled dimming, focus ring, dark mode.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Radio>;
+
+export const Markup: React.FC = () => (
+  <Stack spacing={3}>
+    <Stack direction="row" spacing={2} alignItems="center">
+      <Typography sx={{ width: 96 }}>Colours</Typography>
+      <Radio defaultChecked color="primary" />
+      <Radio defaultChecked color="secondary" />
+      <Radio defaultChecked color="error" />
+      <Radio defaultChecked color="success" />
+      <Radio defaultChecked={false} />
+    </Stack>
+
+    <Stack direction="row" spacing={2} alignItems="center">
+      <Typography sx={{ width: 96 }}>Sizes</Typography>
+      <Radio defaultChecked size="small" />
+      <Radio defaultChecked size="medium" />
+      <Radio defaultChecked={false} size="small" />
+      <Radio defaultChecked={false} size="medium" />
+    </Stack>
+
+    <Stack direction="row" spacing={2} alignItems="center">
+      <Typography sx={{ width: 96 }}>Disabled</Typography>
+      <Radio defaultChecked disabled />
+      <Radio defaultChecked={false} disabled />
+    </Stack>
+  </Stack>
+);
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/RadioGroup.stories.tsx
+++ b/src/mui/RadioGroup.stories.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  FormControl,
+  FormControlLabel,
+  FormHelperText,
+  FormLabel,
+  Radio,
+  RadioGroup,
+  Stack,
+} from "@mui/material";
+
+const meta: Meta<typeof RadioGroup> = {
+  title: "MUI Coverage/Individual/RadioGroup",
+  component: RadioGroup,
+  tags: ["!autodocs", "!dev"],
+  excludeStories: ["Markup"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: spacing between options in both orientations, group label typography, selected control colour, error and disabled treatment, helper-text placement, dark mode.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof RadioGroup>;
+
+export const Markup: React.FC = () => (
+  <Stack direction="row" spacing={6} alignItems="flex-start">
+    <FormControl>
+      <FormLabel id="classification-label">Classification</FormLabel>
+      <RadioGroup aria-labelledby="classification-label" defaultValue="official" name="classification">
+        <FormControlLabel value="official" control={<Radio />} label="Official" />
+        <FormControlLabel value="secret" control={<Radio />} label="Secret" />
+        <FormControlLabel value="top-secret" control={<Radio />} label="Top secret" disabled />
+      </RadioGroup>
+      <FormHelperText>Applies to every record in the set.</FormHelperText>
+    </FormControl>
+
+    <FormControl error>
+      <FormLabel id="row-label">Row layout</FormLabel>
+      <RadioGroup row aria-labelledby="row-label" defaultValue="" name="row-group">
+        <FormControlLabel value="yes" control={<Radio />} label="Yes" />
+        <FormControlLabel value="no" control={<Radio />} label="No" />
+        <FormControlLabel value="maybe" control={<Radio />} label="Maybe" />
+      </RadioGroup>
+      <FormHelperText>Pick one to continue.</FormHelperText>
+    </FormControl>
+  </Stack>
+);
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/Rating.stories.tsx
+++ b/src/mui/Rating.stories.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Rating, Stack, Typography } from "@mui/material";
+
+const meta: Meta<typeof Rating> = {
+  title: "MUI Coverage/Individual/Rating",
+  component: Rating,
+  tags: ["!autodocs", "!dev"],
+  excludeStories: ["Markup"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: filled versus empty icon colour against the palette, icon size steps, spacing between icons, half-value rendering, read-only and disabled dimming, focus ring, dark mode.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Rating>;
+
+export const Markup: React.FC = () => (
+  <Stack spacing={3}>
+    <Stack direction="row" spacing={2} alignItems="center">
+      <Typography sx={{ width: 96 }}>Sizes</Typography>
+      <Rating defaultValue={3} size="small" />
+      <Rating defaultValue={3} size="medium" />
+      <Rating defaultValue={3} size="large" />
+    </Stack>
+    <Stack direction="row" spacing={2} alignItems="center">
+      <Typography sx={{ width: 96 }}>Precision</Typography>
+      <Rating defaultValue={2.5} precision={0.5} />
+      <Rating defaultValue={4} max={10} />
+    </Stack>
+    <Stack direction="row" spacing={2} alignItems="center">
+      <Typography sx={{ width: 96 }}>States</Typography>
+      <Rating value={4} readOnly />
+      <Rating value={2} disabled />
+      <Rating defaultValue={0} />
+    </Stack>
+  </Stack>
+);
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/Slide.stories.tsx
+++ b/src/mui/Slide.stories.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import useCycle from "./useCycle";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Box, Paper, Slide, Typography } from "@mui/material";
+
+const meta: Meta<typeof Slide> = {
+  title: "MUI Coverage/Individual/Slide",
+  excludeStories: ["Markup"],
+  component: Slide,
+  tags: ["!autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: duration and easing only. Slide carries no visual design of its own — all visible design belongs to the Paper inside it — but the theme owns transitions.duration and transitions.easing, so the timing is themeable. The story loops so the motion is visible.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Slide>;
+
+export const Markup: React.FC = () => {
+  const container = React.useRef<HTMLDivElement>(null);
+  const on = useCycle();
+
+  return (
+    <Box
+      ref={container}
+      sx={{ width: 320, height: 160, position: "relative", overflow: "hidden" }}
+    >
+      <Slide in={on} direction="up" container={container.current}>
+        <Paper sx={{ p: 2, height: 160 }}>
+          <Typography variant="h6">Slide</Typography>
+          <Typography variant="body2">
+            Constrained to its container, so it slides within this box rather
+            than across the canvas.
+          </Typography>
+        </Paper>
+      </Slide>
+    </Box>
+  );
+};
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/Slider.stories.tsx
+++ b/src/mui/Slider.stories.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Slider, Stack, Typography } from "@mui/material";
+
+const meta: Meta<typeof Slider> = {
+  title: "MUI Coverage/Individual/Slider",
+  component: Slider,
+  tags: ["!autodocs"],
+  excludeStories: ["Markup"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: track and rail colour and thickness, thumb size and shadow, value-label shape and contrast, mark and mark-label typography, size steps, disabled dimming, focus ring, dark mode.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Slider>;
+
+type Mark = { value: number; label: string };
+
+const marks: Mark[] = [
+  { value: 0, label: "0" },
+  { value: 25, label: "25" },
+  { value: 50, label: "50" },
+  { value: 75, label: "75" },
+  { value: 100, label: "100" },
+];
+
+export const Markup: React.FC = () => (
+  <Stack spacing={4} sx={{ width: 360 }}>
+    <Stack spacing={1}>
+      <Typography variant="body2">Continuous, primary</Typography>
+      <Slider defaultValue={40} />
+    </Stack>
+    <Stack spacing={1}>
+      <Typography variant="body2">Range, secondary, small</Typography>
+      <Slider defaultValue={[20, 70]} size="small" color="secondary" />
+    </Stack>
+    <Stack spacing={1}>
+      <Typography variant="body2">Value label always on</Typography>
+      <Slider defaultValue={60} valueLabelDisplay="on" />
+    </Stack>
+    <Stack spacing={1}>
+      <Typography variant="body2">Disabled</Typography>
+      <Slider defaultValue={30} disabled />
+    </Stack>
+  </Stack>
+);
+
+const MarksMarkup: React.FC = () => (
+  <Stack spacing={4} sx={{ width: 360 }}>
+    <Stack spacing={1}>
+      <Typography variant="body2">Stepped with labelled marks</Typography>
+      <Slider defaultValue={50} step={25} marks={marks} valueLabelDisplay="auto" />
+    </Stack>
+    <Stack spacing={1}>
+      <Typography variant="body2">Restricted to marks</Typography>
+      <Slider defaultValue={75} step={null} marks={marks} valueLabelDisplay="on" />
+    </Stack>
+    <Stack spacing={1}>
+      <Typography variant="body2">Unlabelled marks, small</Typography>
+      <Slider defaultValue={[25, 75]} step={25} marks size="small" />
+    </Stack>
+  </Stack>
+);
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };
+export const WithMarks: Story = { render: () => <MarksMarkup /> };

--- a/src/mui/Snackbar.stories.tsx
+++ b/src/mui/Snackbar.stories.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  Alert,
+  Box,
+  Button,
+  Snackbar,
+  SnackbarContent,
+  Stack,
+} from "@mui/material";
+
+const meta: Meta<typeof Snackbar> = {
+  excludeStories: ["Markup"],
+  title: "MUI Coverage/Individual/Snackbar",
+  component: Snackbar,
+  tags: ["!autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: surface colour, text contrast, action colour, radius, elevation, wrapping and dark mode. MUI inverts SnackbarContent in dark mode by design (emphasize(background.default, 0.98)), which is why the surface goes light. The Alert rows show the variant most apps actually use inside a Snackbar.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Snackbar>;
+
+export const Markup: React.FC = () => (
+  <Stack spacing={2} sx={{ maxWidth: 560 }}>
+    <SnackbarContent message="Message only, no action" />
+    <SnackbarContent
+      message="Changes saved"
+      action={
+        <Button color="secondary" size="small">
+          Undo
+        </Button>
+      }
+    />
+    <SnackbarContent
+      message="A longer message that wraps onto a second line so the padding, line height and action alignment can be judged together."
+      action={
+        <Button color="secondary" size="small">
+          Retry
+        </Button>
+      }
+    />
+    <Stack spacing={1}>
+      <Alert severity="success">Alert inside a snackbar - success</Alert>
+      <Alert severity="error">Alert inside a snackbar - error</Alert>
+      <Alert severity="warning">Alert inside a snackbar - warning</Alert>
+      <Alert severity="info">Alert inside a snackbar - info</Alert>
+    </Stack>
+    <Box sx={{ position: "relative", height: 120 }}>
+      <Snackbar
+        open
+        onClose={() => undefined}
+        sx={{ position: "absolute" }}
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+        message="Positioned Snackbar, bottom left of its box"
+      />
+    </Box>
+  </Stack>
+);
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/SpeedDial.stories.tsx
+++ b/src/mui/SpeedDial.stories.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import useCycle from "./useCycle";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Box, SpeedDial, SpeedDialAction, SpeedDialIcon } from "@mui/material";
+import { Check, Clear, Edit } from "@telicent-oss/mui-icons-material";
+
+const meta: Meta<typeof SpeedDial> = {
+  excludeStories: ["Markup"],
+  title: "MUI Coverage/Individual/SpeedDial",
+  component: SpeedDial,
+  tags: ["!autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: the FAB fill and icon contrast, action button surfaces, tooltip labels, dark mode. Shows theming, not production positioning or stacking.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof SpeedDial>;
+
+export const Markup: React.FC = () => {
+  const open = useCycle(2400);
+
+  return (
+  <Box sx={{ position: "relative", height: 320 }}>
+    <SpeedDial
+      ariaLabel="Example actions"
+      open={open}
+      icon={<SpeedDialIcon />}
+      sx={{ position: "absolute", bottom: 16, right: 16 }}
+    >
+      <SpeedDialAction icon={<Edit />} tooltipTitle="Edit" tooltipOpen />
+      <SpeedDialAction icon={<Check />} tooltipTitle="Approve" tooltipOpen />
+      <SpeedDialAction icon={<Clear />} tooltipTitle="Reject" tooltipOpen />
+    </SpeedDial>
+  </Box>
+  );
+};
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/Stepper.stories.tsx
+++ b/src/mui/Stepper.stories.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  Button,
+  MobileStepper,
+  Paper,
+  Stack,
+  Step,
+  StepButton,
+  StepConnector,
+  StepContent,
+  StepIcon,
+  StepLabel,
+  Stepper,
+  Typography,
+} from "@mui/material";
+import { ChevronLeft, ChevronRight } from "@telicent-oss/mui-icons-material";
+
+const meta: Meta<typeof Stepper> = {
+  title: "MUI Coverage/Individual/Stepper",
+  excludeStories: ["Markup"],
+  component: Stepper,
+  tags: ["!autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: completed vs active vs upcoming step icon colours, connector line colour and weight, label typography, step content indentation, mobile stepper progress bar, dark mode.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Stepper>;
+
+const steps: string[] = ["Select dataset", "Map ontology", "Review and publish"];
+const activeStep = 1;
+
+export const Markup: React.FC = () => (
+  <Stack spacing={5} sx={{ width: 560 }}>
+    <Stepper activeStep={activeStep} connector={<StepConnector />}>
+      {steps.map((label) => (
+        <Step key={label}>
+          <StepLabel>{label}</StepLabel>
+        </Step>
+      ))}
+    </Stepper>
+
+    <Stepper activeStep={activeStep} nonLinear>
+      {steps.map((label) => (
+        <Step key={label} completed={steps.indexOf(label) < activeStep}>
+          <StepButton>{label}</StepButton>
+        </Step>
+      ))}
+    </Stepper>
+
+    <Stepper activeStep={activeStep} orientation="vertical">
+      {steps.map((label) => (
+        <Step key={label}>
+          <StepLabel>{label}</StepLabel>
+          <StepContent>
+            <Typography variant="body2">Content for {label}.</Typography>
+          </StepContent>
+        </Step>
+      ))}
+    </Stepper>
+
+    <Stack direction="row" spacing={2} alignItems="center">
+      <StepIcon icon={1} completed />
+      <StepIcon icon={2} active />
+      <StepIcon icon={3} />
+      <StepIcon icon={4} error />
+    </Stack>
+
+    <Paper>
+      <MobileStepper
+        variant="progress"
+        steps={steps.length}
+        position="static"
+        activeStep={activeStep}
+        nextButton={
+          <Button size="small">
+            Next
+            <ChevronRight />
+          </Button>
+        }
+        backButton={
+          <Button size="small">
+            <ChevronLeft />
+            Back
+          </Button>
+        }
+      />
+    </Paper>
+  </Stack>
+);
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/SwipeableDrawer.stories.tsx
+++ b/src/mui/SwipeableDrawer.stories.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  Box,
+  Divider,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  SwipeableDrawer,
+  Typography,
+} from "@mui/material";
+import { Check, List as ListIcon, LocationOn } from "@telicent-oss/mui-icons-material";
+
+const meta: Meta<typeof SwipeableDrawer> = {
+  excludeStories: ["Markup"],
+  title: "MUI Coverage/Individual/SwipeableDrawer",
+  component: SwipeableDrawer,
+  tags: ["!autodocs", "!dev"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: drawer paper background and elevation, list item density, selected and hover states, divider colour, dark mode. Shows theming, not production positioning or stacking.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof SwipeableDrawer>;
+
+const noop = (): void => undefined;
+
+export const Markup: React.FC = () => (
+  <Box sx={{ position: "relative", height: 320, width: 560, overflow: "hidden" }}>
+    <SwipeableDrawer
+      open
+      anchor="left"
+      onOpen={noop}
+      onClose={noop}
+      ModalProps={{
+        disablePortal: true,
+        keepMounted: true,
+        disableScrollLock: true,
+        disableAutoFocus: true,
+        disableEnforceFocus: true,
+      }}
+      sx={{ position: "absolute" }}
+      PaperProps={{ sx: { position: "absolute", width: 240 } }}
+      BackdropProps={{ sx: { position: "absolute" } }}
+    >
+      <Box sx={{ p: 2 }}>
+        <Typography variant="subtitle1">Filters</Typography>
+      </Box>
+      <Divider />
+      <List>
+        <ListItemButton selected>
+          <ListItemIcon>
+            <LocationOn />
+          </ListItemIcon>
+          <ListItemText primary="Nearby" />
+        </ListItemButton>
+        <ListItemButton>
+          <ListItemIcon>
+            <ListIcon />
+          </ListItemIcon>
+          <ListItemText primary="Records" secondary="All datasets" />
+        </ListItemButton>
+        <ListItemButton disabled>
+          <ListItemIcon>
+            <Check />
+          </ListItemIcon>
+          <ListItemText primary="Approved" />
+        </ListItemButton>
+      </List>
+    </SwipeableDrawer>
+  </Box>
+);
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/Table.stories.tsx
+++ b/src/mui/Table.stories.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableFooter,
+  TableHead,
+  TablePagination,
+  TableRow,
+  TableSortLabel,
+} from "@mui/material";
+
+const meta: Meta<typeof Table> = {
+  title: "MUI Coverage/Individual/Table",
+  excludeStories: ["Markup"],
+  component: Table,
+  tags: ["!autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: header weight and background, row divider colour, cell padding at default and dense sizes, sort label and arrow contrast, selected and hover row states, pagination control density, dark mode.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Table>;
+
+type Column = {
+  id: keyof Row;
+  label: string;
+  numeric: boolean;
+};
+
+type Row = {
+  id: string;
+  vessel: string;
+  flag: string;
+  entities: number;
+};
+
+const columns: Column[] = [
+  { id: "vessel", label: "Vessel", numeric: false },
+  { id: "flag", label: "Flag", numeric: false },
+  { id: "entities", label: "Entities", numeric: true },
+];
+
+const rows: Row[] = [
+  { id: "r1", vessel: "Aurora", flag: "NO", entities: 128 },
+  { id: "r2", vessel: "Balaena", flag: "GB", entities: 54 },
+  { id: "r3", vessel: "Corvus", flag: "PT", entities: 311 },
+  { id: "r4", vessel: "Dorado", flag: "ES", entities: 7 },
+];
+
+const noop = (): void => undefined;
+
+export const Markup: React.FC<{ size?: "small" | "medium" }> = ({ size = "medium" }) => (
+  <TableContainer component={Paper} sx={{ width: 560 }}>
+    <Table size={size}>
+      <TableHead>
+        <TableRow>
+          {columns.map((column) => (
+            <TableCell
+              key={column.id}
+              align={column.numeric ? "right" : "left"}
+              sortDirection={column.id === "entities" ? "desc" : false}
+            >
+              <TableSortLabel
+                active={column.id === "entities"}
+                direction="desc"
+                onClick={noop}
+              >
+                {column.label}
+              </TableSortLabel>
+            </TableCell>
+          ))}
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {rows.map((row) => (
+          <TableRow key={row.id} hover selected={row.id === "r2"}>
+            <TableCell>{row.vessel}</TableCell>
+            <TableCell>{row.flag}</TableCell>
+            <TableCell align="right">{row.entities}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+      <TableFooter>
+        <TableRow>
+          <TablePagination
+            count={40}
+            page={1}
+            rowsPerPage={10}
+            rowsPerPageOptions={[10, 25, 50]}
+            onPageChange={noop}
+            onRowsPerPageChange={noop}
+          />
+        </TableRow>
+      </TableFooter>
+    </Table>
+  </TableContainer>
+);
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };
+
+export const DenseWithTelicentTheme: Story = { render: () => <Markup size="small" /> };

--- a/src/mui/Tabs.stories.tsx
+++ b/src/mui/Tabs.stories.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Box, Stack, Tab, Tabs } from "@mui/material";
+
+const meta: Meta<typeof Tabs> = {
+  title: "MUI Coverage/Individual/Tabs",
+  excludeStories: ["Markup"],
+  component: Tabs,
+  tags: ["!autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: indicator colour and thickness, selected vs unselected label colour, tab density and min width, scroll button styling, disabled and focus states, dark mode.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Tabs>;
+
+const scrollableTabs: string[] = [
+  "Overview",
+  "Entities",
+  "Relationships",
+  "Provenance",
+  "Access",
+  "Schema",
+  "History",
+  "Exports",
+  "Settings",
+  "Audit",
+];
+
+export const Markup: React.FC = () => (
+  <Stack spacing={4} sx={{ width: 520 }}>
+    <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
+      <Tabs value={1}>
+        <Tab label="Overview" />
+        <Tab label="Entities" />
+        <Tab label="Provenance" />
+        <Tab label="Disabled" disabled />
+      </Tabs>
+    </Box>
+    <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
+      <Tabs value={2} variant="scrollable" scrollButtons allowScrollButtonsMobile>
+        {scrollableTabs.map((label) => (
+          <Tab key={label} label={label} />
+        ))}
+      </Tabs>
+    </Box>
+    <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
+      <Tabs value={0} variant="fullWidth" textColor="secondary" indicatorColor="secondary">
+        <Tab label="Full width" />
+        <Tab label="Second" />
+      </Tabs>
+    </Box>
+  </Stack>
+);
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/ToggleButtonGroup.stories.tsx
+++ b/src/mui/ToggleButtonGroup.stories.tsx
@@ -1,0 +1,104 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Stack, ToggleButton, ToggleButtonGroup, Typography } from "@mui/material";
+
+const meta: Meta<typeof ToggleButtonGroup> = {
+  title: "MUI Coverage/Individual/ToggleButtonGroup",
+  component: ToggleButtonGroup,
+  tags: ["!autodocs"],
+  excludeStories: ["Markup"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: selected fill and text contrast, border colour and shared edges between buttons, corner radii on the group ends, button density, size steps, disabled dimming, hover and focus states, dark mode.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ToggleButtonGroup>;
+
+type Alignment = "left" | "center" | "right";
+
+const alignments: Alignment[] = ["left", "center", "right"];
+
+const AlignmentGroup: React.FC<{
+  size: "small" | "medium" | "large";
+  disabled?: boolean;
+}> = ({ size, disabled }) => {
+  const [value, setValue] = React.useState<Alignment>("center");
+  const handleChange = (
+    _event: React.MouseEvent<HTMLElement>,
+    next: Alignment | null,
+  ): void => {
+    if (next !== null) setValue(next);
+  };
+  return (
+    <ToggleButtonGroup
+      exclusive
+      value={value}
+      onChange={handleChange}
+      size={size}
+      disabled={disabled}
+      aria-label="text alignment"
+    >
+      {alignments.map((alignment) => (
+        <ToggleButton key={alignment} value={alignment} aria-label={`${alignment} aligned`}>
+          {alignment.charAt(0).toUpperCase() + alignment.slice(1)}
+        </ToggleButton>
+      ))}
+    </ToggleButtonGroup>
+  );
+};
+
+const MultiSelectGroup: React.FC = () => {
+  const [values, setValues] = React.useState<Alignment[]>(["left", "right"]);
+  const handleChange = (
+    _event: React.MouseEvent<HTMLElement>,
+    next: Alignment[],
+  ): void => {
+    setValues(next);
+  };
+  return (
+    <ToggleButtonGroup value={values} onChange={handleChange} aria-label="multi select">
+      {alignments.map((alignment) => (
+        <ToggleButton key={alignment} value={alignment}>
+          {alignment.charAt(0).toUpperCase() + alignment.slice(1)}
+        </ToggleButton>
+      ))}
+    </ToggleButtonGroup>
+  );
+};
+
+export const Markup: React.FC = () => (
+  <Stack spacing={3} alignItems="flex-start">
+    <Stack direction="row" spacing={2} alignItems="center">
+      <Typography sx={{ width: 120 }}>Sizes</Typography>
+      <AlignmentGroup size="small" />
+      <AlignmentGroup size="medium" />
+      <AlignmentGroup size="large" />
+    </Stack>
+    <Stack direction="row" spacing={2} alignItems="center">
+      <Typography sx={{ width: 120 }}>Multi-select</Typography>
+      <MultiSelectGroup />
+    </Stack>
+    <Stack direction="row" spacing={2} alignItems="center">
+      <Typography sx={{ width: 120 }}>Vertical</Typography>
+      <ToggleButtonGroup orientation="vertical" exclusive value="center">
+        {alignments.map((alignment) => (
+          <ToggleButton key={alignment} value={alignment}>
+            {alignment.charAt(0).toUpperCase() + alignment.slice(1)}
+          </ToggleButton>
+        ))}
+      </ToggleButtonGroup>
+    </Stack>
+    <Stack direction="row" spacing={2} alignItems="center">
+      <Typography sx={{ width: 120 }}>Disabled</Typography>
+      <AlignmentGroup size="medium" disabled />
+    </Stack>
+  </Stack>
+);
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/Tooltip.stories.tsx
+++ b/src/mui/Tooltip.stories.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Box, Button, Stack, Tooltip } from "@mui/material";
+
+const meta: Meta<typeof Tooltip> = {
+  excludeStories: ["Markup"],
+  title: "MUI Coverage/Individual/Tooltip",
+  component: Tooltip,
+  tags: ["!autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: tooltip background and text contrast, radius, arrow colour, font size, dark mode. Shows theming, not production positioning or stacking.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Tooltip>;
+
+export const Markup: React.FC = () => (
+  <Stack direction="row" spacing={8} sx={{ height: 140, alignItems: "center" }}>
+    <Box sx={{ position: "relative" }}>
+      <Tooltip
+        open
+        title="Plain tooltip"
+        placement="bottom"
+        slotProps={{ popper: { disablePortal: true } }}
+      >
+        <Button>Plain</Button>
+      </Tooltip>
+    </Box>
+    <Box sx={{ position: "relative" }}>
+      <Tooltip
+        open
+        arrow
+        title="Tooltip with arrow"
+        placement="bottom"
+        slotProps={{ popper: { disablePortal: true } }}
+      >
+        <Button>With arrow</Button>
+      </Tooltip>
+    </Box>
+  </Stack>
+);
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/Zoom.stories.tsx
+++ b/src/mui/Zoom.stories.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import useCycle from "./useCycle";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Box, Zoom, Paper, Typography } from "@mui/material";
+
+const meta: Meta<typeof Zoom> = {
+  title: "MUI Coverage/Individual/Zoom",
+  excludeStories: ["Markup"],
+  component: Zoom,
+  tags: ["!autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Judge: duration and easing only. Zoom carries no visual design of its own — all visible design belongs to the Paper inside it — but the theme owns transitions.duration and transitions.easing, so the timing is themeable. The story loops so the motion is visible.",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Zoom>;
+
+export const Markup: React.FC = () => {
+  const on = useCycle();
+
+  return (
+  <Box sx={{ width: 320, height: 160 }}>
+    <Zoom in={on}>
+      <Paper sx={{ p: 2, height: 160 }}>
+        <Typography variant="h6">Zoom</Typography>
+        <Typography variant="body2">
+          Rendered with `in` set, so the transition is already complete and the
+          Paper is fully visible.
+        </Typography>
+      </Paper>
+    </Zoom>
+  </Box>
+  );
+};
+
+export const WithTelicentTheme: Story = { render: () => <Markup /> };

--- a/src/mui/useCycle.ts
+++ b/src/mui/useCycle.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Flips a boolean on an interval so a transition story plays continuously.
+ * Without it a transition rendered with a static `in` sits at its end state
+ * and shows nothing — but the theme owns `transitions.duration` and
+ * `transitions.easing`, so the timing is worth seeing.
+ */
+const useCycle = (intervalMs = 1600): boolean => {
+  const [on, setOn] = useState(true);
+
+  useEffect(() => {
+    const id = setInterval(() => setOn((prev) => !prev), intervalMs);
+    return () => clearInterval(id);
+  }, [intervalMs]);
+
+  return on;
+};
+
+export default useCycle;


### PR DESCRIPTION
Ticket: https://telicent.atlassian.net/browse/LAB-91

### Goal

Let the FE team see every MUI component the design system does not export, under our theme, and size the work to bless each one for our palette and UX requirements.

Spike. Nothing is exported and nothing is released — `src/export.ts` is untouched and the `mui` namespace still has three keys.

### Work Completed

A `MUI Coverage` section in Storybook, three parts:

- **Proposed included** — 34 components on one scrolling page, grouped (Inputs & forms, Data display, Surfaces & overlays, Navigation, Feedback, Motion, Layout) with jump links
- **Proposed excluded** — 62 components in seven tables with the reason and what to use instead
- **Individual/** — a page per component for drill-down

Stories import `@mui/material` directly, which is correct in this repo: the eslint ban on `@mui/*` lives in consuming apps.

Counts, measured against `dist/export.d.ts` (228 exported names) and `node_modules/@mui/material` (133 component modules):

| Bucket | Count |
| --- | --- |
| Name or capability the DS already owns | 36 |
| Excluded as unassessable | 26 |
| Dropped by request | 5 |
| Shown in the kitchen sink | 34 |

### Design Testing

- Pre-release version: n/a — nothing published
- Storybook for this branch: https://telicent-oss.github.io/telicent-ds/LAB-91/mui-coverage-spike

### Testing Method

- `yarn build` and `yarn build-storybook` pass; the index carries 41 pages and 43 stories, no phantom entries
- `npx tsc --noEmit` exits 0
- `yarn test` passes: 75 suites, 40 snapshots
- `yarn lint` could not run — see Engineering Notes

### Code Review Tips

Start with the Storybook link, not the diff. The page is the deliverable; the code is fixtures.

Two findings already worth acting on, both visible on the page:

- `palette.secondary` does not exist in the DS theme. `ThemeModePalette` allows only `primary`, `tertiary`, `text` and `background`, so anything using `color="secondary"` falls back to MUI's purple. Wider than this spike.
- `SnackbarContent` inverts to a light surface in dark mode by MUI's design (`emphasize(background.default, 0.98)`). A candidate for `MuiSnackbarContent` overrides.

### Engineering Notes

<details>
<summary>Details</summary>

`.storybook/preview.tsx` is the only non-story file changed. An earlier revision of this spike rendered each component twice, once with no design-system provider, and needed a `parameters.stock` branch to escape the global `UIThemeProvider` decorator. That approach is gone and the branch was removed with it.

Of the 34 shown, only `Avatar` and `Menu` carry DS `styleOverrides` today (`MuiAvatar`, `MuiMenuItem`). The other 32 get Telicent colour and type on MUI's own radii, padding, elevation and density.

Transitions (`Fade`, `Grow`, `Zoom`, `Collapse`, `Slide`) and `SpeedDial` loop on a timer via `src/mui/useCycle.ts`, otherwise they sit at their end state and show nothing. The theme owns `transitions.duration` and `transitions.easing`, so the timing is worth seeing.

Portal-based components (`Menu`, `Popover`, `Popper`, `Tooltip`, `Backdrop`, `Snackbar`, `SpeedDial`, and the `Dialog` in Dialog children) are contained with `disablePortal` and absolute positioning, plus `disableScrollLock` and `disableEnforceFocus` where a Modal is involved. Without those, one open modal locks body scroll and breaks the scrolling the page exists for. Positioning and stacking are therefore not production-accurate on those sections; each says so.

`yarn lint` is broken repo-wide and predates this branch: there is no `eslint.config.*`, no `.eslintrc*` and no `eslintConfig` key, while ESLint 9.39.2 is installed and the `lint` script still passes `--resolve-plugins-relative-to`, removed in v9. Not fixed here; it needs a deliberate repo-wide decision.

The five dropped components are hidden with a `!dev` tag rather than deleted, so one word per file restores them.

Prioritisation input: `apps/graph` and `apps/search` import 36 MUI components directly across 100 import sites. 18 of those are in this spike, 15 have a DS equivalent that was bypassed, and 3 have no home.

</details>

### Out-of-scope

- Exporting any of this. `src/export.ts` is unchanged
- Writing `styleOverrides` for the 32 unstyled components — this spike sizes that work
- Fixing the repo-wide eslint config
- `@mui/lab` and `@mui/x-date-pickers`, both DS dependencies, so DatePicker and Timeline users still reach around the ban
