### PR TITLE
TELFE-1613: Emit CJS interop for externalised MUI defaults in UMD build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,6 +40,7 @@ export default defineConfig({
         "@emotion/styled",
       ],
       output: {
+        interop: "auto",
         globals: {
           react: "React",
           "react-dom": "ReactDOM",


### PR DESCRIPTION
Ticket: [TELFE-1613](https://telicent.atlassian.net/browse/TELFE-1613)

### Goal

Follow-up to #532. Fix `dist/ds.umd.cjs` so CJS consumers (SSR, Jest without ESM transform, older bundlers) can render MUI-based DS components again.

### Work Completed

Added `output.interop: "auto"` to `build.rollupOptions` in `vite.config.ts`.

Without it, Rollup bound `import Typography from "@mui/material/Typography"` to the raw CJS module `{ __esModule: true, default: ... }` and emitted `jsx(Typography, ...)` — passing the module wrapper where a component was expected. `interop: "auto"` makes Rollup unwrap `.default` at each call site.

ESM output (`ds.js`) is byte-identical — `interop` only affects CJS/UMD.

### Testing Method

- `yarn build` — inspect `dist/ds.umd.cjs`: `_interopDefault` helper present, MUI call sites use `<Name>__default.default`.
- `yarn test` — 364 passed, 0 failed.
- Downstream: bump the failing consumer to a `3.6.1-rc` prerelease built from this branch and re-run the crashing render path.

---

<details>
  <summary><strong>🕵️ Review Guidance</strong></summary>

---

General guidance

- Generally, approve a PR if it makes the system better, even if it's not perfect. — [Google: The Standard of Code Review](https://google.github.io/eng-practices/review/reviewer/standard.html)
- The aim of both PR AUTHOR and PR REVIEWER is to get the code merged
- Aim for consensus, defined as _everyone can live with the outcome_
- PR with changes requires 2 approvals
- PR with no changes requires 1 approvals

For PR REVIEWER:

1. Read the ticket & description
2. [Review the code](https://google.github.io/eng-practices/review/reviewer/looking-for.html)
3. Request any changes that are essential.
4. For non-essential comments:
   - Use prefixes, e.g. "**nit:** change to Pascal case"
     - **nit:** small, non-essential change
     - **obs:** just an observation, doesn't affect the PR
     - **idea:** a suggestion to think about
     - **q:** questions
   - Use modifiers, e.g. "**obs**`[pr-owner-resolve]`: Jim is also editing this file"
     - `pr-author-resolve` PR author can resolve after reading
     - `pr-author-delete` (rare) delete after reading to avoid confusion
5. try to add _at least_ a helpful comment per ~500 lines; less if the PR is already busy

For PR AUTHOR:

1. Aim for enough detail in PR description for things to go smoothly
2. After requested changes, [re-request a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews#re-requesting-a-review) (so the PR shows up in [reviews-requested:@me](https://github.com/pulls?q=is%3Apr+is%3Aopen+archived%3Afalse+sort%3Aupdated-desc+review-requested%3A%40me+))

</details>


[TELFE-1613]: https://telicent.atlassian.net/browse/TELFE-1613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ