### PR TITLE
feat(map): add feature hover events to BasicMap + Menu Fragment warning fix

### DIFF
--- a/__mocks__/ol/Observable.ts
+++ b/__mocks__/ol/Observable.ts
@@ -1,0 +1,3 @@
+export const unByKey = jest.fn();
+
+export default {};

--- a/src/components/Navigation/Menu/Menu.test.tsx
+++ b/src/components/Navigation/Menu/Menu.test.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { cleanup, screen } from "@testing-library/react";
+
+import { Menu } from "./Menu";
+import { setup } from "../../../test-utils";
+
+describe("Menu", () => {
+  afterEach(cleanup);
+
+  it("does not warn about Fragment children when options include a divider", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    const { user } = setup(
+      <Menu
+        aria-label="test-menu"
+        menuId="test-menu"
+        options={[
+          { id: "edit", label: "Edit" },
+          { id: "delete", label: "Delete", dividerAbove: true },
+        ]}
+        button={(btnProps) => (
+          <button type="button" {...btnProps}>
+            open
+          </button>
+        )}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "open" }));
+    await screen.findByRole("menu");
+
+    const fragmentWarning = errorSpy.mock.calls.find(
+      ([msg]) =>
+        typeof msg === "string" &&
+        msg.includes("Menu component doesn't accept a Fragment"),
+    );
+    expect(fragmentWarning).toBeUndefined();
+
+    errorSpy.mockRestore();
+  });
+});

--- a/src/components/Navigation/Menu/Menu.tsx
+++ b/src/components/Navigation/Menu/Menu.tsx
@@ -95,10 +95,10 @@ export const Menu: React.FC<MenuProps> = ({
         }}
         sx={sx}
       >
-        {options.map((opt, idx) => (
-          <React.Fragment key={opt.id}>
-            {opt.dividerAbove && <MUIDivider />}
+        {options.flatMap((opt, idx) => {
+          const item = (
             <MUIMenuItem
+              key={opt.id}
               disabled={opt.disabled}
               selected={Boolean(opt.selected)}
               autoFocus={autoFocusSelected && idx === selectedIndex}
@@ -114,8 +114,19 @@ export const Menu: React.FC<MenuProps> = ({
               {opt.icon ? <MUIListItemIcon>{opt.icon}</MUIListItemIcon> : null}
               <MUIListItemText>{opt.label}</MUIListItemText>
             </MUIMenuItem>
-          </React.Fragment>
-        ))}
+          );
+
+          return opt.dividerAbove
+            ? [
+                <MUIDivider
+                  key={`${opt.id}-divider`}
+                  component="li"
+                  role="separator"
+                />,
+                item,
+              ]
+            : [item];
+        })}
       </MUIMenu>
     </>
   );

--- a/src/feature-components/Map/v2/composites/BasicMap/BasicMap.stories.tsx
+++ b/src/feature-components/Map/v2/composites/BasicMap/BasicMap.stories.tsx
@@ -1,9 +1,10 @@
-import React, { useRef } from "react";
+import React, { useRef, useState } from "react";
 import { Box } from "@mui/material";
 import { Meta, StoryObj } from "@storybook/react-vite";
 import { BasicMapV2 } from "./BasicMap";
 import { BasicMapProperties } from "../../types/map-types";
 import { LayerConfig } from "../../types/layers";
+import { MarkerFeature } from "../../types/markers";
 
 
 export const allArgs: BasicMapProperties = {
@@ -94,6 +95,96 @@ export const Template: Story = {
 	args: {
 		layers: baseLayers
 	}
+};
+
+const eventMarkers: MarkerFeature[] = [
+	{
+		id: "marker-a",
+		geohash: "gcpvj0",
+		name: "Marker A (London)",
+		style: { markerType: "pin", color: "#ff6600" },
+	},
+	{
+		id: "marker-b",
+		geohash: "u09tvw",
+		name: "Marker B (Paris)",
+		style: { markerType: "pin", color: "#0066ff" },
+	},
+];
+
+/**
+ * Both `onFeatureHover` and `onFeatureClick` are wired to a debug panel that
+ * shows the raw id + pixel the DS emits. Callback contract:
+ *
+ * - `onFeatureHover(id, { pixel })` fires when the pointer enters a marker.
+ * - `onFeatureHover(null)` fires when the pointer leaves the last-hovered
+ *   marker (no pixel is included).
+ * - Moving the pointer **within** the same marker does not re-fire.
+ * - Moving directly from marker A to marker B fires once, with B's id and
+ *   pixel — the id change implicitly signals A is no longer hovered.
+ *
+ * The DS emits events only. The consuming app owns any popover / cursor /
+ * highlight / throttling behaviour built on top of these events.
+ */
+export const FeatureEvents: Story = {
+	args: {
+		zoom: 5,
+		center: [2, 49],
+		layers: baseLayers.map((l) => ({ ...l, visible: true })),
+		markers: eventMarkers,
+		polygons: [],
+	},
+	render: (args) => {
+		const [log, setLog] = useState<string[]>([]);
+		const push = (line: string) =>
+			setLog((prev) => [line, ...prev].slice(0, 12));
+
+		return (
+			<Box sx={{ position: "relative", width: "100%", height: "100%" }}>
+				<BasicMapV2
+					{...args}
+					onFeatureHover={(id, event) => {
+						const line = id === null
+							? "hover: null"
+							: `hover: ${id} @ [${event?.pixel[0]}, ${event?.pixel[1]}]`;
+						console.log(line);
+						push(line);
+					}}
+					onFeatureClick={(ids, event) => {
+						const line = `click: [${ids.join(", ")}]` +
+							(event ? ` @ [${event.pixel[0]}, ${event.pixel[1]}]` : "");
+						console.log(line);
+						push(line);
+					}}
+				/>
+				<Box
+					sx={{
+						position: "absolute",
+						top: 8,
+						right: 8,
+						minWidth: 260,
+						maxHeight: 220,
+						overflow: "auto",
+						padding: 1,
+						background: "rgba(0,0,0,0.75)",
+						color: "#fff",
+						font: "12px/1.4 monospace",
+						borderRadius: 1,
+						zIndex: 10,
+						pointerEvents: "none",
+					}}
+				>
+					<div style={{ fontWeight: 600, marginBottom: 4 }}>
+						Feature events (newest first)
+					</div>
+					{log.length === 0 && <div>Hover or click a marker…</div>}
+					{log.map((line, i) => (
+						<div key={i}>{line}</div>
+					))}
+				</Box>
+			</Box>
+		);
+	},
 };
 
 

--- a/src/feature-components/Map/v2/composites/BasicMap/interactions/__tests__/addHoverInteraction.test.ts
+++ b/src/feature-components/Map/v2/composites/BasicMap/interactions/__tests__/addHoverInteraction.test.ts
@@ -1,0 +1,156 @@
+import { addHoverInteraction } from "../addHoverInteraction";
+import { unByKey } from "ol/Observable";
+import type { Map as OlMap } from "ol";
+import type VectorLayer from "ol/layer/Vector";
+
+jest.mock("ol/Observable", () => ({
+  unByKey: jest.fn(),
+}));
+
+type PointerHandler = (evt: {
+  dragging?: boolean;
+  pixel: [number, number];
+}) => void;
+
+type FakeMap = {
+  on: jest.Mock;
+  forEachFeatureAtPixel: jest.Mock;
+};
+
+const makeMap = (): { map: OlMap; getHandler: () => PointerHandler; fakeMap: FakeMap } => {
+  const listeners: Record<string, PointerHandler> = {};
+  const fakeMap: FakeMap = {
+    on: jest.fn((event: string, handler: PointerHandler) => {
+      listeners[event] = handler;
+      return { event, handler } as unknown;
+    }) as jest.Mock,
+    forEachFeatureAtPixel: jest.fn(),
+  };
+  return {
+    map: fakeMap as unknown as OlMap,
+    fakeMap,
+    getHandler: () => listeners.pointermove,
+  };
+};
+
+const featureWithId = (id: string) => ({
+  getId: () => id,
+});
+
+describe("addHoverInteraction", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("fires enter with id and pixel when pointer enters a marker from empty space", () => {
+    const { map, fakeMap, getHandler } = makeMap();
+    const onHover = jest.fn();
+
+    addHoverInteraction({
+      map,
+      layer: {} as VectorLayer,
+      onHover,
+    });
+
+    fakeMap.forEachFeatureAtPixel.mockImplementation(
+      (_pixel: unknown, cb: (f: unknown) => boolean) => cb(featureWithId("A"))
+    );
+
+    getHandler()({ pixel: [10, 20] });
+
+    expect(onHover).toHaveBeenCalledTimes(1);
+    expect(onHover).toHaveBeenCalledWith("A", { pixel: [10, 20] });
+  });
+
+  it("does not re-fire when pointer moves within the same marker", () => {
+    const { map, fakeMap, getHandler } = makeMap();
+    const onHover = jest.fn();
+
+    addHoverInteraction({ map, layer: {} as VectorLayer, onHover });
+
+    fakeMap.forEachFeatureAtPixel.mockImplementation(
+      (_pixel: unknown, cb: (f: unknown) => boolean) => cb(featureWithId("A"))
+    );
+
+    getHandler()({ pixel: [10, 20] });
+    getHandler()({ pixel: [11, 21] });
+    getHandler()({ pixel: [12, 22] });
+
+    expect(onHover).toHaveBeenCalledTimes(1);
+    expect(onHover).toHaveBeenCalledWith("A", { pixel: [10, 20] });
+  });
+
+  it("fires null (no pixel) when pointer leaves the last-hovered marker", () => {
+    const { map, fakeMap, getHandler } = makeMap();
+    const onHover = jest.fn();
+
+    addHoverInteraction({ map, layer: {} as VectorLayer, onHover });
+
+    fakeMap.forEachFeatureAtPixel.mockImplementationOnce(
+      (_pixel: unknown, cb: (f: unknown) => boolean) => cb(featureWithId("A"))
+    );
+    getHandler()({ pixel: [10, 20] });
+
+    // No feature under pointer this time
+    fakeMap.forEachFeatureAtPixel.mockImplementationOnce(() => undefined);
+    getHandler()({ pixel: [80, 80] });
+
+    expect(onHover).toHaveBeenCalledTimes(2);
+    expect(onHover).toHaveBeenNthCalledWith(1, "A", { pixel: [10, 20] });
+    expect(onHover).toHaveBeenNthCalledWith(2, null);
+  });
+
+  it("fires a single call with the new id when moving directly from A to B", () => {
+    const { map, fakeMap, getHandler } = makeMap();
+    const onHover = jest.fn();
+
+    addHoverInteraction({ map, layer: {} as VectorLayer, onHover });
+
+    fakeMap.forEachFeatureAtPixel.mockImplementationOnce(
+      (_pixel: unknown, cb: (f: unknown) => boolean) => cb(featureWithId("A"))
+    );
+    getHandler()({ pixel: [10, 20] });
+
+    fakeMap.forEachFeatureAtPixel.mockImplementationOnce(
+      (_pixel: unknown, cb: (f: unknown) => boolean) => cb(featureWithId("B"))
+    );
+    getHandler()({ pixel: [50, 60] });
+
+    expect(onHover).toHaveBeenCalledTimes(2);
+    expect(onHover).toHaveBeenNthCalledWith(1, "A", { pixel: [10, 20] });
+    expect(onHover).toHaveBeenNthCalledWith(2, "B", { pixel: [50, 60] });
+  });
+
+  it("ignores dragging events", () => {
+    const { map, fakeMap, getHandler } = makeMap();
+    const onHover = jest.fn();
+
+    addHoverInteraction({ map, layer: {} as VectorLayer, onHover });
+
+    fakeMap.forEachFeatureAtPixel.mockImplementation(
+      (_pixel: unknown, cb: (f: unknown) => boolean) => cb(featureWithId("A"))
+    );
+
+    getHandler()({ pixel: [10, 20], dragging: true });
+
+    expect(onHover).not.toHaveBeenCalled();
+    expect(fakeMap.forEachFeatureAtPixel).not.toHaveBeenCalled();
+  });
+
+  it("detach removes the listener via unByKey", () => {
+    const { map, fakeMap } = makeMap();
+    const onHover = jest.fn();
+
+    const detach = addHoverInteraction({
+      map,
+      layer: {} as VectorLayer,
+      onHover,
+    });
+
+    detach();
+
+    expect(unByKey).toHaveBeenCalledTimes(1);
+    // Ensure the key we unregister is the one map.on returned
+    expect(unByKey).toHaveBeenCalledWith(fakeMap.on.mock.results[0].value);
+  });
+});

--- a/src/feature-components/Map/v2/composites/BasicMap/interactions/__tests__/addSelectInteraction.test.ts
+++ b/src/feature-components/Map/v2/composites/BasicMap/interactions/__tests__/addSelectInteraction.test.ts
@@ -90,7 +90,7 @@ describe("addSelectInteraction", () => {
     expect(result).toEqual([]);
   });
 
-  it("invokes onSelect callback with selected features", () => {
+  it("invokes onSelect callback with selected features and pixel event", () => {
     const onSelect = jest.fn();
 
     const selected = [{ id: 1 }, { id: 2 }] as unknown as Feature[];
@@ -107,9 +107,27 @@ describe("addSelectInteraction", () => {
 
     addSelectInteraction({ map, layer, onSelect });
 
-    // Simulate select event
+    selectHandler?.({ selected, mapBrowserEvent: { pixel: [120, 240] } });
+
+    expect(onSelect).toHaveBeenCalledWith(selected, { pixel: [120, 240] });
+  });
+
+  it("passes undefined event when mapBrowserEvent lacks pixel", () => {
+    const onSelect = jest.fn();
+    const selected = [] as unknown as Feature[];
+
+    let selectHandler: Function | undefined;
+
+    (Select as jest.Mock).mockImplementation(() => ({
+      on: jest.fn((event, handler) => {
+        if (event === "select") selectHandler = handler;
+      }),
+    }));
+
+    addSelectInteraction({ map, layer, onSelect });
+
     selectHandler?.({ selected });
 
-    expect(onSelect).toHaveBeenCalledWith(selected);
+    expect(onSelect).toHaveBeenCalledWith(selected, undefined);
   });
 });

--- a/src/feature-components/Map/v2/composites/BasicMap/interactions/addHoverInteraction.ts
+++ b/src/feature-components/Map/v2/composites/BasicMap/interactions/addHoverInteraction.ts
@@ -1,0 +1,55 @@
+import { Map as OlMap } from "ol";
+import BaseLayer from "ol/layer/Base";
+import VectorLayer from "ol/layer/Vector";
+import type { EventsKey } from "ol/events";
+import { unByKey } from "ol/Observable";
+import { FeatureEvent } from "../../../types/map-types";
+
+interface AddHoverInteractionOptions {
+  map: OlMap;
+  layer: VectorLayer;
+  onHover: (id: string | null, event?: FeatureEvent) => void;
+}
+
+/**
+ * Attaches a pointermove hit-test that reports enter/leave transitions on the
+ * given vector layer's features. Fires only when the hovered feature id
+ * changes — moving within the same feature does not re-fire. Returns a
+ * detach function.
+ */
+export const addHoverInteraction = ({
+  map,
+  layer,
+  onHover,
+}: AddHoverInteractionOptions): (() => void) => {
+  let lastId: string | null = null;
+
+  const key: EventsKey = map.on("pointermove", (evt) => {
+    if (evt.dragging) return;
+
+    let currentId: string | null = null;
+    map.forEachFeatureAtPixel(
+      evt.pixel,
+      (feat) => {
+        const id = feat.getId?.();
+        if (typeof id === "string") {
+          currentId = id;
+          return true;
+        }
+        return false;
+      },
+      { layerFilter: (l: BaseLayer) => l === layer }
+    );
+
+    if (currentId === lastId) return;
+
+    lastId = currentId;
+    if (currentId === null) {
+      onHover(null);
+    } else {
+      onHover(currentId, { pixel: [evt.pixel[0], evt.pixel[1]] });
+    }
+  });
+
+  return () => unByKey(key);
+};

--- a/src/feature-components/Map/v2/composites/BasicMap/interactions/addSelectInteraction.ts
+++ b/src/feature-components/Map/v2/composites/BasicMap/interactions/addSelectInteraction.ts
@@ -4,11 +4,12 @@ import { Feature, Map as OlMap } from "ol";
 import type VectorLayer from "ol/layer/Vector";
 import { Stroke, Style } from "ol/style";
 import type { StyleFunction } from "ol/style/Style";
+import { FeatureEvent } from "../../../types/map-types";
 
 interface AddSelectInteractionOptions {
   map: OlMap;
   layer: VectorLayer;
-  onSelect?: (features: Feature[]) => void;
+  onSelect?: (features: Feature[], event?: FeatureEvent) => void;
 }
 
 export const addSelectInteraction = ({
@@ -36,7 +37,12 @@ export const addSelectInteraction = ({
   if (onSelect) {
     select.on("select", (evt) => {
       const selected = evt.selected as Feature[];
-      onSelect(selected);
+      const pixel = evt.mapBrowserEvent?.pixel;
+      const event: FeatureEvent | undefined =
+        pixel && pixel.length === 2
+          ? { pixel: [pixel[0], pixel[1]] }
+          : undefined;
+      onSelect(selected, event);
     });
   }
 

--- a/src/feature-components/Map/v2/primitives/MapCanvas/MapCanvas.tsx
+++ b/src/feature-components/Map/v2/primitives/MapCanvas/MapCanvas.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useRef, useState } from "react";
 import Feature from "ol/Feature";
 import View from "ol/View";
-import { MapCanvasV2Props } from "../../types/map-types";
+import { FeatureEvent, MapCanvasV2Props } from "../../types/map-types";
 import { fitToFeature, fitToFeatures } from "../../composites/BasicMap/interactions/addPanToFeature";
 import { addSelectInteraction } from "../../composites/BasicMap/interactions/addSelectInteraction";
+import { addHoverInteraction } from "../../composites/BasicMap/interactions/addHoverInteraction";
 import { findVectorLayerById } from "../../utils/feature";
 import { attachTileLoadErrorLogging, MARKER_LAYER_ID } from "../../utils/layers";
 import { ensureView } from "../../utils/ensureView";
@@ -16,6 +17,7 @@ export const MapCanvasV2: React.FC<MapCanvasV2Props> = ({
 	zoom,
 	center,
 	onFeatureClick,
+	onFeatureHover,
 	layers,
 	mapInstanceRef,
 	controls
@@ -79,7 +81,7 @@ export const MapCanvasV2: React.FC<MapCanvasV2Props> = ({
 		const select = addSelectInteraction({
 			map,
 			layer: markerLayer,
-			onSelect: (features: Feature[]) => {
+			onSelect: (features: Feature[], event?: FeatureEvent) => {
 				const ids = features
 					.map(f => f.getId?.())
 					.filter((id): id is string => typeof id === "string");
@@ -90,15 +92,24 @@ export const MapCanvasV2: React.FC<MapCanvasV2Props> = ({
 				}
 
 				if (onFeatureClick) {
-					onFeatureClick(ids);
+					onFeatureClick(ids, event);
 				}
 			},
 		});
 
+		const detachHover = onFeatureHover
+			? addHoverInteraction({
+				map,
+				layer: markerLayer,
+				onHover: onFeatureHover,
+			})
+			: undefined;
+
 		return () => {
 			mapInstanceRef.current?.removeInteraction(select);
+			detachHover?.();
 		};
-	}, [layers]);
+	}, [layers, onFeatureHover, onFeatureClick]);
 
 	return <div id="TelicentMap" className="map-container" style={{
 		width: "100%", height: "100%", background: "#f8f4f0"

--- a/src/feature-components/Map/v2/primitives/MapCanvas/__tests__/MapCanvas.test.tsx
+++ b/src/feature-components/Map/v2/primitives/MapCanvas/__tests__/MapCanvas.test.tsx
@@ -3,6 +3,7 @@ jest.mock("ol/control");
 import { render, cleanup } from "@testing-library/react";
 import { createMap } from "../../../utils/mapFactory";
 import { addSelectInteraction } from "../../../composites/BasicMap/interactions/addSelectInteraction";
+import { addHoverInteraction } from "../../../composites/BasicMap/interactions/addHoverInteraction";
 import { findVectorLayerById } from "../../../utils/feature";
 import { fitToFeature, fitToFeatures } from "../../../composites/BasicMap/interactions/addPanToFeature";
 import { MapCanvasV2 } from "../MapCanvas";
@@ -19,6 +20,10 @@ jest.mock("../../../utils/feature", () => ({
 
 jest.mock("../../../composites/BasicMap/interactions/addSelectInteraction", () => ({
 	addSelectInteraction: jest.fn(),
+}));
+
+jest.mock("../../../composites/BasicMap/interactions/addHoverInteraction", () => ({
+	addHoverInteraction: jest.fn(() => jest.fn()),
 }));
 
 jest.mock("../../../composites/BasicMap/interactions/addPanToFeature", () => ({
@@ -100,7 +105,69 @@ describe("MapCanvasV2", () => {
 		}));
 
 		expect(fitToFeature).toHaveBeenCalledWith(mockMapInstance, mockFeature);
-		expect(onFeatureClick).toHaveBeenCalledWith(["feature1"]);
+		expect(onFeatureClick).toHaveBeenCalledWith(["feature1"], undefined);
+	});
+
+	it("forwards pixel from Select event through to onFeatureClick", () => {
+		const layers = [{ id: "layer1" }] as unknown as BaseLayer[];
+		const onFeatureClick = jest.fn();
+
+		(findVectorLayerById as jest.Mock).mockReturnValue("mockMarkerLayer");
+		(addSelectInteraction as jest.Mock).mockImplementation(({ onSelect }) => {
+			onSelect([mockFeature], { pixel: [42, 84] });
+			return "mockInteraction";
+		});
+
+		render(
+			<MapCanvasV2
+				layers={layers}
+				mapInstanceRef={{ current: null }}
+				onFeatureClick={onFeatureClick}
+				{...defaultProps}
+			/>
+		);
+
+		expect(onFeatureClick).toHaveBeenCalledWith(["feature1"], { pixel: [42, 84] });
+	});
+
+	it("wires onFeatureHover through addHoverInteraction when provided", () => {
+		const layers = [{ id: "layer1" }] as unknown as BaseLayer[];
+		const onFeatureHover = jest.fn();
+
+		(findVectorLayerById as jest.Mock).mockReturnValue("mockMarkerLayer");
+
+		render(
+			<MapCanvasV2
+				layers={layers}
+				mapInstanceRef={{ current: null }}
+				onFeatureHover={onFeatureHover}
+				{...defaultProps}
+			/>
+		);
+
+		expect(addHoverInteraction).toHaveBeenCalledWith(
+			expect.objectContaining({
+				map: mockMapInstance,
+				layer: "mockMarkerLayer",
+				onHover: onFeatureHover,
+			})
+		);
+	});
+
+	it("does not attach hover interaction when onFeatureHover is omitted", () => {
+		const layers = [{ id: "layer1" }] as unknown as BaseLayer[];
+
+		(findVectorLayerById as jest.Mock).mockReturnValue("mockMarkerLayer");
+
+		render(
+			<MapCanvasV2
+				layers={layers}
+				mapInstanceRef={{ current: null }}
+				{...defaultProps}
+			/>
+		);
+
+		expect(addHoverInteraction).not.toHaveBeenCalled();
 	});
 
 	it("handles multiple features correctly", () => {
@@ -124,7 +191,7 @@ describe("MapCanvasV2", () => {
 		);
 
 		expect(fitToFeatures).toHaveBeenCalledWith(mockMapInstance, [mockFeature, feature2]);
-		expect(onFeatureClick).toHaveBeenCalledWith(["feature1", "feature2"]);
+		expect(onFeatureClick).toHaveBeenCalledWith(["feature1", "feature2"], undefined);
 	});
 
 	it("removes select interaction on unmount", () => {

--- a/src/feature-components/Map/v2/types/map-types.ts
+++ b/src/feature-components/Map/v2/types/map-types.ts
@@ -37,10 +37,22 @@ export type StyleConfig =
 export type LayersRef = React.MutableRefObject<BaseLayer[] | null>;
 export type MapInstanceRef = React.MutableRefObject<Map | null>;
 
+export type FeatureEvent = {
+  pixel: [number, number];
+};
+
+export type OnFeatureClick = (ids: string[], event?: FeatureEvent) => void;
+
+export type OnFeatureHover = (
+  id: string | null,
+  event?: FeatureEvent
+) => void;
+
 export type MapCanvasV2Props = {
   layers: BaseLayer[];
   mapInstanceRef: MapInstanceRef;
-  onFeatureClick?: (ids: string[]) => void;
+  onFeatureClick?: OnFeatureClick;
+  onFeatureHover?: OnFeatureHover;
   zoom: number;
   center: Coordinate;
   controls?: Partial<MapControlsConfig>;
@@ -75,7 +87,8 @@ export interface BasicMapProperties {
   mapStyleOptions?: LegacyMapConfig;
   markers: MarkerFeature[];
   polygons: PolygonFeature[];
-  onFeatureClick?: (ids: string[]) => void;
+  onFeatureClick?: OnFeatureClick;
+  onFeatureHover?: OnFeatureHover;
   onLayersReady?: (isReady: boolean) => void;
 }
 


### PR DESCRIPTION
Ticket: TELFE-1330

### Goal

Add hover event support to `BasicMapV2` so consuming apps can build cursor / popover / highlight behaviour on top of marker interactions. Previously the DS only emitted click events, forcing apps to build their own hover detection over the OpenLayers instance.

### Work Completed

- **Map hover events** — new `addHoverInteraction` bound to `pointermove` on the marker vector layer. Fires `onFeatureHover(id, { pixel })` on enter, `onFeatureHover(null)` on leave, and deduplicates within-marker movement so the callback only fires on true enter/leave transitions. Marker-to-marker moves fire once with the new id.
- **BasicMap wiring** — `MapCanvas`, `map-types`, and `addSelectInteraction` updated to accept and thread `onFeatureHover`. Existing click behaviour unchanged.
- **Storybook** — new `FeatureEvents` story with a live debug panel that surfaces hover + click events emitted by the map.
- **Tests** — full coverage of the hover interaction's enter / within / leave / marker-to-marker semantics; `MapCanvas` and `addSelectInteraction` tests updated for the new prop.
- **Bonus: MUI Menu Fragment warning fix** — `Menu` component was wrapping mapped items in `<React.Fragment>`, which triggered a runtime `console.error` in every consuming app because MUI's `Menu` can't attach keyboard-nav props to Fragments. Replaced with `flatMap` returning a flat array; dividers now render as `<li role="separator">` for correct semantics inside the menu's `<ul>`. Regression test added.

### Design Testing

- Pre-release version: _e.g. v1.2.3-JIRA-123.0_
- [ ] This PR is setup for easy assessment of "<strong>Design approval areas</strong>")

<details>
  <summary><strong>Design approval areas</strong></summary>

  <hr />
  
  A _indicative_ list of suggested screenshots or videos.

Action each: Mark "`[x]`" (click) for _complete_, or "`[-]`" for _not-applicable_.

- [ ] UI content:
  - [ ] **Ideal** - show UI with "happy content" i.e. what Figma considers typical
  - [ ] **Empty** - show UI with empty (or minimum) content
  - [ ] **Full** - show UI with all (or technically maximum) content
- [ ] UI States:
  - [ ] **Form validation** - show UI for validation errors, hints and success
  - [ ] **Network states** - show UI for fetch failures and success
  - [ ] **env-config errors** - show release-engineer UI for app config errors
- [ ] Responsiveness:
  - [ ] **Min width** - show UI with minimum width supported by parent container, or [most common desktop](https://www.google.com/search?q=most+common+desktop+screen+resolution+now) split screen
  - [ ] **Min height** - show UI with minimum height supported by parent container, or [most common desktop](https://www.google.com/search?q=most+common+desktop+screen+resolution+now) half height
- [ ] Accessibility: new issues introduced this PR (perhaps include report before, and report after)

</details>

### Testing Method

- `yarn jest src/components/Navigation/Menu/Menu.test.tsx` — passes; guards the MUI Fragment warning regression.
- `yarn jest src/feature-components/Map/v2/composites/BasicMap/interactions/__tests__/addHoverInteraction.test.ts` — passes; covers enter / within-marker / leave / marker-to-marker transitions.
- Manual: Storybook → `Feature Components / BasicMap / FeatureEvents`, hover the markers and confirm the overlay logs enter events, no within-marker re-fires, and a `hover: null` on leave.
- Verdaccio: prerelease was published and consumed by the 5 downstream apps (graph, query, search, admin, catalogue). The Menu Fragment `console.error` no longer fires in any of them.

### Code Review Tips

- Start with `addHoverInteraction.ts` — the enter/leave dedup logic is the load-bearing bit.
- The Menu fix commit (`fb18f2f5`) is standalone and can be reviewed independently of the map work; the test commit that follows it (`699df6e6`) is its regression guard.

### Engineering Notes

The base commit on this branch is a WIP snapshot brought forward from a stash created during the 3.1.1-0 hackathon. Kept as-is for provenance; the feature commits build on top of it. Version in `package.json` is unchanged from `main` (`3.5.0`) — release-please will pick the bump when this merges.

### Out-of-scope

- Consumer-side popover / cursor / highlight / throttling behaviour built on top of the hover events. The DS emits events only; apps own the visual response. Called out explicitly in the `FeatureEvents` story JSDoc.

---

<details>
  <summary><strong>🕵️ Review Guidance</strong></summary>

---

General guidance

- Generally, approve a PR if it makes the system better, even if it's not perfect. — [Google: The Standard of Code Review](https://google.github.io/eng-practices/review/reviewer/standard.html)
- The aim of both PR AUTHOR and PR REVIEWER is to get the code merged
- Aim for consensus, defined as _everyone can live with the outcome_
- PR with changes requires 2 approvals
- PR with no changes requires 1 approvals

For PR REVIEWER:

1. Read the ticket & description
2. [Review the code](https://google.github.io/eng-practices/review/reviewer/looking-for.html)
3. Request any changes that are essential.
4. For non-essential comments:
   - Use prefixes, e.g. "**nit:** change to Pascal case"
     - **nit:** small, non-essential change
     - **obs:** just an observation, doesn't affect the PR
     - **idea:** a suggestion to think about
     - **q:** questions
   - Use modifiers, e.g. "**obs**`[pr-owner-resolve]`: Jim is also editing this file"
     - `pr-author-resolve` PR author can resolve after reading
     - `pr-author-delete` (rare) delete after reading to avoid confusion
5. try to add _at least_ a helpful comment per ~500 lines; less if the PR is already busy

For PR AUTHOR:

1. Aim for enough detail in PR description for things to go smoothly
2. After requested changes, [re-request a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews#re-requesting-a-review) (so the PR shows up in [reviews-requested:@me](https://github.com/pulls?q=is%3Apr+is%3Aopen+archived%3Afalse+sort%3Aupdated-desc+review-requested%3A%40me+))

</details>
