### PR TITLE
feat: add QuestionIcon to data-display icons

### DIFF
--- a/src/components/data-display/Icons/QuestionIcon.tsx
+++ b/src/components/data-display/Icons/QuestionIcon.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import MUISvgIcon, {
+  SvgIconProps as MUISvgIconProps,
+} from "@mui/material/SvgIcon";
+
+const QuestionIcon: React.FC<MUISvgIconProps> = (iconProps) => (
+  <MUISvgIcon {...iconProps}>
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22ZM12 20.4332C16.6575 20.4332 20.4332 16.6575 20.4332 12C20.4332 7.34247 16.6575 3.56679 12 3.56679C7.34247 3.56679 3.56679 7.34247 3.56679 12C3.56679 16.6575 7.34247 20.4332 12 20.4332Z"
+      fill="currentColor"
+    />
+    <path
+      d="M12 6C9.79086 6 8 7.79086 8 10H10C10 8.89543 10.8954 8 12 8C13.1046 8 14 8.89543 14 10C14 11.75 11 12 11 14.5H13C13 12.75 16 11.75 16 10C16 7.79086 14.2091 6 12 6Z"
+      fill="currentColor"
+    />
+    <path
+      d="M12 15.75C11.3096 15.75 10.75 16.3096 10.75 17C10.75 17.6904 11.3096 18.25 12 18.25C12.6904 18.25 13.25 17.6904 13.25 17C13.25 16.3096 12.6904 15.75 12 15.75Z"
+      fill="currentColor"
+    />
+  </MUISvgIcon>
+);
+
+export default QuestionIcon;

--- a/src/components/data-display/Icons/index.ts
+++ b/src/components/data-display/Icons/index.ts
@@ -12,6 +12,7 @@ export { default as MapIcon } from "./MapIcon";
 export { default as MinusCircleIcon } from "./MinusCircleIcon";
 export { default as PlayIcon } from "./PlayIcon";
 export { default as PlusCircleIcon } from "./PlusCircleIcon";
+export { default as QuestionIcon } from "./QuestionIcon";
 export { default as WarningIcon } from "./WarningIcon";
 export { default as TelicentMark } from "./TelicentMark";
 export { default as TelicentHorizontalSVG } from "./TelicentHorizontalSVG";

--- a/src/story-coverage.test.ts
+++ b/src/story-coverage.test.ts
@@ -84,6 +84,7 @@ it("looks for components that appear to be missing a story - snapshots these com
       "./src/components/data-display/Icons/MinusCircleIcon.tsx",
       "./src/components/data-display/Icons/PlayIcon.tsx",
       "./src/components/data-display/Icons/PlusCircleIcon.tsx",
+      "./src/components/data-display/Icons/QuestionIcon.tsx",
       "./src/components/data-display/Icons/TelicentHorizontalSVG.tsx",
       "./src/components/data-display/Icons/TelicentMark.tsx",
       "./src/components/data-display/Icons/UserIcon.tsx",


### PR DESCRIPTION
### Goal

Add a `QuestionIcon` to the DS icon set so consumers have a standard "help/info" glyph available alongside the other data-display icons.

### Work Completed

- New presentational component `src/components/data-display/Icons/QuestionIcon.tsx` — MUI `SvgIcon` wrapper with a circle + "?" + dot path, uses `currentColor` so it inherits size and colour from parent styling.
- Exported from `src/components/data-display/Icons/index.ts` (alphabetically placed with the other icons).
- Added to the story-coverage snapshot allow-list in `src/story-coverage.test.ts` — no story yet, so it goes on the known-missing list to keep the coverage test green.

### Design Testing

Icon-only addition — no UI surface change beyond a new exported component. Design approval block kept for completeness; expect most items to be marked `[-]`.

- Pre-release version: _e.g. v1.2.3-JIRA-123.0_
- [ ] This PR is setup for easy assessment of "<strong>Design approval areas</strong>")

<details>
  <summary><strong>Design approval areas</strong></summary>

  <hr />
  
  A _indicative_ list of suggested screenshots or videos.

Action each: Mark "`[x]`" (click) for _complete_, or "`[-]`" for _not-applicable_.

- [ ] UI content:
  - [ ] **Ideal** - show UI with "happy content" i.e. what Figma considers typical
  - [ ] **Empty** - show UI with empty (or minimum) content
  - [ ] **Full** - show UI with all (or technically maximum) content
- [ ] UI States:
  - [ ] **Form validation** - show UI for validation errors, hints and success
  - [ ] **Network states** - show UI for fetch failures and success
  - [ ] **env-config errors** - show release-engineer UI for app config errors
- [ ] Responsiveness:
  - [ ] **Min width** - show UI with minimum width supported by parent container, or [most common desktop](https://www.google.com/search?q=most+common+desktop+screen+resolution+now) split screen
  - [ ] **Min height** - show UI with minimum height supported by parent container, or [most common desktop](https://www.google.com/search?q=most+common+desktop+screen+resolution+now) half height
- [ ] Accessibility: new issues introduced this PR (perhaps include report before, and report after)

</details>

### Testing Method

- `yarn tsc --noEmit` and full `jest` suite ran clean via the pre-push hook.
- `story-coverage.test.ts` updated to include `QuestionIcon.tsx` in the known-missing-story list, so the snapshot check passes.

### Out-of-scope

- No Storybook story yet — icon is registered in the missing-story allow-list. Add a story in a follow-up if we want it in the Storybook grid.

---

<details>
  <summary><strong>🕵️ Review Guidance</strong></summary>

---

General guidance

- Generally, approve a PR if it makes the system better, even if it's not perfect. — [Google: The Standard of Code Review](https://google.github.io/eng-practices/review/reviewer/standard.html)
- The aim of both PR AUTHOR and PR REVIEWER is to get the code merged
- Aim for consensus, defined as _everyone can live with the outcome_
- PR with changes requires 2 approvals
- PR with no changes requires 1 approvals

For PR REVIEWER:

1. Read the ticket & description
2. [Review the code](https://google.github.io/eng-practices/review/reviewer/looking-for.html)
3. Request any changes that are essential.
4. For non-essential comments:
   - Use prefixes, e.g. "**nit:** change to Pascal case"
     - **nit:** small, non-essential change
     - **obs:** just an observation, doesn't affect the PR
     - **idea:** a suggestion to think about
     - **q:** questions
   - Use modifiers, e.g. "**obs**`[pr-owner-resolve]`: Jim is also editing this file"
     - `pr-author-resolve` PR author can resolve after reading
     - `pr-author-delete` (rare) delete after reading to avoid confusion
5. try to add _at least_ a helpful comment per ~500 lines; less if the PR is already busy

For PR AUTHOR:

1. Aim for enough detail in PR description for things to go smoothly
2. After requested changes, [re-request a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews#re-requesting-a-review) (so the PR shows up in [reviews-requested:@me](https://github.com/pulls?q=is%3Apr+is%3Aopen+archived%3Afalse+sort%3Aupdated-desc+review-requested%3A%40me+))

</details>
